### PR TITLE
Remove unused tiny-keccak dependency from ziskos/entrypoint/Cargo.toml file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,7 +2318,7 @@ dependencies = [
  "proofman-macros",
  "proofman-util",
  "rayon",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
  "tracing",
  "witness",
  "zisk-common",
@@ -3431,15 +3431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "git+https://github.com/0xPolygonHermez/zisk-patch-tiny-keccak.git?branch=zisk#a5cb98ca4d9d390b39b10c9e81a061fd830aea35"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,7 +4536,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
  "zisk-pil",
  "ziskos",
 ]
@@ -4607,7 +4598,7 @@ version = "0.9.0"
 dependencies = [
  "generic-array",
  "sha2",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -4641,5 +4632,4 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "static_assertions",
- "tiny-keccak 2.0.2 (git+https://github.com/0xPolygonHermez/zisk-patch-tiny-keccak.git?branch=zisk)",
 ]

--- a/ziskos/entrypoint/Cargo.toml
+++ b/ziskos/entrypoint/Cargo.toml
@@ -12,7 +12,6 @@ lib-c = { path = "../../lib-c" }
 lazy_static = "1.5.0"
 static_assertions = "1.1"
 rand = "0.8.5"
-tiny-keccak = { git = "https://github.com/0xPolygonHermez/zisk-patch-tiny-keccak.git", branch = "zisk", features = [ "keccak" ] }
 getrandom = { version = "0.2", features = ["custom"] }
 cfg-if = "1.0"
 num-bigint = { workspace = true }


### PR DESCRIPTION
This PR removes the unused tiny-keccak dependency from the ziskos/entrypoint/Cargo.toml