### PR TITLE
docs: update broken link in benchmark reference

### DIFF
--- a/emulator/benches/benchmark.rs
+++ b/emulator/benches/benchmark.rs
@@ -7,7 +7,7 @@ use zisk_core::{Riscv2zisk, ZiskRom};
 use ziskemu::{EmuOptions, Emulator, ZiskEmulator};
 
 // Thanks to the example provided by @jebbow in his article
-// https://www.jibbow.com/posts/criterion-flamegraphs/
+// https://andreas-zimmerer.medium.com/automatic-flamegraphs-for-benchmarks-with-criterion-f8e59499cc2a
 
 /*
 fn fibonacci(n: u64) -> u64 {


### PR DESCRIPTION
emulator/benches/benchmark.rs: replaced outdated blog link (jibbow.com) with a working Medium article about automatic flamegraphs for Criterion benchmarks.