### PR TITLE
fix: Compute low address in the jump dest table using the entrypoint to determine the boundary

### DIFF
--- a/core/src/elf2rom.rs
+++ b/core/src/elf2rom.rs
@@ -120,6 +120,7 @@ pub fn elf2rom(elf_file: &Path) -> Result<ZiskRom, Box<dyn Error>> {
     // Split the ROM instructions based on their address in order to get a better performance when
     // searching for the corresponding intruction to the pc program address
     let mut max_rom_entry = 0;
+    let mut min_rom_instructions = u64::MAX;
     let mut max_rom_instructions = 0;
     let mut min_rom_na_unstructions = u64::MAX;
     let mut max_rom_na_unstructions = 0;
@@ -153,6 +154,7 @@ pub fn elf2rom(elf_file: &Path) -> Result<ZiskRom, Box<dyn Error>> {
                 min_rom_na_unstructions = std::cmp::min(min_rom_na_unstructions, addr);
                 max_rom_na_unstructions = std::cmp::max(max_rom_na_unstructions, addr);
             } else {
+                min_rom_instructions = min_rom_instructions.min(addr);
                 max_rom_instructions = max_rom_instructions.max(addr);
             }
         } else {
@@ -161,6 +163,11 @@ pub fn elf2rom(elf_file: &Path) -> Result<ZiskRom, Box<dyn Error>> {
     }
     rom.max_bios_pc = max_rom_entry;
     rom.max_program_pc = max_rom_instructions;
+    rom.min_program_pc = if min_rom_instructions == u64::MAX { 
+        ROM_ADDR 
+    } else { 
+        min_rom_instructions 
+    };
 
     let num_rom_entry = (max_rom_entry - ROM_ENTRY) / 4 + 1;
     let num_rom_instructions = (max_rom_instructions - ROM_ADDR) / 4 + 1;

--- a/core/src/zisk_rom.rs
+++ b/core/src/zisk_rom.rs
@@ -114,6 +114,10 @@ pub struct ZiskRom {
     /// List of instruction program counter (address) in incremental order:
     /// 0x1000, 0x1004, ..., 0x80000000, 0x80000004, ...
     pub sorted_pc_list: Vec<u64>,
+
+    /// Minimum rom instruction PC (first program instruction address)
+    /// This is typically 0x80000000 but can be different (e.g., 0x80001000 with Go's internal linker)
+    pub min_program_pc: u64,
 }
 
 /// ZisK ROM implementation

--- a/core/src/zisk_rom_2_asm.rs
+++ b/core/src/zisk_rom_2_asm.rs
@@ -3284,11 +3284,12 @@ impl ZiskRom2Asm {
         *code += ".section .rodata\n";
         *code += ".align 64\n";
 
-        // Ensure the minimum program address label exists (it might not be in sorted_pc_list)
+        // Safety check: Ensure the minimum program address label exists
         //
-        // This handles edge cases where the program's declared start address doesn't contain
-        // an actual instruction, which can happen when the linker adds alignment padding at
-        // the section start as an example.
+        // This is defensive programming for rare cases where min_program_pc has no valid
+        // instruction (non-NOP padding, data in text section).
+        // In practice with NOP padding, this check never triggers and the entrypoint
+        // is the min_program_pc
         if rom.min_program_pc >= ROM_ADDR && !rom.sorted_pc_list.contains(&rom.min_program_pc) {
             *code +=
                 &format!("map_pc_{:x}: \t.quad pc_{:x}\n", rom.min_program_pc, rom.min_program_pc);


### PR DESCRIPTION
Related to #480 