### PR TITLE
Remove broken repo link 

### DIFF
--- a/witness-computation/README.md
+++ b/witness-computation/README.md
@@ -16,7 +16,7 @@ Install the following repositories:
 ```bash
 git clone https://github.com/0xPolygonHermez/pil2-compiler.git
 git clone https://github.com/0xPolygonHermez/pil2-proofman-js.git
-git clone https://github.com/0xPolygonHermez/pil2-components.git
+git clone https://github.com/0xPolygonHermez/
 git clone https://github.com/0xPolygonHermez/pil2-proofman.git
 ```
 


### PR DESCRIPTION
The repo pil2-components no longer exists, so the link was broken and blocking setup.
I removed it for now - if there’s a proper replacement, let me know and I’ll update the README right away.