### PR TITLE
make all ops but keccak and things that use Wrapping const fns :boom:

### DIFF
--- a/core/src/zisk_ops.rs
+++ b/core/src/zisk_ops.rs
@@ -297,7 +297,7 @@ pub const fn op_flag(_a: u64, _b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_flag()
 #[inline(always)]
-pub fn opc_flag(ctx: &mut InstContext) {
+pub const fn opc_flag(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_flag(ctx.a, ctx.b);
 }
 
@@ -309,7 +309,7 @@ pub const fn op_copyb(_a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_copyb()
 #[inline(always)]
-pub fn opc_copyb(ctx: &mut InstContext) {
+pub const fn opc_copyb(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_copyb(ctx.a, ctx.b);
 }
 
@@ -327,7 +327,7 @@ pub const fn op_signextend_b(_a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_signextend_b()
 #[inline(always)]
-pub fn opc_signextend_b(ctx: &mut InstContext) {
+pub const fn opc_signextend_b(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_signextend_b(ctx.a, ctx.b);
 }
 
@@ -343,7 +343,7 @@ pub const fn op_signextend_h(_a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_signextend_h()
 #[inline(always)]
-pub fn opc_signextend_h(ctx: &mut InstContext) {
+pub const fn opc_signextend_h(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_signextend_h(ctx.a, ctx.b);
 }
 
@@ -359,7 +359,7 @@ pub const fn op_signextend_w(_a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_signextend_w()
 #[inline(always)]
-pub fn opc_signextend_w(ctx: &mut InstContext) {
+pub const fn opc_signextend_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_signextend_w(ctx.a, ctx.b);
 }
 
@@ -424,7 +424,7 @@ pub const fn op_sll(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_sll()
 #[inline(always)]
-pub fn opc_sll(ctx: &mut InstContext) {
+pub const fn opc_sll(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_sll(ctx.a, ctx.b);
 }
 
@@ -450,7 +450,7 @@ pub const fn op_sra(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_sra()
 #[inline(always)]
-pub fn opc_sra(ctx: &mut InstContext) {
+pub const fn opc_sra(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_sra(ctx.a, ctx.b);
 }
 
@@ -463,7 +463,7 @@ pub const fn op_srl(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_srl()
 #[inline(always)]
-pub fn opc_srl(ctx: &mut InstContext) {
+pub const fn opc_srl(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_srl(ctx.a, ctx.b);
 }
 
@@ -507,7 +507,7 @@ pub const fn op_eq(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_eq()
 #[inline(always)]
-pub fn opc_eq(ctx: &mut InstContext) {
+pub const fn opc_eq(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_eq(ctx.a, ctx.b);
 }
 
@@ -524,7 +524,7 @@ pub const fn op_eq_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_eq_w()
 #[inline(always)]
-pub fn opc_eq_w(ctx: &mut InstContext) {
+pub const fn opc_eq_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_eq_w(ctx.a, ctx.b);
 }
 
@@ -541,7 +541,7 @@ pub const fn op_ltu(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_ltu()
 #[inline(always)]
-pub fn opc_ltu(ctx: &mut InstContext) {
+pub const fn opc_ltu(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_ltu(ctx.a, ctx.b);
 }
 
@@ -558,7 +558,7 @@ pub const fn op_lt(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_lt()
 #[inline(always)]
-pub fn opc_lt(ctx: &mut InstContext) {
+pub const fn opc_lt(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_lt(ctx.a, ctx.b);
 }
 
@@ -575,7 +575,7 @@ pub const fn op_ltu_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_ltu_w()
 #[inline(always)]
-pub fn opc_ltu_w(ctx: &mut InstContext) {
+pub const fn opc_ltu_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_ltu_w(ctx.a, ctx.b);
 }
 
@@ -592,7 +592,7 @@ pub const fn op_lt_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_lt_w()
 #[inline(always)]
-pub fn opc_lt_w(ctx: &mut InstContext) {
+pub const fn opc_lt_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_lt_w(ctx.a, ctx.b);
 }
 
@@ -609,7 +609,7 @@ pub const fn op_leu(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_leu()
 #[inline(always)]
-pub fn opc_leu(ctx: &mut InstContext) {
+pub const fn opc_leu(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_leu(ctx.a, ctx.b);
 }
 
@@ -626,7 +626,7 @@ pub const fn op_le(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_le()
 #[inline(always)]
-pub fn opc_le(ctx: &mut InstContext) {
+pub const fn opc_le(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_le(ctx.a, ctx.b);
 }
 
@@ -643,7 +643,7 @@ pub const fn op_leu_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_leu_w()
 #[inline(always)]
-pub fn opc_leu_w(ctx: &mut InstContext) {
+pub const fn opc_leu_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_leu_w(ctx.a, ctx.b);
 }
 
@@ -660,7 +660,7 @@ pub const fn op_le_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_le_w()
 #[inline(always)]
-pub fn opc_le_w(ctx: &mut InstContext) {
+pub const fn opc_le_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_le_w(ctx.a, ctx.b);
 }
 
@@ -674,7 +674,7 @@ pub const fn op_and(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_and()
 #[inline(always)]
-pub fn opc_and(ctx: &mut InstContext) {
+pub const fn opc_and(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_and(ctx.a, ctx.b);
 }
 
@@ -686,7 +686,7 @@ pub const fn op_or(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_or()
 #[inline(always)]
-pub fn opc_or(ctx: &mut InstContext) {
+pub const fn opc_or(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_or(ctx.a, ctx.b);
 }
 
@@ -698,7 +698,7 @@ pub const fn op_xor(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_xor()
 #[inline(always)]
-pub fn opc_xor(ctx: &mut InstContext) {
+pub const fn opc_xor(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_xor(ctx.a, ctx.b);
 }
 
@@ -748,7 +748,7 @@ pub const fn op_muluh(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_muluh()
 #[inline(always)]
-pub fn opc_muluh(ctx: &mut InstContext) {
+pub const fn opc_muluh(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_muluh(ctx.a, ctx.b);
 }
 
@@ -760,7 +760,7 @@ pub const fn op_mulh(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_mulh()
 #[inline(always)]
-pub fn opc_mulh(ctx: &mut InstContext) {
+pub const fn opc_mulh(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_mulh(ctx.a, ctx.b);
 }
 
@@ -772,7 +772,7 @@ pub const fn op_mulsuh(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_mulsuh()
 #[inline(always)]
-pub fn opc_mulsuh(ctx: &mut InstContext) {
+pub const fn opc_mulsuh(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_mulsuh(ctx.a, ctx.b);
 }
 
@@ -789,7 +789,7 @@ pub const fn op_divu(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_divu()
 #[inline(always)]
-pub fn opc_divu(ctx: &mut InstContext) {
+pub const fn opc_divu(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_divu(ctx.a, ctx.b);
 }
 
@@ -808,7 +808,7 @@ pub const fn op_div(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_div()
 #[inline(always)]
-pub fn opc_div(ctx: &mut InstContext) {
+pub const fn opc_div(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_div(ctx.a, ctx.b);
 }
 
@@ -825,7 +825,7 @@ pub const fn op_divu_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_divu_w()
 #[inline(always)]
-pub fn opc_divu_w(ctx: &mut InstContext) {
+pub const fn opc_divu_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_divu_w(ctx.a, ctx.b);
 }
 
@@ -842,7 +842,7 @@ pub const fn op_div_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_div_w()
 #[inline(always)]
-pub fn opc_div_w(ctx: &mut InstContext) {
+pub const fn opc_div_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_div_w(ctx.a, ctx.b);
 }
 
@@ -859,7 +859,7 @@ pub const fn op_remu(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_remu()
 #[inline(always)]
-pub fn opc_remu(ctx: &mut InstContext) {
+pub const fn opc_remu(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_remu(ctx.a, ctx.b);
 }
 
@@ -876,7 +876,7 @@ pub const fn op_rem(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_rem()
 #[inline(always)]
-pub fn opc_rem(ctx: &mut InstContext) {
+pub const fn opc_rem(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_rem(ctx.a, ctx.b);
 }
 
@@ -893,7 +893,7 @@ pub const fn op_remu_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_remu_w()
 #[inline(always)]
-pub fn opc_remu_w(ctx: &mut InstContext) {
+pub const fn opc_remu_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_remu_w(ctx.a, ctx.b);
 }
 
@@ -910,7 +910,7 @@ pub const fn op_rem_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_rem_w()
 #[inline(always)]
-pub fn opc_rem_w(ctx: &mut InstContext) {
+pub const fn opc_rem_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_rem_w(ctx.a, ctx.b);
 }
 
@@ -928,7 +928,7 @@ pub const fn op_minu(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_minu()
 #[inline(always)]
-pub fn opc_minu(ctx: &mut InstContext) {
+pub const fn opc_minu(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_minu(ctx.a, ctx.b);
 }
 
@@ -944,7 +944,7 @@ pub const fn op_min(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_min()
 #[inline(always)]
-pub fn opc_min(ctx: &mut InstContext) {
+pub const fn opc_min(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_min(ctx.a, ctx.b);
 }
 
@@ -960,7 +960,7 @@ pub const fn op_minu_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_minu_w()
 #[inline(always)]
-pub fn opc_minu_w(ctx: &mut InstContext) {
+pub const fn opc_minu_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_minu_w(ctx.a, ctx.b);
 }
 
@@ -976,7 +976,7 @@ pub const fn op_min_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_min_w()
 #[inline(always)]
-pub fn opc_min_w(ctx: &mut InstContext) {
+pub const fn opc_min_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_min_w(ctx.a, ctx.b);
 }
 
@@ -992,7 +992,7 @@ pub const fn op_maxu(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_maxu()
 #[inline(always)]
-pub fn opc_maxu(ctx: &mut InstContext) {
+pub const fn opc_maxu(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_maxu(ctx.a, ctx.b);
 }
 
@@ -1008,7 +1008,7 @@ pub const fn op_max(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_max()
 #[inline(always)]
-pub fn opc_max(ctx: &mut InstContext) {
+pub const fn opc_max(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_max(ctx.a, ctx.b);
 }
 
@@ -1024,7 +1024,7 @@ pub const fn op_maxu_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_maxu_w()
 #[inline(always)]
-pub fn opc_maxu_w(ctx: &mut InstContext) {
+pub const fn opc_maxu_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_maxu_w(ctx.a, ctx.b);
 }
 
@@ -1040,7 +1040,7 @@ pub const fn op_max_w(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_max_w()
 #[inline(always)]
-pub fn opc_max_w(ctx: &mut InstContext) {
+pub const fn opc_max_w(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_max_w(ctx.a, ctx.b);
 }
 
@@ -1077,8 +1077,8 @@ pub fn opc_keccak(ctx: &mut InstContext) {
 /// Unimplemented.  Keccak can only be called from the system call context via InstContext.
 /// This is provided just for completeness.
 #[inline(always)]
-pub fn op_keccak(_a: u64, _b: u64) -> (u64, bool) {
-    unimplemented!("op_keccak() is not implemented");
+pub const fn op_keccak(_a: u64, _b: u64) -> (u64, bool) {
+    panic!("op_keccak() is not implemented");
 }
 
 impl From<ZiskRequiredOperation> for ZiskOp {
@@ -1096,7 +1096,7 @@ pub const fn op_pubout(a: u64, b: u64) -> (u64, bool) {
 
 /// InstContext-based wrapper over op_pubout()
 #[inline(always)]
-pub fn opc_pubout(ctx: &mut InstContext) {
+pub const fn opc_pubout(ctx: &mut InstContext) {
     (ctx.c, ctx.flag) = op_pubout(ctx.a, ctx.b);
     //println!("public ${} = {:#010x}", ctx.a, ctx.b);
 }


### PR DESCRIPTION
With the new rust 1.83 changes, we are able to make most zisk ops const fns. The only remaining blockers are on keccak and any ops that make use of `Wrapping`. The keccak limitation stems from a key limitation right now which is that `Vec::as_slice()` as a const fn has not been stabilized yet. Once this is stabilized, we can upgrade `Mem` such that `read` is a const fn, and then we will be able to make the keccak op itself a const fn.

The `Wrapping` stuff might be up-gradable now, but we would have to do away with using `Wrapping`, and I don't know much about this one.

If all of these blockers are removed, the `execute` / `call` / etc methods on `ZiskOp` can all become const fns, which would be a HUGE boon for performance in situations where operands are known at compile-time.