### PR TITLE
Add time metrics to emulator, in Msteps/s

### DIFF
--- a/emulator/src/emu.rs
+++ b/emulator/src/emu.rs
@@ -378,4 +378,9 @@ impl Emu<'_> {
     pub fn terminated(&self) -> bool {
         self.ctx.end
     }
+
+    /// Returns the number of executed steps
+    pub fn number_of_steps(&self) -> u64 {
+        self.ctx.step
+    }
 }

--- a/emulator/src/emu_options.rs
+++ b/emulator/src/emu_options.rs
@@ -38,6 +38,9 @@ pub struct EmuOptions {
     pub log_output: bool,
     /// Trace every this number of steps
     pub trace_steps: Option<u64>,
+    /// Log performance metrics
+    #[clap(short = 'm', long, value_name = "LOG_METRICS", default_value = "false")]
+    pub log_metrics: bool,
 }
 
 /// Default constructor for impl fmt::Display for EmuOptions structure
@@ -55,6 +58,7 @@ impl Default for EmuOptions {
             log_step: false,
             log_output: false,
             trace_steps: None,
+            log_metrics: false,
         }
     }
 }

--- a/emulator/src/emulate.rs
+++ b/emulator/src/emulate.rs
@@ -5,6 +5,7 @@ use std::{
     fs::metadata,
     path::{Path, PathBuf},
     process,
+    time::Instant,
 };
 
 pub fn emulate(options: &EmuOptions, callback: Option<fn(&mut Vec<EmuTrace>)>) {
@@ -122,11 +123,23 @@ pub fn process_rom(
     // Create a emulator instance with this rom and input
     let mut emu = Emu::new(rom, input.to_owned(), options.clone(), callback);
 
+    let start = Instant::now();
+
     // Run the emulation
     emu.run();
     if !emu.terminated() {
         println!("Emulation did not complete");
         process::exit(1);
+    }
+
+    let duration = start.elapsed();
+
+    // Log performance metrics
+    if options.log_metrics {
+        let secs = duration.as_secs_f64();
+        let steps = emu.number_of_steps() as f64;
+        let tp = steps / secs / 1000000.0;
+        println!("process_rom() steps={} duration={:.4} tp={:.4} Msteps/s", steps, secs, tp);
     }
 
     // OUTPUT:


### PR DESCRIPTION
Adding flag -m to EmuOptions to log performance metrics in Msteps/s.
closes #33 