### PR TITLE
Show error returned when panic in asm_min_traces_runners.rs

### DIFF
--- a/emulator-asm/asm-runner/src/asm_min_traces_runner.rs
+++ b/emulator-asm/asm-runner/src/asm_min_traces_runner.rs
@@ -204,7 +204,7 @@ impl AsmRunnerMT {
         let mut sem_out = NamedSemaphore::create(sem_output_name.clone(), 0).unwrap_or_else(|e| {
             panic!(
                 "AsmRunnerMT::run() failed calling NamedSemaphore::create({}), error: {}",
-                sem_input_name, e
+                sem_output_name, e
             )
         });
 
@@ -212,7 +212,7 @@ impl AsmRunnerMT {
             .unwrap_or_else(|e| {
                 panic!(
                     "AsmRunnerMT::run() failed calling NamedSemaphore::create({}), error: {}",
-                    sem_input_name, e
+                    sem_chunk_done_name, e
                 )
             });
 

--- a/emulator-asm/asm-runner/src/asm_min_traces_runner.rs
+++ b/emulator-asm/asm-runner/src/asm_min_traces_runner.rs
@@ -294,7 +294,7 @@ impl AsmRunnerMT {
                     }
                 }
                 Err(e) => {
-                    error!("Semaphore error: {:?}", e);
+                    error!("Semaphore sem_chunk_done error: {:?}", e);
 
                     if chunk_id.0 == 0 {
                         break 1;

--- a/emulator-asm/asm-runner/src/asm_rom_histogram_runner.rs
+++ b/emulator-asm/asm-runner/src/asm_rom_histogram_runner.rs
@@ -127,7 +127,7 @@ impl AsmRunnerRomH {
         // Wait for the assembly emulator to complete writing the trace
         if let Err(e) = semin.wait() {
             panic!(
-                "AsmRunnerRomH::run() failed calling semout.wait({}), error: {}",
+                "AsmRunnerRomH::run() failed calling semin.wait({}), error: {}",
                 sem_input_name, e
             );
         }

--- a/emulator-asm/asm-runner/src/asm_rom_histogram_runner.rs
+++ b/emulator-asm/asm-runner/src/asm_rom_histogram_runner.rs
@@ -121,7 +121,7 @@ impl AsmRunnerRomH {
         if let Err(e) = command.arg(&shmem_prefix).spawn() {
             error!("Child process failed: {:?}", e);
         } else if options.verbose || options.log_output {
-            info!("Child exited successfully");
+            info!("Child process launched successfully");
         }
 
         // Wait for the assembly emulator to complete writing the trace


### PR DESCRIPTION
This PR enhances the error reporting in asm_min_traces_runner.rs by including detailed error information in panic messages and replacing eprintln! calls with structured logging.

- Update panic messages to display error details
- Replace eprintln! with log macros for consistent logging
- Fix logging strings for better clarity