### PR TITLE
Add Nix flake for project dependencies

### DIFF
--- a/book/getting_started/install.md
+++ b/book/getting_started/install.md
@@ -14,6 +14,21 @@
 sudo apt-get install -y xz-utils jq curl git build-essential qemu-system libomp-dev libgmp-dev nlohmann-json3-dev protobuf-compiler uuid-dev libgrpc++-dev libsecp256k1-dev libsodium-dev libpqxx-dev nasm
 ```
 
+### Nix Flake
+
+Alternatively, you can use [Nix package manager](https://github.com/NixOS/nix) to install all dependencies. First, follow the [guide to install Nix](https://determinate.systems/nix/) on your OS.
+
+Afterwards, use `flake.nix` in `zisk` repository to load the development environment with:
+```
+nix develop
+
+# You can also use a custom shell: 
+nix develop -c zsh
+```
+
+This will start a new shell with correctly set `PATH` and `LD_LIBRARY_PATH` for dependencies necessary to build the project.
+You can exit this shell with Ctrl+D.
+
 ### OSX prerequisites
 ```bash
 # Install brew first.

--- a/book/getting_started/quickstart.md
+++ b/book/getting_started/quickstart.md
@@ -130,7 +130,7 @@ cd zisk
 
 ### Compile the PIl2 Stark C++ Library (run only once):
 ```bash
-(cd ../pil2-proofman/pil2-stark && git submodule init && git submodule update && make clean && make -j starks_lib && make -j bctree) && export RUSTFLAGS="-L native=$PWD/../pil2-proofman/pil2-stark/lib"
+(cd ../pil2-proofman/pil2-stark && git submodule init && git submodule update && make clean && make -j starks_lib && make -j bctree) && export RUSTFLAGS=$RUSTFLAGS" -L native=$PWD/../pil2-proofman/pil2-stark/lib"
 ```
 
 ### Generate PIL-Helpers Rust Code

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728979988,
+        "narHash": "sha256-GBJRnbFLDg0y7ridWJHAP4Nn7oss50/VNgqoXaf/RVk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7881fbfd2e3ed1dfa315fca889b2cfd94be39337",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "A flake with project build dependencies";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.systems.url = "github:nix-systems/default";
+  inputs.flake-utils = {
+    url = "github:numtide/flake-utils";
+    inputs.systems.follows = "systems";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfreePredicate = pkg:
+            builtins.elem (nixpkgs.lib.getName pkg) [ "mkl" ];
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.grpc
+            pkgs.gmp
+            pkgs.jq
+            pkgs.libsodium
+            pkgs.libpqxx
+            pkgs.libuuid
+            pkgs.openssl
+            pkgs.postgresql
+            pkgs.protobuf
+            pkgs.secp256k1
+            pkgs.nlohmann_json
+            pkgs.nasm
+            pkgs.libgit2
+          ] ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.mkl ])
+            ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin
+              [ pkgs.darwin.apple_sdk.frameworks.Security ]);
+
+          RUSTFLAGS = (builtins.map (a: "-L ${a}/lib") [ pkgs.libgit2 ]);
+        };
+      });
+}


### PR DESCRIPTION
This flake includes all deps for building "zisk" and related projects.

To use it, install Nix package manager by following [this guide](https://determinate.systems/nix/) and call `nix develop`.
Afterwards, use your normal workflow in this environment, e.g. cargo build.

I've tested this on ArchLinux and OSX and it should also work on other Linux flavors.