### PR TITLE
fix: handle nop instruction

### DIFF
--- a/core/src/riscv2zisk_context.rs
+++ b/core/src/riscv2zisk_context.rs
@@ -163,6 +163,7 @@ impl Riscv2ZiskContext<'_> {
             "csrrwi" => self.csrrwi(riscv_instruction),
             "csrrsi" => self.csrrsi(riscv_instruction),
             "csrrci" => self.csrrci(riscv_instruction),
+            "nop" => self.nop(riscv_instruction),
             _ => panic!(
                 "Riscv2ZiskContext::convert() found invalid riscv_instruction.inst={}",
                 riscv_instruction.inst

--- a/riscv/src/riscv_interpreter.rs
+++ b/riscv/src/riscv_interpreter.rs
@@ -52,9 +52,17 @@ pub fn riscv_interpreter(code: &[u32]) -> Vec<RiscvInstruction> {
         // Get the RISCV instruction
         let inst = *inst_ref;
 
-        // Ignore instructions that are zero
+        // Handle zero instructions as NOPs to preserve correct instruction indexing
         if inst == 0 {
-            //println!("riscv_interpreter() found inst=0 at position s={}", s);
+            //println!("riscv_interpreter() found inst=0 at position s={}, treating as NOP", s);
+            // Create a NOP instruction (zero instruction)
+            let nop = RiscvInstruction {
+                rvinst: 0,
+                inst: "nop".to_string(),
+                t: "NOP".to_string(),
+                ..Default::default()
+            };
+            insts.push(nop);
             continue;
         }
 


### PR DESCRIPTION
The initial zero instruction test case in #480 is exercising two things, so leaving this in draft for now