### PR TITLE
fix edge case with memory collector

### DIFF
--- a/state-machines/mem-common/src/mem_module_check_point.rs
+++ b/state-machines/mem-common/src/mem_module_check_point.rs
@@ -23,8 +23,7 @@ impl MemModuleCheckPoint {
     }
     pub fn add_rows(&mut self, addr: u32, count: u32) {
         // data is processed by order address, an only one address by chunk/step
-        // TODO: assert -> debug_assert
-        assert!(addr >= self.to_addr);
+        debug_assert!(addr >= self.to_addr);
 
         self.count += count;
 


### PR DESCRIPTION
Edge case with mem-collector, when count = 0 but remain information to obtain previous segment info. For other side the counter is a rows counter, because now with dual mem an row could verify two memory access.