### PR TITLE
chore: Add 16 bit zero example

### DIFF
--- a/elf-regressions/compressed/test_unimp.s
+++ b/elf-regressions/compressed/test_unimp.s
@@ -1,0 +1,12 @@
+# Test case to reproduce 16 bit zeroes
+
+.section .text.init
+.global _start
+
+_start:
+    unimp        # Assembler generates 0x0000 (in RVC mode) 
+    
+    li a7, 93
+    ecall
+
+1:  j 1b                # Infinite loop


### PR DESCRIPTION
`unimp` is compiled into 16-bit zero