### PR TITLE
Add support for testing assembly RISC-V ELF files to the pr.yml github action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,15 +44,10 @@ jobs:
   test-x86_64:
     name: Test on Ubuntu x86_64
     runs-on: self-hosted
-    timeout-minutes: 120
+    timeout-minutes: 30
     container:
       image: ubuntu:22.04
-      options:
-        --shm-size=32g  
-        -v /home/gha/cache-setup:/output:rw
-    defaults:
-      run:
-        shell: bash        
+      options: --memory=128g --cpus=128 --shm-size=64g
     env:
       ZISK_GHA: "1"
       ZISK_REPO_DIR: ${{ github.workspace }}
@@ -75,13 +70,11 @@ jobs:
           cd "$GITHUB_WORKSPACE/tools/test-env"
           ./build_zisk.sh
 
-      - name: Build setup
-        env:
-          USE_CACHE_SETUP: "1"
-        run: |     
+      - name: Install setup
+        run: |
           cd "$GITHUB_WORKSPACE/tools/test-env"
-          ./build_setup.sh
-
+          ./install_setup_public.sh
+  
       - name: Test sha_hasher
         run: |
           cd "$GITHUB_WORKSPACE/tools/test-env"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,11 +23,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y openmpi-bin openmpi-common libopenmpi-dev nlohmann-json3-dev  build-essential libbenchmark-dev libomp-dev libgmp-dev  nasm libsodium-dev cmake
-
-      - name: Setup CI
-        uses: ./.github/actions/setup
+          cd "$GITHUB_WORKSPACE/tools/test-env"
+          sudo ./install_deps.sh
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1
@@ -47,18 +44,23 @@ jobs:
   test-x86_64:
     name: Test on Ubuntu x86_64
     runs-on: self-hosted
-    timeout-minutes: 30
+    timeout-minutes: 120
     container:
       image: ubuntu:22.04
-      options: --memory=128g --cpus=128 --shm-size=64g
+      options:
+        --shm-size=32g  
+        -v /home/gha/cache-setup:/output:rw
+    defaults:
+      run:
+        shell: bash        
     env:
       ZISK_GHA: "1"
       ZISK_REPO_DIR: ${{ github.workspace }}
       BLOCK_INPUTS_DISTRIBUTED: "21429020_5_0.bin"
       DISTRIBUTED_PROCESSES: "2"
       DISTRIBUTED_THREADS: "64"
-      PROVE_FLAGS: "-a -y"      
-      TERM: xterm  
+      PROVE_FLAGS: "-a -y"
+      TERM: xterm
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -73,11 +75,13 @@ jobs:
           cd "$GITHUB_WORKSPACE/tools/test-env"
           ./build_zisk.sh
 
-      - name: Install setup
-        run: |
+      - name: Build setup
+        env:
+          USE_CACHE_SETUP: "1"
+        run: |     
           cd "$GITHUB_WORKSPACE/tools/test-env"
-          ./install_setup_public.sh
-  
+          ./build_setup.sh
+
       - name: Test sha_hasher
         run: |
           cd "$GITHUB_WORKSPACE/tools/test-env"
@@ -92,6 +96,9 @@ jobs:
     name: Test on macOS
     runs-on: macos-14
     timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash    
     env:
       ZISK_GHA: "1"
       ZISK_REPO_DIR: ${{ github.workspace }}
@@ -118,6 +125,45 @@ jobs:
           cd "$GITHUB_WORKSPACE/tools/test-env"
           ./test_sha_hasher.sh
 
+  test-riscof:
+    name: Test Riscof ELF files
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash        
+    env:
+      ZISK_GHA: "1"
+      ZISK_REPO_DIR: ${{ github.workspace }}
+      TERM: xterm
+    steps:
+      - name: Increase shared memory (/dev/shm)
+        run: |
+          set -euxo pipefail
+          df -h /dev/shm || true
+          sudo mount -o remount,size=16G /dev/shm || sudo mount -o remount,size=16G /run/shm
+          df -h /dev/shm
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Checkout zisk-testvectors repo
+        uses: actions/checkout@v4
+        with:
+          repository: 0xPolygonHermez/zisk-testvectors
+          path: zisk-testvectors 
+
+      - name: Install dependencies
+        run: |
+          cd "$GITHUB_WORKSPACE/tools/test-env"
+          sudo ./install_deps.sh
+
+      - name: Emulate in assembly Riscof ELF files
+        run: |
+          . "$HOME/.cargo/env"
+          cd "$GITHUB_WORKSPACE"
+          sudo ./tools/emulate_asm_all.sh $GITHUB_WORKSPACE/zisk-testvectors/riscof/riscof_work/rv64i_m
+
   lint:
     name: Formatting & Clippy
     runs-on: ubuntu-latest
@@ -129,25 +175,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y openmpi-bin openmpi-common libopenmpi-dev
-
-      - name: Setup CI
-        uses: ./.github/actions/setup
-
-      - name: Clean rust toolchain
-        run: |
-          rustup self uninstall -y || true
-          rm -rf ~/.rustup ~/.cargo        
-
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
-          override: true
-          components: rustfmt
+          cd "$GITHUB_WORKSPACE/tools/test-env"
+          sudo ./install_deps.sh
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/tools/emulate_asm_all.sh
+++ b/tools/emulate_asm_all.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+
+source "$HOME/.cargo/env"
+
 echo "Emulate in assembly all ELF files found in a directory"
 
 # Check that at least one argument has been passed
@@ -33,7 +37,7 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-if [$DEBUG -eq 1 ]; then
+if [ $DEBUG -eq 1 ]; then
     echo "Debug mode enabled";
     set -x;  # Enable debugging output
 else
@@ -64,12 +68,22 @@ if [ $LIST -eq 1 ]; then
     exit 0;
 fi
 
+# Build ZisK
+echo "Building ZisK..."
+cargo build
+# Create an empty input file
+echo "Creating empty input file"
+touch ./emulator-asm/empty_input.bin
+
 # Record the number of files
 MAX_COUNTER=${COUNTER}
 
-# Create an empty input file
-INPUT_FILE="/tmp/empty_input.bin"
-touch $INPUT_FILE
+# Kill previous instances of the emulator server, if any
+if pgrep -x ziskemuasm >/dev/null; then
+    pkill -x ziskemuasm
+    echo "Sleeping for 5 seconds to kill previous ziskemuasm instances..."
+    sleep 5
+fi
 
 # For all files
 COUNTER=0
@@ -94,16 +108,14 @@ do
     echo ""
     echo "Emulating file ${COUNTER} of ${MAX_COUNTER}: ${ELF_FILE}"
 
-    # Transpile the ELF RISC-V file to Zisk, and then generate assembly file emu.asm
-    cargo build --bin=riscv2zisk
-    ./target/debug/riscv2zisk $ELF_FILE emulator-asm/src/emu.asm --gen=1
+    # Transpile the ELF RISC-V file to ZisK, and then generate assembly file emu.asm
+    ./target/debug/riscv2zisk $ELF_FILE emulator-asm/src/emu.asm --gen=1 || exit 1
 
     # Compile the assembly emulator derived from this ELF file
     cd emulator-asm
     make
 
     # Execute it and save output
-    touch empty_input.bin
     build/ziskemuasm -s --gen=1 -o --silent 2>&1|tee output &
 
     # Store the PID of the background process
@@ -119,7 +131,7 @@ do
 
     # Compare output vs reference
     ELF_FILE_DIRECTORY=${ELF_FILE%%my.elf}
-    REFERENCE_FILE="../${ELF_FILE_DIRECTORY}../ref/Reference-sail_c_simulator.signature"
+    REFERENCE_FILE="$(realpath "${ELF_FILE_DIRECTORY}/../ref/Reference-sail_c_simulator.signature")"
     echo "Calling diff of ./output vs reference=$REFERENCE_FILE"
     if diff output $REFERENCE_FILE; then
         DIFF_PASSED_COUNTER=$((DIFF_PASSED_COUNTER+1))
@@ -135,3 +147,9 @@ do
     cd ..
 done
 
+if [ $DIFF_FAILED_COUNTER -eq 0 ]; then
+    echo "✅ All ELF files processed successfully."
+else
+    echo "❌ ${DIFF_FAILED_COUNTER} ELF files have failed."
+    exit 1
+fi

--- a/tools/emulate_asm_all.sh
+++ b/tools/emulate_asm_all.sh
@@ -120,11 +120,11 @@ do
 
     # Store the PID of the background process
     # BG_PID=$!
-    echo "Sleeping for 10 seconds to let the emulator server initialize..."
-    sleep 10
-    build/ziskemuasm -c -i empty_input.bin --gen=1 --shutdown
-    echo "Sleeping for 5 seconds to let the emulator server complete..."
+    echo "Sleeping for 5 seconds to let the emulator server initialize..."
     sleep 5
+    build/ziskemuasm -c -i empty_input.bin --gen=1 --shutdown
+    echo "Sleeping for 2 seconds to let the emulator server complete..."
+    sleep 2
 
     #echo "Killing the background process..."
     #kill $BG_PID


### PR DESCRIPTION
This PR adds support for testing assembly RISC-V ELF files from the riscof test suite to the GitHub Actions CI workflow. The changes enhance the existing assembly emulation script with better error handling and integrate riscof ELF file testing into the CI pipeline.

- Improved the assembly emulation script with error handling, better output formatting, and proper process management
- Added a new GitHub Actions job to test riscof ELF files by checking out the zisk-testvectors repository
- Standardized dependency installation across CI jobs to use a centralized script