### PR TITLE
Fix: Ensure PROFILE variable is set before use in ziskup script

### DIFF
--- a/ziskup/ziskup
+++ b/ziskup/ziskup
@@ -203,6 +203,10 @@ EOF
       ;;
   esac
 
+  results=($(get_profile_and_shell))
+  PROFILE="${results[0]}"
+  PREF_SHELL="${results[1]}"
+
   # Only add ziskup if it isn't already in PATH.
   if [[ ":$PATH:" != *":${ZISK_BIN_DIR}:"* ]]; then
       # Add the ziskup directory to the path and ensure the old PATH variables remain.
@@ -220,10 +224,6 @@ EOF
       echo
       warn "libusb not found. You may need to install it manually on macOS via Homebrew (brew install openssl)."
   fi
-
-  results=($(get_profile_and_shell))
-  PROFILE="${results[0]}"
-  PREF_SHELL="${results[1]}"
 
   step "Done! ZisK version ${ZISK_VERSION} has been installed."
   say "Your preferred shell '${PREF_SHELL}' was detected and ZisK has been added to your PATH. To start using the ZisK CLI tools, run 'source ${PROFILE}' or open a new terminal session."


### PR DESCRIPTION
## Description

This PR fixes a bug in the `ziskup` installation script where the `$PROFILE` shell variable was used in the final success message before it was actually populated.

**Problem:**

The script determined the user's shell profile file (e.g., `.zshenv`, `.bashrc`) using the `get_profile_and_shell` function. However, this function call and the subsequent assignment to the `PROFILE` variable happened *after* the variable was referenced in the success message printed to the user. This resulted in the following error:
```
/home/admin/.zisk/bin/ziskup: line 209: $PROFILE: ambiguous redirect
```

**Fix:**

The lines responsible for calling `get_profile_and_shell` and assigning the results to `PROFILE` and `PREF_SHELL` have been moved earlier in the script, ensuring these variables are correctly populated before they are used in the final message.
