### PR TITLE
extend timeout

### DIFF
--- a/cli/src/toolchain/install_toolchain.rs
+++ b/cli/src/toolchain/install_toolchain.rs
@@ -26,7 +26,7 @@ impl InstallToolchainCmd {
         // Setup client.
         let client = Client::builder()
             .user_agent("Mozilla/5.0")
-            .timeout(std::time::Duration::from_secs(60))
+            .timeout(std::time::Duration::from_secs(1800))
             .build()?;
 
         // Setup variables.


### PR DESCRIPTION
The installer often crashes when downloading the Rust toolchain (~257 MB). [File Link](https://github.com/0xPolygonHermez/rust/releases/latest/download/rust-toolchain-aarch64-apple-darwin.tar.gz)
It fails after about 60 seconds with:

```
thread 'main' panicked at cli/src/toolchain/install_toolchain.rs:97:22:
called `Result::unwrap()` on an `Err` value: "Error while downloading file"
```

Turns out the HTTP client had a **hardcoded 60 s total timeout**, so any slower network or large file download just times out and panics.
