### PR TITLE
update pils with bits column feature to avoid use a manual hint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["cryptography"]
 
 [workspace.metadata]
 gha_pil2_proofman_js_branch = "pre-develop-0.13.0"
-gha_pil2_compiler_branch = "develop"
+gha_pil2_compiler_branch = "develop-0.8.0"
 
 [workspace]
 members = [

--- a/pil/src/pil_helpers/traces.rs
+++ b/pil/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "1dea3c88c13a3b850a4940829b20cb72fd61e1803b527ca8bf35e27766d64494";
+pub const PILOUT_HASH: &str = "a7596025b46f73c16f52e6234f3763f4469b69f18714b88da50d0fd41d4dde1b";
 
 //AIRGROUP CONSTANTS
 

--- a/precompiles/arith_eq/pil/arith_eq.pil
+++ b/precompiles/arith_eq/pil/arith_eq.pil
@@ -72,28 +72,17 @@ airtemplate ArithEq (int N = 2**18, const int operation_bus_id = OPERATION_BUS_I
     const int MAX_CEQS = 3; // Max concurrent equations
     const int QS = 3;       // Number of quotients
 
-    col witness x1;
-    @witness_bits{ name: "x1", bits: CHUNK_BITS }
-    col witness y1;
-    @witness_bits{ name: "y1", bits: CHUNK_BITS }
-    col witness x2;
-    @witness_bits{ name: "x2", bits: CHUNK_BITS }
-    col witness y2;
-    @witness_bits{ name: "y2", bits: CHUNK_BITS }
-    col witness x3;
-    @witness_bits{ name: "x3", bits: CHUNK_BITS }
-    col witness y3;
-    @witness_bits{ name: "y3", bits: CHUNK_BITS }
-    col witness q0;
-    @witness_bits{ name: "q0", bits: Q_HSC_BITS }
-    col witness q1;
-    @witness_bits{ name: "q1", bits: Q_HSC_BITS }
-    col witness q2;
-    @witness_bits{ name: "q2", bits: Q_HSC_BITS }
-    col witness s;
-    @witness_bits{ name: "s", bits: Q_HSC_BITS }
-    col witness sel_op[OPS];
-    @witness_bits{ name: "sel_op", bits: 1 }
+    col witness bits(CHUNK_BITS) x1;
+    col witness bits(CHUNK_BITS) y1;
+    col witness bits(CHUNK_BITS) x2;
+    col witness bits(CHUNK_BITS) y2;
+    col witness bits(CHUNK_BITS) x3;
+    col witness bits(CHUNK_BITS) y3;
+    col witness bits(Q_HSC_BITS) q0;
+    col witness bits(Q_HSC_BITS) q1;
+    col witness bits(Q_HSC_BITS) q2;
+    col witness bits(Q_HSC_BITS) s;
+    col witness bits(1) sel_op[OPS];
 
     const expr sel_arith256 = sel_op[0];
     const expr sel_arith256_mod = sel_op[1];
@@ -151,8 +140,7 @@ airtemplate ArithEq (int N = 2**18, const int operation_bus_id = OPERATION_BUS_I
     include "equations/bn254_complex_mul_x3.pil"
     include "equations/bn254_complex_mul_y3.pil"
 
-    col witness sel_op_clk0[OPS];
-    @witness_bits{ name: "sel_op_clk0", bits: 1 }
+    col witness bits(1) sel_op_clk0[OPS];
 
     const expr arith256_clk0 = sel_op_clk0[0];
     const expr arith256_mod_clk0 = sel_op_clk0[1];
@@ -236,8 +224,7 @@ airtemplate ArithEq (int N = 2**18, const int operation_bus_id = OPERATION_BUS_I
     // inverse to demostrate that x1 and x2 are different.
 
     const expr x_delta_chunk = x2 - x1;
-    col witness x_delta_chunk_inv;
-    @witness_bits{ name: "x_delta_chunk_inv", bits: 64 }
+    col witness bits(64) x_delta_chunk_inv;
 
     // x_chunk_different as binary value, only when x_delta_chunk_inv == inv(x_delta_chunk),
     // its value is 1.
@@ -261,8 +248,7 @@ airtemplate ArithEq (int N = 2**18, const int operation_bus_id = OPERATION_BUS_I
 
     // x_are_different is used to indicate that in current clock we knows that x1 and x2 are different
 
-    col witness x_are_different;
-    @witness_bits{ name: "x_are_different", bits: 1 }
+    col witness bits(1) x_are_different;
     x_are_different * (1 - x_are_different) === 0;
 
     // x_are_different in first clock that x_are_different == 1, after that x_are_different must be 0.
@@ -369,10 +355,8 @@ airtemplate ArithEq (int N = 2**18, const int operation_bus_id = OPERATION_BUS_I
     // extra column, we replicate this table for all chunks, total size is 2^18 * 2^4 = 2^22 rows.
     // An extra column here is "pay" for each instance, but in a table is paid once.
 
-    col witness x3_lt;
-    @witness_bits{ name: "x3_lt", bits: 1 }
-    col witness y3_lt;
-    @witness_bits{ name: "y3_lt", bits: 1 }
+    col witness bits(1) x3_lt;
+    col witness bits(1) y3_lt;
 
     x3_lt * (1 - x3_lt) === 0;
     y3_lt * (1 - y3_lt) === 0;
@@ -388,8 +372,7 @@ airtemplate ArithEq (int N = 2**18, const int operation_bus_id = OPERATION_BUS_I
     lookup_assumes(ARITH_EQ_LT_TABLE_ID, [2 * 'x3_lt * (1 - CLK_0) + x3_lt, delta_x3], sel: sel_check_x_lt_prime);
     lookup_assumes(ARITH_EQ_LT_TABLE_ID, [2 * 'y3_lt * (1 - CLK_0) + y3_lt, delta_y3], sel: sel_check_y_lt_prime);
 
-    col witness carry[MAX_CEQS][CBC];
-    @witness_bits{ name: "carry", bits: 64, signed: 1 }
+    col witness bits(64, signed) carry[MAX_CEQS][CBC];
 
     for (int i = 0; i < MAX_CEQS; ++i) {
         carry[i][0] * CLK_0 === 0;
@@ -418,8 +401,7 @@ airtemplate ArithEq (int N = 2**18, const int operation_bus_id = OPERATION_BUS_I
     // of clock selector and step_addr. This expression has degree 2. In some situations it could be
     // useful to save columns.
 
-    col witness step_addr;
-    @witness_bits{ name: "step_addr", bits: 40 }
+    col witness bits(40) step_addr;
 
     const int MAIN_STEP = 0;
 

--- a/precompiles/arith_eq_384/pil/arith_eq_384.pil
+++ b/precompiles/arith_eq_384/pil/arith_eq_384.pil
@@ -63,28 +63,17 @@ airtemplate ArithEq384(const int N, const int operation_bus_id = OPERATION_BUS_I
     const int MAX_CEQS = 3; // Max concurrent equations
     const int QS = 3;       // Number of quotients
 
-    col witness x1;
-    @witness_bits{ name: "x1", bits: CHUNK_BITS }
-    col witness y1;
-    @witness_bits{ name: "y1", bits: CHUNK_BITS }
-    col witness x2;
-    @witness_bits{ name: "x2", bits: CHUNK_BITS }
-    col witness y2;
-    @witness_bits{ name: "y2", bits: CHUNK_BITS }
-    col witness x3;
-    @witness_bits{ name: "x3", bits: CHUNK_BITS }
-    col witness y3;
-    @witness_bits{ name: "y3", bits: CHUNK_BITS }
-    col witness q0;
-    @witness_bits{ name: "q0", bits: Q_HSC_BITS }
-    col witness q1;
-    @witness_bits{ name: "q1", bits: Q_HSC_BITS }
-    col witness q2;
-    @witness_bits{ name: "q2", bits: Q_HSC_BITS }
-    col witness s;
-    @witness_bits{ name: "s", bits: Q_HSC_BITS }
-    col witness sel_op[OPS];
-    @witness_bits{ name: "sel_op", bits: 1 }
+    col witness bits(CHUNK_BITS) x1;
+    col witness bits(CHUNK_BITS) y1;
+    col witness bits(CHUNK_BITS) x2;
+    col witness bits(CHUNK_BITS) y2;
+    col witness bits(CHUNK_BITS) x3;
+    col witness bits(CHUNK_BITS) y3;
+    col witness bits(Q_HSC_BITS) q0;
+    col witness bits(Q_HSC_BITS) q1;
+    col witness bits(Q_HSC_BITS) q2;
+    col witness bits(Q_HSC_BITS) s;
+    col witness bits(1) sel_op[OPS];
 
 
     const expr sel_arith384_mod = sel_op[0];
@@ -127,8 +116,7 @@ airtemplate ArithEq384(const int N, const int operation_bus_id = OPERATION_BUS_I
     include "equations/bls12_381_complex_mul_x3.pil"
     include "equations/bls12_381_complex_mul_y3.pil"
 
-    col witness sel_op_clk0[OPS];
-    @witness_bits{ name: "sel_op_clk0", bits: 1 }
+    col witness bits(1) sel_op_clk0[OPS];
 
     const expr arith384_mod_clk0 = sel_op_clk0[0];
     const expr bls12_381_curve_add_clk0 = sel_op_clk0[1];
@@ -204,8 +192,7 @@ airtemplate ArithEq384(const int N, const int operation_bus_id = OPERATION_BUS_I
     // inverse to demostrate that x1 and x2 are different.
 
     const expr x_delta_chunk = x2 - x1;
-    col witness x_delta_chunk_inv;
-    @witness_bits{ name: "x_delta_chunk_inv", bits: 64 }
+    col witness bits(64) x_delta_chunk_inv;
 
     // x_chunk_different as binary value, only when x_delta_chunk_inv == inv(x_delta_chunk),
     // its value is 1.
@@ -229,8 +216,7 @@ airtemplate ArithEq384(const int N, const int operation_bus_id = OPERATION_BUS_I
 
     // x_are_different is used to indicate that in current clock we knows that x1 and x2 are different
 
-    col witness x_are_different;
-    @witness_bits{ name: "x_are_different", bits: 1 }
+    col witness bits(1) x_are_different;
     x_are_different * (1 - x_are_different) === 0;
 
     // x_are_different in first clock that x_are_different == 1, after that x_are_different must be 0.
@@ -337,10 +323,8 @@ airtemplate ArithEq384(const int N, const int operation_bus_id = OPERATION_BUS_I
     // extra column, we replicate this table for all chunks, total size is 2^18 * 2^4 = 2^22 rows.
     // An extra column here is "pay" for each instance, but in a table is paid once.
 
-    col witness x3_lt;
-    @witness_bits{ name: "x3_lt", bits: 1 }
-    col witness y3_lt;
-    @witness_bits{ name: "y3_lt", bits: 1 }
+    col witness bits(1) x3_lt;
+    col witness bits(1) y3_lt;
 
     x3_lt * (1 - x3_lt) === 0;
     y3_lt * (1 - y3_lt) === 0;
@@ -355,8 +339,7 @@ airtemplate ArithEq384(const int N, const int operation_bus_id = OPERATION_BUS_I
     lookup_assumes(ARITH_EQ_LT_TABLE_ID, [2 * 'x3_lt * (1 - CLK_0) + x3_lt, delta_x3], sel: sel_check_x_lt_prime);
     lookup_assumes(ARITH_EQ_LT_TABLE_ID, [2 * 'y3_lt * (1 - CLK_0) + y3_lt, delta_y3], sel: sel_check_y_lt_prime);
 
-    col witness carry[MAX_CEQS][CBC];
-    @witness_bits{ name: "carry", bits: 64, signed: 1 }
+    col witness bits(64, signed) carry[MAX_CEQS][CBC];
     for (int i = 0; i < MAX_CEQS; ++i) {
         // Initial carry must be 0
         carry[i][0] * CLK_0 === 0;
@@ -385,8 +368,7 @@ airtemplate ArithEq384(const int N, const int operation_bus_id = OPERATION_BUS_I
     // of clock selector and step_addr. This expression has degree 2. In some situations it could be
     // useful to save columns.
 
-    col witness step_addr;
-    @witness_bits{ name: "step_addr", bits: 40 }
+    col witness bits(40) step_addr;
 
     const int MAIN_STEP = 0;
 

--- a/precompiles/big_int/pil/big_int_add.pil
+++ b/precompiles/big_int/pil/big_int_add.pil
@@ -51,42 +51,31 @@ airtemplate BigIntAdd(const int N = 2**21, const int operation_bus_id = OPERATIO
     const int N_RC = bits / (RC * 32);
     assert_eq(N_RC * RC * 32, bits);
 
-    col witness a[N_RC][RC];
-    @witness_bits{ name: "a", bits: 32 }    
-    col witness b[N_RC][RC];
-    @witness_bits{ name: "b", bits: 32 }
-    col witness c_chunks[N_RC][RC*2];
-    @witness_bits{ name: "c_chunks", bits: 16 }
-    col witness cout[N_RC][RC];
-    @witness_bits{ name: "cout", bits: 1 }
+    col witness bits(32) a[N_RC][RC];
+    col witness bits(32) b[N_RC][RC];
+    col witness bits(16) c_chunks[N_RC][RC*2];
+    col witness bits(1) cout[N_RC][RC];
 
     // address of struct with params
-    col witness addr_params;
-    @witness_bits{ name: "addr_params", bits: 32 }
+    col witness bits(32) addr_params;
 
     // address of a chunks
-    col witness addr_a;
-    @witness_bits{ name: "addr_a", bits: 32 }
+    col witness bits(32) addr_a;
 
     // address of b chunks
-    col witness addr_b;
-    @witness_bits{ name: "addr_b", bits: 32 }
+    col witness bits(32) addr_b;
 
     // address of c chunks
-    col witness addr_c;
-    @witness_bits{ name: "addr_c", bits: 32 }
+    col witness bits(32) addr_c;
 
     // main step of the operation
-    col witness step;
-    @witness_bits{ name: "step", bits: 40 }
+    col witness bits(40) step;
 
     // carry in binary column
-    col witness cin;
-    @witness_bits{ name: "cin", bits: 1 }
+    col witness bits(1) cin;
 
     // selector for enable row
-    col witness sel;
-    @witness_bits{ name: "sel", bits: 1 }
+    col witness bits(1) sel;
 
     const expr c[N_RC][RC];
 

--- a/precompiles/keccakf/pil/keccakf.pil
+++ b/precompiles/keccakf/pil/keccakf.pil
@@ -51,14 +51,10 @@ airtemplate Keccakf(const int N, const int chunks, const int bits, const int RC,
     col fixed CONN_C;
     col fixed CONN_D;
 
-    col witness free_in_a[chunks];
-    @witness_bits{ name: "free_in_a", bits: bits }
-    col witness free_in_b[chunks];
-    @witness_bits{ name: "free_in_b", bits: bits }
-    col witness free_in_c[chunks];
-    @witness_bits{ name: "free_in_c", bits: bits }
-    col witness free_in_d[chunks];
-    @witness_bits{ name: "free_in_d", bits: bits }
+    col witness bits(bits) free_in_a[chunks];
+    col witness bits(bits) free_in_b[chunks];
+    col witness bits(bits) free_in_c[chunks];
+    col witness bits(bits) free_in_d[chunks];
 
     // --> Circuit gates constraints
     for (int i = 0; i < chunks; i++) {
@@ -131,10 +127,8 @@ airtemplate Keccakf(const int N, const int chunks, const int bits, const int RC,
         ----------------------------------------------------------------------------------------          
     */
 
-    col witness bit[mem_bits_in_parallel];
-    @witness_bits{ name: "bit", bits: 1 }
-    col witness val[mem_bits_in_parallel];
-    @witness_bits{ name: "val", bits: 64 }    
+    col witness bits(1) bit[mem_bits_in_parallel];
+    col witness bits(64) val[mem_bits_in_parallel];
 
     // Ensure that bit[i] is a bit
     for (int i = 0; i < mem_bits_in_parallel; i++) {
@@ -197,8 +191,7 @@ airtemplate Keccakf(const int N, const int chunks, const int bits, const int RC,
     // (1),(2) and (3) prove that the bit decomposition is correct
 
     // A single col is sufficient for storing the step and the address
-    col witness step_addr;
-    @witness_bits{ name: "step_addr", bits: 40 }
+    col witness bits(40) step_addr;
 
     // Number of memory accesses needed to handle the bits
     const int MEM_BITS = RB * RC;
@@ -296,13 +289,11 @@ airtemplate Keccakf(const int N, const int chunks, const int bits, const int RC,
     const expr mem_addr = clock_map(step_addr, pos: ADDR_STATE, start: 0,         end: IN_BLOCKS,     delta: 8, factor: MEM_SIZE) +
                           clock_map(step_addr, pos: ADDR_STATE, start: IN_BLOCKS, end: IN_OUT_BLOCKS, delta: 8, factor: MEM_SIZE);
 
-    col witness in_use_clk_0;
-    @witness_bits{ name: "in_use_clk_0", bits: 1 }
+    col witness bits(1) in_use_clk_0;
     in_use_clk_0 * (1 - in_use_clk_0) === 0;
     (1 - CLK_0) * in_use_clk_0 === 0; // it can only be active when CLK_0 is active
 
-    col witness in_use;
-    @witness_bits{ name: "in_use", bits: 1 }
+    col witness bits(1) in_use;
     in_use * (1 - in_use) === 0;
 
     // if in_use is activated, it must be activated until there are not more input/output blocks

--- a/precompiles/sha256f/pil/sha256f.pil
+++ b/precompiles/sha256f/pil/sha256f.pil
@@ -82,12 +82,9 @@ airtemplate Sha256f(const int N = 2**22, const int RC = 2, const int RB = 32,
     const expr is_mixing        = clock_set(start: 0, end: CLOCKS_MIXING - 1,      offset: CLOCKS_LOAD_STATE + CLOCKS_LOAD_INPUT);
     const expr is_writing_state = clock_set(start: 0, end: CLOCKS_WRITE_STATE - 1, offset: CLOCKS_LOAD_STATE + CLOCKS_LOAD_INPUT + CLOCKS_MIXING);
 
-    col witness a[32];
-    @witness_bits{ name: "a", bits: 1 }
-    col witness e[32];
-    @witness_bits{ name: "e", bits: 1 }
-    col witness w[32];
-    @witness_bits{ name: "w", bits: 1 }
+    col witness bits(1) a[32];
+    col witness bits(1) e[32];
+    col witness bits(1) w[32];
 
     // a,e and w are bits
     for (int i = 0; i < 32; i++) {
@@ -128,12 +125,9 @@ airtemplate Sha256f(const int N = 2**22, const int RC = 2, const int RB = 32,
     // Similarly, for the new w value, we add 3 32-bit numbers, and this generates
     // a number of at most 34 bits, since 2^33 < 3*(2^32-1) < 2^34
     // We use the following columns to store the carry bits
-    col witness new_a_carry_bits;
-    @witness_bits{ name: "new_a_carry_bits", bits: 8 }
-    col witness new_e_carry_bits;
-    @witness_bits{ name: "new_e_carry_bits", bits: 8 }
-    col witness new_w_carry_bits;
-    @witness_bits{ name: "new_w_carry_bits", bits: 4 }
+    col witness bits(8) new_a_carry_bits;
+    col witness bits(8) new_e_carry_bits;
+    col witness bits(4) new_w_carry_bits;
     range_check(expression: new_a_carry_bits, min: 0, max: P2_3 - 1);
     range_check(expression: new_e_carry_bits, min: 0, max: P2_3 - 1);
     expr rc_new_w_carry_bits = 1;
@@ -172,8 +166,7 @@ airtemplate Sha256f(const int N = 2**22, const int RC = 2, const int RB = 32,
         while sending both addr_ind_0 and addr_ind_1 to the memory.         
     */
 
-    col witness step_addr;
-    @witness_bits{ name: "step_addr", bits: 40 }
+    col witness bits(40) step_addr;
 
     /*
         MEMORY ACCESS MAP
@@ -232,13 +225,11 @@ airtemplate Sha256f(const int N = 2**22, const int RC = 2, const int RB = 32,
 
     const expr main_step = clock_map(step_addr, STEP_MAIN, start: 0, end: 17);
 
-    col witness in_use_clk_0;
-    @witness_bits{ name: "in_use_clk_0", bits: 1 }
+    col witness bits(1) in_use_clk_0;
     in_use_clk_0 * (1 - in_use_clk_0) === 0;
     (1 - CLK_0) * in_use_clk_0 === 0; // it can only be active when CLK_0 is active
 
-    col witness in_use;
-    @witness_bits{ name: "in_use", bits: 1 }
+    col witness bits(1) in_use;
     in_use * (1 - in_use) === 0;
     const expr in_use_active = clock_set(start: 1, end: 17);
     in_use_active * (in_use - 'in_use) === 0; // if activated, it must be activated while in use

--- a/state-machines/arith/pil/arith.pil
+++ b/state-machines/arith/pil/arith.pil
@@ -13,59 +13,38 @@ airtemplate Arith(int N = 2**18, const int operation_bus_id = OPERATION_BUS_ID, 
     const int CHUNKS_INPUT = 4;
     const int CHUNKS_OP = CHUNKS_INPUT * 2;
 
-    col witness carry[CHUNKS_OP - 1];
-    @witness_bits{ name: "carry", bits: 64, signed: 1 }
-    col witness a[CHUNKS_INPUT];
-    @witness_bits{ name: "a", bits: 16 }
-    col witness b[CHUNKS_INPUT];
-    @witness_bits{ name: "b", bits: 16 }
-    col witness c[CHUNKS_INPUT];
-    @witness_bits{ name: "c", bits: 16 }
-    col witness d[CHUNKS_INPUT];
-    @witness_bits{ name: "d", bits: 16 }
+    col witness bits(64, signed) carry[CHUNKS_OP - 1];
+    col witness bits(16) a[CHUNKS_INPUT];
+    col witness bits(16) b[CHUNKS_INPUT];
+    col witness bits(16) c[CHUNKS_INPUT];
+    col witness bits(16) d[CHUNKS_INPUT];
 
-    col witness na;     // a is negative
-    @witness_bits{ name: "na", bits: 1 }
-    col witness nb;     // b is negative
-    @witness_bits{ name: "nb", bits: 1 }
-    col witness nr;     // rem is negative
-    @witness_bits{ name: "nr", bits: 1 }
-    col witness np;     // prod is negative
-    @witness_bits{ name: "np", bits: 1 }
-    col witness sext;   // sign extend for 32 bits result
-    @witness_bits{ name: "sext", bits: 1 }
+    col witness bits(1) na;
+    col witness bits(1) nb;
+    col witness bits(1) nr;
+    col witness bits(1) np;
+    col witness bits(1) sext;
 
-    col witness m32;    // 32 bits operation
-    @witness_bits{ name: "m32", bits: 1 }
-    col witness div;    // division operation (div,rem)
-    @witness_bits{ name: "div", bits: 1 }
+    col witness bits(1) m32;
+    col witness bits(1) div;
 
-    col witness fab;    // fab, to decrease degree of intermediate products a * b
+    col witness bits(64, signed) fab;
                         // fab = 1  if sign of a,b are the same
                         // fab = -1 if sign of a,b are different
-    @witness_bits{ name: "fab", bits: 64, signed: 1 }
 
-    col witness na_fb;
-    @witness_bits{ name: "na_fb", bits: 64, signed: 1 }
-    col witness nb_fa;
-    @witness_bits{ name: "nb_fa", bits: 64, signed: 1 }
+    col witness bits(64, signed) na_fb;
+    col witness bits(64, signed) nb_fa;
 
 /*
-    col witness secondary;       // op_index: 0 => first result, 1 => second result;
-    @witness_bits{ name: "secondary", bits: 1 }
+    col witness bits(1) secondary;
     secondary * (secondary - 1) === 0;
 */
-    col witness main_div;
-    @witness_bits{ name: "main_div", bits: 1 }
-    col witness main_mul;
-    @witness_bits{ name: "main_mul", bits: 1 }
-    col witness signed;
-    @witness_bits{ name: "signed", bits: 1 }
+    col witness bits(1) main_div;
+    col witness bits(1) main_mul;
+    col witness bits(1) signed;
 
-    col witness div_by_zero;
-    @witness_bits{ name: "div_by_zero", bits: 1 }
-    col witness div_overflow;
-    @witness_bits{ name: "div_overflow", bits: 1 }
+    col witness bits(1) div_by_zero;
+    col witness bits(1) div_overflow;
 
     main_div * (main_div - 1) === 0;
     main_mul * (main_mul - 1) === 0;
@@ -104,8 +83,7 @@ airtemplate Arith(int N = 2**18, const int operation_bus_id = OPERATION_BUS_ID, 
     div_overflow * (c[3] - (1 - m32) * 0x8000) === 0;
 
     // b != 0 <==> sum_all_bs != 0
-    col witness inv_sum_all_bs;
-    @witness_bits{ name: "inv_sum_all_bs", bits: 64, signed: 1 }
+    col witness bits(64, signed) inv_sum_all_bs;
 
     // div = 0 => div_by_zero must be 0 => 0 (no need calculate inverse)
     // div = 1 and div_by_zero = 0 => 1 calculate inverse to demostrate b != 0
@@ -238,8 +216,7 @@ airtemplate Arith(int N = 2**18, const int operation_bus_id = OPERATION_BUS_ID, 
     np * (1 - np) === 0;
     sext * (1 - sext) === 0;
 
-    col witness op;
-    @witness_bits{ name: "op", bits: 8 }
+    col witness bits(8) op;
 
     // div m32 sa  sb  primary  secondary  opcodes              na   nb   np   nr   sext(c)
     // -------------------------------------------------------------------------------------
@@ -279,16 +256,14 @@ airtemplate Arith(int N = 2**18, const int operation_bus_id = OPERATION_BUS_ID, 
     const expr bus_res1_64 = (secondary * (d[2] + d[3] * CHUNK_SIZE) +
                               main_mul * (c[2] + c[3] * CHUNK_SIZE) +
                               main_div * (a[2] + a[3] * CHUNK_SIZE));
-    col witness bus_res1;
-    @witness_bits{ name: "bus_res1", bits: 32 }
+    col witness bits(32) bus_res1;
 
     bus_res1 === sext * 0xFFFF_FFFF + (1 - m32) * bus_res1_64;
 
     m32 * bus_a1 === 0;
     m32 * bus_b1 === 0;
 
-    col witness multiplicity;
-    @witness_bits{ name: "multiplicity", bits: 1 }
+    col witness bits(1) multiplicity;
 
     lookup_proves(operation_bus_id, [op,
                                      bus_a0, bus_a1,
@@ -308,10 +283,8 @@ airtemplate Arith(int N = 2**18, const int operation_bus_id = OPERATION_BUS_ID, 
          arith_range_table_assumes(ARITH_RANGE_CARRY, carry[index]);     // TODO: review carry range
     }
 
-    col witness range_ab;
-    @witness_bits{ name: "range_ab", bits: 7 }
-    col witness range_cd;
-    @witness_bits{ name: "range_cd", bits: 7 }
+    col witness bits(7) range_ab;
+    col witness bits(7) range_cd;
 
     arith_table_assumes(op, m32, div, na, nb, np, nr, sext, div_by_zero, div_overflow, main_mul,
                         main_div, signed, range_ab, range_cd);

--- a/state-machines/arith/pil/arith_mul64.pil
+++ b/state-machines/arith/pil/arith_mul64.pil
@@ -12,38 +12,25 @@ airtemplate ArithMul64(int N = 2**18, const int operation_bus_id, const int dual
     const int CHUNKS_INPUT = 4;
     const int CHUNKS_OP = CHUNKS_INPUT * 2;
 
-    col witness carry[CHUNKS_OP - 1];
-    @witness_bits{ name: "carry", bits: 64, signed: 1 }
-    col witness a[CHUNKS_INPUT];
-    @witness_bits{ name: "a", bits: 1 }
-    col witness b[CHUNKS_INPUT];
-    @witness_bits{ name: "b", bits: 16 }
-    col witness c[CHUNKS_INPUT];
-    @witness_bits{ name: "c", bits: 16 }
-    col witness d[CHUNKS_INPUT];
-    @witness_bits{ name: "d", bits: 16 }
+    col witness bits(64, signed) carry[CHUNKS_OP - 1];
+    col witness bits(1) a[CHUNKS_INPUT];
+    col witness bits(16) b[CHUNKS_INPUT];
+    col witness bits(16) c[CHUNKS_INPUT];
+    col witness bits(16) d[CHUNKS_INPUT];
 
-    col witness na;     // a is negative
-    @witness_bits{ name: "na", bits: 1 }
-    col witness nb;     // b is negative
-    @witness_bits{ name: "nb", bits: 1 }
-    col witness np;     // prod is negative
-    @witness_bits{ name: "np", bits: 1 }
+    col witness bits(1) na;
+    col witness bits(1) nb;
+    col witness bits(1) np;
 
-    col witness fab;    // fab, to decrease degree of intermediate products a * b
+    col witness bits(64) fab;
                         // fab = 1  if sign of a,b are the same
                         // fab = -1 if sign of a,b are different
-    @witness_bits{ name: "fab", bits: 64 }
 
-    col witness na_fb;
-    @witness_bits{ name: "na_fb", bits: 64 }
-    col witness nb_fa;
-    @witness_bits{ name: "nb_fa", bits: 64 }
+    col witness bits(64) na_fb;
+    col witness bits(64) nb_fa;
 
-    col witness main_mul;
-    @witness_bits{ name: "main_mul", bits: 1 }
-    col witness signed;
-    @witness_bits{ name: "signed", bits: 1 }
+    col witness bits(1) main_mul;
+    col witness bits(1) signed;
 
     main_mul * (main_mul - 1) === 0;
     main_mul * main_div === 0;
@@ -61,8 +48,7 @@ airtemplate ArithMul64(int N = 2**18, const int operation_bus_id, const int dual
     }
 
     // b != 0 <==> sum_all_bs != 0
-    col witness inv_sum_all_bs;
-    @witness_bits{ name: "inv_sum_all_bs", bits: 1 }
+    col witness bits(1) inv_sum_all_bs;
 
     const expr eq[CHUNKS_OP];
 
@@ -176,8 +162,7 @@ airtemplate ArithMul64(int N = 2**18, const int operation_bus_id, const int dual
     nb * (1 - nb) === 0;
     np * (1 - np) === 0;
 
-    col witness op;
-    @witness_bits{ name: "op", bits: 8 }
+    col witness bits(8) op;
 
     // div m32 sa  sb  primary  secondary  opcodes              na   nb   np   nr   sext(c)
     // -------------------------------------------------------------------------------------
@@ -209,16 +194,14 @@ airtemplate ArithMul64(int N = 2**18, const int operation_bus_id, const int dual
     const expr bus_res1_64 = (secondary * (d[2] + d[3] * CHUNK_SIZE) +
                               main_mul * (c[2] + c[3] * CHUNK_SIZE) +
                               main_div * (a[2] + a[3] * CHUNK_SIZE));
-    col witness bus_res1;
-    @witness_bits{ name: "bus_res1", bits: 32 }
+    col witness bits(32) bus_res1;
 
     bus_res1 === sext * 0xFFFF_FFFF + (1 - m32) * bus_res1_64;
 
     m32 * bus_a1 === 0;
     m32 * bus_b1 === 0;
 
-    col witness multiplicity;
-    @witness_bits{ name: "multiplicity", bits: 1 }
+    col witness bits(1) multiplicity;
 
     // Check that remainder (d) is lower than divisor (b) when division is performed
     // Specifically, we ensure that 0 <= |d| < |b|
@@ -232,10 +215,8 @@ airtemplate ArithMul64(int N = 2**18, const int operation_bus_id, const int dual
          arith_range_table_assumes(ARITH_RANGE_CARRY, carry[index]);     // TODO: review carry range
     }
 
-    col witness range_ab;
-    @witness_bits{ name: "range_ab", bits: 7 }
-    col witness range_cd;
-    @witness_bits{ name: "range_cd", bits: 7 }
+    col witness bits(7) range_ab;
+    col witness bits(7) range_cd;
 
     arith_table_assumes(op, m32, div, na, nb, np, nr, sext, div_by_zero, div_overflow, main_mul,
                         main_div, signed, range_ab, range_cd);

--- a/state-machines/binary/pil/binary.pil
+++ b/state-machines/binary/pil/binary.pil
@@ -60,26 +60,17 @@ airtemplate Binary(const int N = 2**21, const int operation_bus_id = OPERATION_B
     const int input_chunk_bytes = bytes / input_chunks;
 
     // Primary columns
-    col witness m_op;              // micro operation code of the binary table (e.g. add)
-    @witness_bits{ name: "m_op", bits: 5 }
-    col witness mode32;            // 1 if the operation is 32 bits, 0 otherwise
-    @witness_bits{ name: "mode32", bits: 1 }
-    col witness free_in_a[bytes];  // input1
-    @witness_bits{ name: "free_in_a", bits: 8 }
-    col witness free_in_b[bytes];  // input2
-    @witness_bits{ name: "free_in_b", bits: 8 }
-    col witness free_in_c[bytes];  // output
-    @witness_bits{ name: "free_in_c", bits: 8 }
-    col witness carry[bytes];      // bytes chunks carries [0,cout:0],[cin:0,cout:1],...,[cin:bytes-2,cout:bytes-1]
-    @witness_bits{ name: "carry", bits: 1 }
+    col witness bits(5) m_op;
+    col witness bits(1) mode32;
+    col witness bits(8) free_in_a[bytes];
+    col witness bits(8) free_in_b[bytes];
+    col witness bits(8) free_in_c[bytes];
+    col witness bits(1) carry[bytes];
 
     // Secondary columns
-    col witness use_last_carry;    // 1 if the operation uses the last carry as its result
-    @witness_bits{ name: "use_last_carry", bits: 1 }
-    col witness op_is_min_max;     // 1 if the operation is any of the MIN/MAX operations
-    @witness_bits{ name: "op_is_min_max", bits: 1 }
-    col witness has_initial_carry; // 1 if the operation has an initial carry
-    @witness_bits{ name: "has_initial_carry", bits: 1 }
+    col witness bits(1) use_last_carry;
+    col witness bits(1) op_is_min_max;
+    col witness bits(1) has_initial_carry;
 
     const expr mode64 = 1 - mode32;
     const expr cout32 = carry[half_bytes-1];
@@ -90,14 +81,10 @@ airtemplate Binary(const int N = 2**21, const int operation_bus_id = OPERATION_B
     cout64*(1 - cout64) === 0;
 
     // Auxiliary columns (primarily used to optimize lookups, but can be substituted with expressions)
-    col witness cout;
-    @witness_bits{ name: "cout", bits: 1 }
-    col witness result_is_a;
-    @witness_bits{ name: "result_is_a", bits: 1 }
-    col witness use_last_carry_mode32;
-    @witness_bits{ name: "use_last_carry_mode32", bits: 1 }
-    col witness use_last_carry_mode64;
-    @witness_bits{ name: "use_last_carry_mode64", bits: 1 }
+    col witness bits(1) cout;
+    col witness bits(1) result_is_a;
+    col witness bits(1) use_last_carry_mode32;
+    col witness bits(1) use_last_carry_mode64;
     cout === mode64 * (cout64 - cout32) + cout32;
     result_is_a === op_is_min_max * cout;
     use_last_carry_mode32 === mode32 * use_last_carry;
@@ -124,12 +111,9 @@ airtemplate Binary(const int N = 2**21, const int operation_bus_id = OPERATION_B
     lookup_assumes(BINARY_TABLE_ID, [0, m_op, free_in_a[0], free_in_b[0], has_initial_carry*INITIAL_CARRY_LT_ABS, free_in_c[0], carry[0] + 2*op_is_min_max + 4*result_is_a]);
 
     // More auxiliary columns
-    col witness m_op_or_ext;
-    @witness_bits{ name: "m_op_or_ext", bits: 5 }
-    col witness free_in_a_or_c[half_bytes];
-    @witness_bits{ name: "free_in_a_or_c", bits: 8 }
-    col witness free_in_b_or_zero[half_bytes];
-    @witness_bits{ name: "free_in_b_or_zero", bits: 8 }
+    col witness bits(5) m_op_or_ext;
+    col witness bits(8) free_in_a_or_c[half_bytes];
+    col witness bits(8) free_in_b_or_zero[half_bytes];
     m_op_or_ext === mode64 * (m_op - EXT_32_OP) + EXT_32_OP;
     int j = 0;
     for (int i = 1; i < bytes; i++) {
@@ -186,7 +170,6 @@ airtemplate Binary(const int N = 2**21, const int operation_bus_id = OPERATION_B
 
     expr op = m_op + 0x20 * mode32;
 
-    col witness multiplicity;
-    @witness_bits{ name: "multiplicity", bits: 1 }
+    col witness bits(1) multiplicity;
     lookup_proves(OPERATION_BUS_ID, [op, ...a, ...b, ...c, cout - result_is_a], multiplicity);
 }

--- a/state-machines/binary/pil/binary_add.pil
+++ b/state-machines/binary/pil/binary_add.pil
@@ -5,14 +5,10 @@ const int ADD_OP = 0x0C;
 
 airtemplate BinaryAdd(const int N = 2**21, const int operation_bus_id = OPERATION_BUS_ID, const int RC = 2, const int operation_code = ADD_OP) {
 
-    col witness a[RC];
-    @witness_bits{ name: "a", bits: 32 }
-    col witness b[RC];
-    @witness_bits{ name: "b", bits: 32 }
-    col witness c_chunks[RC*2];
-    @witness_bits{ name: "c_chunks", bits: 16 }
-    col witness cout[RC];
-    @witness_bits{ name: "cout", bits: 1 }
+    col witness bits(32) a[RC];
+    col witness bits(32) b[RC];
+    col witness bits(16) c_chunks[RC*2];
+    col witness bits(1) cout[RC];
     const expr c[RC];
 
     for (int i = 0; i < RC; i++) {
@@ -27,7 +23,6 @@ airtemplate BinaryAdd(const int N = 2**21, const int operation_bus_id = OPERATIO
         range_check(expression: c_chunks[i * 2 + 1], min: 0, max: 2**16 - 1);
     }
 
-    col witness multiplicity;
-    @witness_bits{ name: "multiplicity", bits: 1 }
+    col witness bits(1) multiplicity;
     lookup_proves(operation_bus_id, [operation_code, ...a, ...b, ...c, 0], multiplicity);
 }

--- a/state-machines/binary/pil/binary_extension.pil
+++ b/state-machines/binary/pil/binary_extension.pil
@@ -70,16 +70,12 @@ airtemplate BinaryExtension(const int N = 2**18, const int operation_bus_id = OP
     const int bits = 64;
     const int bytes = bits / 8;
 
-    col witness op;
-    @witness_bits{ name: "op", bits: 6 }
-    col witness in1[bytes];
-    @witness_bits{ name: "in1", bits: 8 }
-    col witness in2_low;@witness_bits{ name: "in2_low", bits: 8 }
+    col witness bits(6) op;
+    col witness bits(8) in1[bytes];
+    col witness bits(8) in2_low;
     
-    col witness out[bytes][2];
-    @witness_bits{ name: "out", bits: 32 }
-    col witness op_is_shift;   // 1 if op is shift, 0 otherwise
-    @witness_bits{ name: "op_is_shift", bits: 1 }
+    col witness bits(32) out[bytes][2];
+    col witness bits(1) op_is_shift;
 
     // Constraints to check the correctness of each binary operation
     for (int j = 0; j < bytes; j++) {
@@ -87,14 +83,12 @@ airtemplate BinaryExtension(const int N = 2**18, const int operation_bus_id = OP
     }
 
     // Constraints to make sure that this component is called from the main component
-    col witness in2[2];
-    @witness_bits{ name: "in2", bits: 32 } // in2[0] only requires 24 bits
+    col witness bits(32) in2[2]; // in2[0] only requires 24 bits
 
     expr in1_low = in1[0] + in1[1]*2**8 + in1[2]*2**16 + in1[3]*2**24;
     expr in1_high = in1[4] + in1[5]*2**8 + in1[6]*2**16 + in1[7]*2**24;
 
-    col witness multiplicity;
-    @witness_bits{ name: "multiplicity", bits: 1 }
+    col witness bits(1) multiplicity;
     lookup_proves(
         operation_bus_id,
         [

--- a/state-machines/main/pil/main.pil
+++ b/state-machines/main/pil/main.pil
@@ -91,115 +91,78 @@ airtemplate Main(int N = 2**21, int RC = 2, int stack_enabled = 0,
 
     // Registers
 
-    col witness a[RC];
-    @witness_bits{ name: "a", bits: 32 }
-
-    col witness b[RC];
-    @witness_bits{ name: "b", bits: 32 }
-
-    col witness c[RC];
-    @witness_bits{ name: "c", bits: 32 }
-
-    col witness flag;                  // Conditional flag modified by operations
-    @witness_bits{ name: "flag", bits: 1 }
-
-    col witness pc;                    // Program counter
-    @witness_bits{ name: "pc", bits: 32 }
+    col witness bits(32) a[RC];
+    col witness bits(32) b[RC];
+    col witness bits(32) c[RC];
+    col witness bits(1) flag;
+    col witness bits(32) pc;
 
     // Source A
 
-    col witness a_src_imm;             // Selector indicating that 'a' uses an immediate value.
-    @witness_bits{ name: "a_src_imm", bits: 1 }
-    col witness a_src_mem;             // Selector indicating that 'a' is read from memory.
-    @witness_bits{ name: "a_src_mem", bits: 1 }
-    col witness a_offset_imm0;         // Depending on the flag values, this witness contains either
+    col witness bits(1) a_src_imm;
+    col witness bits(1) a_src_mem;
+    col witness bits(64, signed) a_offset_imm0;
                                        // the lower 32-bit part of an immediate value or the memory
                                        // address offset.
-    @witness_bits{ name: "a_offset_imm0", bits: 64, signed: 1 }
     if (stack_enabled == 1) {
-        col witness air.sp;
-        @witness_bits{ name: "sp", bits: 32 }
-        col witness air.a_src_sp;
-        @witness_bits{ name: "a_src_sp", bits: 1 }
-        col witness air.a_use_sp_imm1;
-        @witness_bits{ name: "a_use_sp_imm1", bits: 32 }
+        col witness bits(32) air.sp;
+        col witness bits(1) air.a_src_sp;
+        col witness bits(32) air.a_use_sp_imm1;
     } else {
-        col witness air.a_imm1;        // The higher 32-bit part of a immediate value
-        @witness_bits{ name: "a_imm1", bits: 32 }
+        col witness bits(32) air.a_imm1;
     }
-    col witness a_src_step;            // Selector to load the `step` in register `a`
-    @witness_bits{ name: "a_src_step", bits: 1 }
+    col witness bits(1) a_src_step;
 
     // Source B
 
-    col witness b_src_imm;             // Selector indicating that 'b' uses an immediate value.
-    @witness_bits{ name: "b_src_imm", bits: 1 }
-    col witness b_src_mem;             // Selector indicating that 'b' is read from memory.
-    @witness_bits{ name: "b_src_mem", bits: 1 }
-    col witness b_offset_imm0;         // Depending on the flag values, this witness contains either
+    col witness bits(1) b_src_imm;
+    col witness bits(1) b_src_mem;
+    col witness bits(64, signed) b_offset_imm0;
                                        // the lower 32-bit part of an immediate value or the memory
                                        // address offset.
-    @witness_bits{ name: "b_offset_imm0", bits: 64, signed: 1 }
 
     if (stack_enabled) {
-        col witness air.b_use_sp_imm1;
-        @witness_bits{ name: "b_use_sp_imm1", bits: 32 }
+        col witness bits(32) air.b_use_sp_imm1;
     } else {
-        col witness air.b_imm1;        // The higher 32-bit part of a immediate value
-        @witness_bits{ name: "b_imm1", bits: 32 }
+        col witness bits(32) air.b_imm1;
     }
-    col witness b_src_ind;             // Selector to indicate take value in a as address to
+    col witness bits(1) b_src_ind;
                                        // read b form memory (b = mem[a])
-    @witness_bits{ name: "b_src_ind", bits: 1 }
-    col witness ind_width;             // bytes: 8, 4, 2, 1
-    @witness_bits{ name: "ind_width", bits: 4 }
+    col witness bits(4) ind_width;
 
     // Operations related
 
-    col witness is_external_op;        // [is_external_op == 1] => operation op sent to bus
-    @witness_bits{ name: "is_external_op", bits: 1 }
-    col witness op;                    // [is_external_op == 0 && op=0] ==>  c=0, flag=1 (flag)
+    col witness bits(1) is_external_op;
+    col witness bits(8) op;
                                        // [is_external_op == 0 && op=1] ==>  c=b, flag=0 (copy_b)
                                        // else then this op is sent to the bus.
-    @witness_bits{ name: "op", bits: 8 }
 
     // Destination C
 
-    col witness store_ra;              // Store the return address instead of the C register.
-    @witness_bits{ name: "store_ra", bits: 1 }
+    col witness bits(1) store_ra;
 
-    col witness store_mem;             // Selector for store c to memory
-    @witness_bits{ name: "store_mem", bits: 1 }
+    col witness bits(1) store_mem;
     
-    col witness store_ind;             // Selector for store c to memory address in a
-    @witness_bits{ name: "store_ind", bits: 1 }
+    col witness bits(1) store_ind;
 
-    col witness store_offset;          // Memory address offset used on c
-    @witness_bits{ name: "store_offset", bits: 64, signed: 1 }
+    col witness bits(64, signed) store_offset;
 
-    col witness set_pc;                // Selector to set to pc the value in c
-    @witness_bits{ name: "set_pc", bits: 1 }
+    col witness bits(1) set_pc;
 
     if (stack_enabled) {
-        col witness air.store_use_sp;  // Selector to calculate store address use sp
-        @witness_bits{ name: "store_use_sp", bits: 1 }
-        col witness air.set_sp;        // Selector to set result as new value of sp
-        @witness_bits{ name: "set_sp", bits: 1 }
-        col witness air.inc_sp;        // Increment of sp (negative or positive)
-        @witness_bits{ name: "inc_sp", bits: 64, signed: 1 }
+        col witness bits(1) air.store_use_sp;
+        col witness bits(1) air.set_sp;
+        col witness bits(64, signed) air.inc_sp;
     }
 
 
-    col witness jmp_offset1;           // Next default pc if flag = 0
-    @witness_bits{ name: "jmp_offset1", bits: 64, signed: 1 }
+    col witness bits(64, signed) jmp_offset1;
 
-    col witness jmp_offset2;           // Next default pc if flag = 1
-    @witness_bits{ name: "jmp_offset2", bits: 64, signed: 1 }
+    col witness bits(64, signed) jmp_offset2;
 
-    col witness m32;                   // Selector to indicate the high part of operands (a,b) send
+    col witness bits(1) m32;
                                        // to bus must be 0, because it's a 32 bits operation. Used
                                        // to avoid sent to bus dirty values.
-    @witness_bits{ name: "m32", bits: 1 }
 
     const expr sel_mem_b;
     sel_mem_b = b_src_mem + b_src_ind;
@@ -208,20 +171,16 @@ airtemplate Main(int N = 2**21, int RC = 2, int stack_enabled = 0,
     // are "converted" to witness to avoid increase the degree on stage 2 with extension.
 
     if (stack_enabled) {
-        col witness air.addr0;
-        @witness_bits{ name: "addr0", bits: 32 }
-        col witness air.addr1;
-        @witness_bits{ name: "addr1", bits: 32 }
-        col witness air.addr2;
-        @witness_bits{ name: "addr2", bits: 32 }
+        col witness bits(32) air.addr0;
+        col witness bits(32) air.addr1;
+        col witness bits(32) air.addr2;
 
         addr0 === a_offset_imm0 + a_use_sp_imm1 * sp;
         addr1 === b_offset_imm0 + b_src_ind * (a[0] + 2**32 * a[1]) +  b_use_sp_imm1 * sp;
         addr2 === store_offset + store_ind * a[0] + store_use_sp * sp;
     } else {
         const expr air.addr0;
-        col witness air.addr1;
-        @witness_bits{ name: "addr1", bits: 32 }
+        col witness bits(32) air.addr1;
         const expr air.addr2;
         addr0 = a_offset_imm0;
         addr1 === b_offset_imm0 + b_src_ind * (a[0] + 2**32 * a[1]);
@@ -289,20 +248,13 @@ airtemplate Main(int N = 2**21, int RC = 2, int stack_enabled = 0,
     //   region. As a result, no memory state machine can validate memory access in this area;
     //   only the main state machine can 'prove' such memory access.
 
-    col witness a_reg_prev_mem_step;      // Previous mem_step where register a_offset_imm0 is used
-    @witness_bits{ name: "a_reg_prev_mem_step", bits: 40 }
-    col witness b_reg_prev_mem_step;      // Previous mem_step where register b_offset_imm0 is used
-    @witness_bits{ name: "b_reg_prev_mem_step", bits: 40 }
-    col witness store_reg_prev_mem_step;  // Previous mem_step where register store_offset is used
-    @witness_bits{ name: "store_reg_prev_mem_step", bits: 40 }
-    col witness store_reg_prev_value[RC]; // Previous value of register store_offset is used
-    @witness_bits{ name: "store_reg_prev_value", bits: 32 }
-    col witness a_src_reg;                // Selector indicating that 'a' is read from register
-    @witness_bits{ name: "a_src_reg", bits: 1 }
-    col witness b_src_reg;                // Selector indicating that 'b' is read from register
-    @witness_bits{ name: "b_src_reg", bits: 1 }
-    col witness store_reg;                // Selector to store result to register
-    @witness_bits{ name: "store_reg", bits: 1 }
+    col witness bits(40) a_reg_prev_mem_step;
+    col witness bits(40) b_reg_prev_mem_step;
+    col witness bits(40) store_reg_prev_mem_step;
+    col witness bits(32) store_reg_prev_value[RC];
+    col witness bits(1) a_src_reg;
+    col witness bits(1) b_src_reg;
+    col witness bits(1) store_reg;
 
     // Calculate the memory step from the main step
 

--- a/state-machines/mem/pil/mem.pil
+++ b/state-machines/mem/pil/mem.pil
@@ -108,14 +108,10 @@ airtemplate Mem(const int N = 2**21, const int id = MEMORY_ID, const int RC = 2,
     // If is_first_segment means that segment must be 0
     is_first_segment * segment_id === 0;
 
-    col witness addr;        // n-byte address, real address = addr * bytes
-    @witness_bits{ name: "addr", bits: 29 }
-    col witness step;
-    @witness_bits{ name: "step", bits: 40 }
-    col witness sel;
-    @witness_bits{ name: "sel", bits: 1 }
-    col witness addr_changes;
-    @witness_bits{ name: "addr_changes", bits: 1 }
+    col witness bits(29) addr;
+    col witness bits(40) step;
+    col witness bits(1) sel;
+    col witness bits(1) addr_changes;
 
     if (dual_mem) {
         // Dual mem feature not supported for free input memory
@@ -125,10 +121,8 @@ airtemplate Mem(const int N = 2**21, const int id = MEMORY_ID, const int RC = 2,
 
         // Two columns, one for step (timestap) of second operation, and other
         // to enable dual operation in the row.
-        col witness air.step_dual;
-        @witness_bits{ name: "step_dual", bits: 40 }
-        col witness air.sel_dual;
-        @witness_bits{ name: "sel_dual", bits: 1 }
+        col witness bits(40) air.step_dual;
+        col witness bits(1) air.sel_dual;
 
         sel_dual * (1 - sel_dual) === 0;
         (1 - sel) * sel_dual === 0;
@@ -143,16 +137,14 @@ airtemplate Mem(const int N = 2**21, const int id = MEMORY_ID, const int RC = 2,
 
     if (free_input_mem) {
         immutable = 1;
-        col witness air.value_word[RC*2];
-        @witness_bits{ name: "value_word", bits: 16 }
+        col witness bits(16) air.value_word[RC*2];
 
         // free read for free input, means an specific address (offset = 0) that could be read
         // many times with different well formed 64-bit values. Used for fcalls and other free-inputs
 
-        col witness air.is_free_read;
-        @witness_bits{ name: "is_free_read", bits: 1 }
-        air.is_free_read * (1 - air.is_free_read) === 0;
-        air.is_free_read * (internal_base_address - addr) === 0;
+        col witness bits(1) air.is_free_read;
+        is_free_read * (1 - is_free_read) === 0;
+        is_free_read * (internal_base_address - addr) === 0;
 
         const expr air.value[RC];
         for (int index = 0; index < RC; ++index) {
@@ -163,8 +155,7 @@ airtemplate Mem(const int N = 2**21, const int id = MEMORY_ID, const int RC = 2,
             range_check(value_word[index*2+1], 0, MAX_RANGE_CHECK_CHUNK - 1, predefined: use_predefined_ranges);
         }
     } else {
-        col witness air.value[RC];
-        @witness_bits{ name: "value", bits: 32 }
+        col witness bits(32) air.value[RC];
     }
 
     if (free_input_mem) {
@@ -179,8 +170,7 @@ airtemplate Mem(const int N = 2**21, const int id = MEMORY_ID, const int RC = 2,
             addr_changes * (1 - sel) * value[i] === 0;
         }
     } else {
-        col witness air.wr;
-        @witness_bits{ name: "wr", bits: 1 }
+        col witness bits(1) air.wr;
         const expr air.rd = 1 - wr;
 
         // boolean constraint over wr;
@@ -373,8 +363,7 @@ airtemplate Mem(const int N = 2**21, const int id = MEMORY_ID, const int RC = 2,
             // - If the previous row was in dual mode, it must match the previous `step_dual`.
             // - Otherwise, it must match the previous `step`.
 
-            col witness air.previous_step;
-            @witness_bits{ name: "previous_step", bits: 40 }
+            col witness bits(40) air.previous_step;
             const expr previous_row_step = 'sel_dual * ('step_dual - 'step) + 'step;
             previous_step === SEGMENT_L1 * (previous_segment_step - previous_row_step) + previous_row_step;
         } else {
@@ -382,8 +371,7 @@ airtemplate Mem(const int N = 2**21, const int id = MEMORY_ID, const int RC = 2,
         }
         const expr delta_step = step - previous_step + (1 - wr);
 
-        col witness increment[2];
-        @witness_bits{ name: "increment", bits: 18 }
+        col witness bits(18) air.increment[2];
         increment[0] + 2**18 * increment[1] + 1 === addr_changes * (delta_addr - delta_step) + delta_step;
 
         is_first_segment * SEGMENT_L1 * (1 - addr_changes) === 0;
@@ -396,8 +384,7 @@ airtemplate Mem(const int N = 2**21, const int id = MEMORY_ID, const int RC = 2,
         range_check(expression: increment[1], min: 0, max: 2**18 - 1);
 
         // to avoid intermediate column
-        col witness air.read_same_addr;
-        @witness_bits{ name: "read_same_addr", bits: 1 }
+        col witness bits(1) air.read_same_addr;
 
         read_same_addr === (1 - addr_changes) * (1 - wr);
 

--- a/state-machines/mem/pil/mem_align.pil
+++ b/state-machines/mem/pil/mem_align.pil
@@ -90,28 +90,17 @@ require "std_range_check.pil"
 airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM = 8, const int CHUNK_BITS = 8, const int use_predefined_ranges = 0) {
     const int CHUNKS_BY_RC = CHUNK_NUM / RC;
 
-    col witness addr;           // CHUNK_NUM-byte address, real address = addr * CHUNK_NUM
-    @witness_bits{ name: "addr", bits: 29 }
-    col witness offset;         // 0..7, position at which the operation starts
-    @witness_bits{ name: "offset", bits: 3 }
-    col witness width;          // 1,2,4,8, width of the operation
-    @witness_bits{ name: "width", bits: 4 }
-    col witness wr;             // 1 if the operation is a write, 0 otherwise
-    @witness_bits{ name: "wr", bits: 1 }
-    col witness pc;             // line of the program to execute
-    @witness_bits{ name: "pc", bits: 8 }
-    col witness reset;          // 1 at the beginning of the operation (indicating an address reset), 0 otherwise
-    @witness_bits{ name: "reset", bits: 1 }
-    col witness sel_up_to_down; // 1 if the next value is the current value (e.g. R -> W)
-    @witness_bits{ name: "sel_up_to_down", bits: 1 }
-    col witness sel_down_to_up; // 1 if the next value is the previous value (e.g. W -> R)
-    @witness_bits{ name: "sel_down_to_up", bits: 1 }
-    col witness reg[CHUNK_NUM]; // Register values, 1 byte each
-    @witness_bits{ name: "reg", bits: 8 }
-    col witness sel[CHUNK_NUM]; // Selectors, 1 if the value is used, 0 otherwise
-    @witness_bits{ name: "sel", bits: 1 }
-    col witness step;           // Memory step
-    @witness_bits{ name: "step", bits: 40 }
+    col witness bits(29) addr;
+    col witness bits(3) offset;
+    col witness bits(4) width;
+    col witness bits(1) wr;
+    col witness bits(8) pc;
+    col witness bits(1) reset;
+    col witness bits(1) sel_up_to_down;
+    col witness bits(1) sel_down_to_up;
+    col witness bits(8) reg[CHUNK_NUM];
+    col witness bits(1) sel[CHUNK_NUM];
+    col witness bits(40) step;
 
     // 1] Ensure the MemAlign follows the program
 
@@ -146,8 +135,7 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
 
     // Perform the lookup against the program
     expr delta_pc;
-    col witness delta_addr; // Auxiliary column
-    @witness_bits{ name: "delta_addr", bits: 64, signed: 1 }
+    col witness bits(64, signed) delta_addr;
     delta_pc = pc' - pc;
     delta_addr === (addr - 'addr) * (1 - reset);
     lookup_assumes(MEM_ALIGN_ROM_ID, [pc, delta_pc, delta_addr, offset, width, flags]);
@@ -170,8 +158,7 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     }
 
     // 3] Prove unaligned memory accesses against the Main component
-    col witness sel_prove;
-    @witness_bits{ name: "sel_prove", bits: 1 }
+    col witness bits(1) sel_prove;
 
     sel_prove * sel_assume === 0; // Disjoint selectors
 
@@ -193,8 +180,7 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     }
 
     // We prove and assume with the same permutation check but with disjoint and different sign selectors
-    col witness value[RC];  // Auxiliary columns
-    @witness_bits{ name: "value", bits: 32 }
+    col witness bits(32) value[RC];
     for (int i = 0; i < RC; i++) {
         value[i] === sel_prove * prove_val[i] + sel_assume * assume_val[i];
     } 

--- a/state-machines/mem/pil/mem_align_byte.pil
+++ b/state-machines/mem/pil/mem_align_byte.pil
@@ -11,38 +11,26 @@ airtemplate MemAlignByte(const int N = 2**10, const int read = 1, const int writ
     const int p2_8 = 2**8;
     const int p2_24 = 2**24;
 
-    col witness sel_high_4b; // offsets: 7,6,5,4
-    @witness_bits{ name: "sel_high_4b", bits: 1 }
-    col witness sel_high_2b; // offsets: 7,6 3,2
-    @witness_bits{ name: "sel_high_2b", bits: 1 }
-    col witness sel_high_b;  // offsets: 7 5 3 1
-    @witness_bits{ name: "sel_high_b", bits: 1 }
+    col witness bits(1) sel_high_4b;
+    col witness bits(1) sel_high_2b;
+    col witness bits(1) sel_high_b;
 
-    col witness direct_value; // no range check, match exactly with value send in bus
-    @witness_bits{ name: "direct_value", bits: 32 }
-    col witness composed_value;
-    @witness_bits{ name: "composed_value", bits: 32 }
+    col witness bits(32) direct_value;
+    col witness bits(32) composed_value;
 
     if (write == 1) {
-        col witness air.written_composed_value;
-        @witness_bits{ name: "written_composed_value", bits: 32 }
-        col witness air.written_byte_value;
-        @witness_bits{ name: "written_byte_value", bits: 8 }
+        col witness bits(32) air.written_composed_value;
+        col witness bits(8) air.written_byte_value;
 
         range_check(min: 0, max: 0xFF, expression: air.written_byte_value);
     }
 
-    col witness value_16b;   // range check 16 bits
-    @witness_bits{ name: "value_16b", bits: 16 }
-    col witness value_8b;    // range check 8 bits
-    @witness_bits{ name: "value_8b", bits: 8 }
-    col witness byte_value;  // range check 8 bits
-    @witness_bits{ name: "byte_value", bits: 8 }
+    col witness bits(16) value_16b;
+    col witness bits(8) value_8b;
+    col witness bits(8) byte_value;
 
-    col witness addr_w;
-    @witness_bits{ name: "addr_w", bits: 29 }
-    col witness step;
-    @witness_bits{ name: "step", bits: 40 }
+    col witness bits(29) addr_w;
+    col witness bits(40) step;
 
     sel_high_4b * (1 - sel_high_4b) === 0;
     sel_high_2b * (1 - sel_high_2b) === 0;
@@ -79,8 +67,7 @@ airtemplate MemAlignByte(const int N = 2**10, const int read = 1, const int writ
 
 
     if (read == 1 && write == 1) {
-        col witness air.is_write;
-        @witness_bits{ name: "is_write", bits: 1 }
+        col witness bits(1) air.is_write;
         is_write * (1 - is_write) === 0;
     } else if (read == 1) {
         const int air.is_write = 0;
@@ -95,8 +82,7 @@ airtemplate MemAlignByte(const int N = 2**10, const int read = 1, const int writ
                        value_8b * value_8b_factor + 
                        value_16b * value_16b_factor;
 
-        col witness mem_write_values[2];
-        @witness_bits{ name: "mem_write_values", bits: 32 }
+        col witness bits(32) air.mem_write_values[2];
 
         mem_write_values[0] === sel_high_4b * (direct_value - written_composed_value) + written_composed_value;
         mem_write_values[1] === sel_high_4b * (written_composed_value - direct_value) + direct_value;  
@@ -105,8 +91,7 @@ airtemplate MemAlignByte(const int N = 2**10, const int read = 1, const int writ
     }
 
     if (read == 1 && write == 1) {
-        col witness air.bus_byte;
-        @witness_bits{ name: "bus_byte", bits: 8 }
+        col witness bits(8) air.bus_byte;
         bus_byte === is_write * (written_byte_value - byte_value) + byte_value;
         permutation_proves(MEMORY_ID, [mem_op, main_addr, step, 1, bus_byte, 0]);
     } else if (read == 1) {

--- a/state-machines/mem/pil/rom_data.pil
+++ b/state-machines/mem/pil/rom_data.pil
@@ -7,14 +7,10 @@ airtemplate RomData(const int N = 2**21, const int id = MEMORY_ID, const int rom
                     const int RC = 2, const int bytes = 8, const int reads_by_row = 1) {
 
 
-    col witness addr; // n-byte address, real address = addr * bytes
-    @witness_bits{ name: "addr", bits: 29 }
-    col witness step[reads_by_row];
-    @witness_bits{ name: "step", bits: 40 }
-    col witness sel[reads_by_row]; // one-hot encoding of the read in the row
-    @witness_bits{ name: "sel", bits: 1 }
-    col witness value[RC];
-    @witness_bits{ name: "value", bits: 32 }
+    col witness bits(29) addr;
+    col witness bits(40) step[reads_by_row];
+    col witness bits(1) sel[reads_by_row];
+    col witness bits(32) value[RC];
 
     for (int i = 0; i < reads_by_row; i++) {
         sel[i] * (1 - sel[i]) === 0;


### PR DESCRIPTION
Update pils to remove manual hint witness_bits, now with new version of pil2-compiler (v0.8.0) this hint is auto generated when use bits column feature.