### PR TITLE
Add nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,8 +33,9 @@
             pkgs.libgit2
             pkgs.cargo
             pkgs.rustc
-            pkgs.darwin.apple_sdk.frameworks.Security
-          ] ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.mkl ]);
+          ] ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.mkl ])
+            ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin
+              [ pkgs.darwin.apple_sdk.frameworks.Security ]);
 
           # Add precompiled library to rustc search path.
           RUSTFLAGS = (builtins.map (a: "-L ${a}/lib") [ pkgs.libgit2 ]

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,6 @@
             pkgs.libsodium
             pkgs.libpqxx
             pkgs.libuuid
-            pkgs.mkl
             pkgs.openssl
             pkgs.postgresql
             pkgs.protobuf
@@ -34,12 +33,13 @@
             pkgs.libgit2
             pkgs.cargo
             pkgs.rustc
-          ];
+            pkgs.darwin.apple_sdk.frameworks.Security
+          ] ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.mkl ]);
+
           # Add precompiled library to rustc search path.
-          RUSTFLAGS = (builtins.map (a: "-L ${a}/lib") [
-            pkgs.libgit2
-            "native=${self}/pil2-stark"
-          ]);
+          RUSTFLAGS = (builtins.map (a: "-L ${a}/lib") [ pkgs.libgit2 ]
+            ++ (pkgs.lib.optionals pkgs.stdenv.isLinux
+              [ "native=${self}/pil2-stark" ]));
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "A flake with project build dependencies";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.systems.url = "github:nix-systems/default";
+  inputs.flake-utils = {
+    url = "github:numtide/flake-utils";
+    inputs.systems.follows = "systems";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfreePredicate = pkg:
+            builtins.elem (nixpkgs.lib.getName pkg) [ "mkl" ];
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.grpc
+            pkgs.gmp
+            pkgs.jq
+            pkgs.libsodium
+            pkgs.libpqxx
+            pkgs.libuuid
+            pkgs.mkl
+            pkgs.openssl
+            pkgs.postgresql
+            pkgs.protobuf
+            pkgs.secp256k1
+            pkgs.nlohmann_json
+            pkgs.nasm
+            pkgs.libgit2
+            pkgs.cargo
+            pkgs.rustc
+          ];
+          # Add precompiled library to rustc search path.
+          RUSTFLAGS = (builtins.map (a: "-L ${a}/lib") [
+            pkgs.libgit2
+            "native=${self}/pil2-stark"
+          ]);
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
           config.allowUnfreePredicate = pkg:
             builtins.elem (nixpkgs.lib.getName pkg) [ "mkl" ];
         };
+        riscv64-pkgs = pkgs.pkgsCross.riscv64;
       in {
         devShells.default = pkgs.mkShell {
           packages = [
@@ -31,8 +32,10 @@
             pkgs.nlohmann_json
             pkgs.nasm
             pkgs.libgit2
-            pkgs.cargo
-            pkgs.rustc
+            # Packages for cross-compiling and running on RISC-V.
+            riscv64-pkgs.buildPackages.buildPackages.qemu
+            riscv64-pkgs.buildPackages.gcc
+            riscv64-pkgs.buildPackages.gdb
           ] ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.mkl ])
             ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin
               [ pkgs.darwin.apple_sdk.frameworks.Security ]);


### PR DESCRIPTION
This flake includes all deps for building "zisk" and related projects.

To use it, install nix by following [this guide](https://determinate.systems/nix/) and call `nix develop`.
Afterwards, use your normal workflow in this environment, e.g. `cargo build`.

I've tested this on ArchLinux and it should also work on Ubuntu.

It also now works on OSX, but it skips dependencies for proving there (Intel MKL/OpenMP).