### PR TITLE
Server panics if running with single process

### DIFF
--- a/server/src/handler_prove.rs
+++ b/server/src/handler_prove.rs
@@ -85,7 +85,7 @@ impl ZiskServiceProveHandler {
 
                 let elapsed = start.elapsed();
 
-                if proofman.rank().unwrap() == 0 {
+                if proofman.get_world_rank() == 0 {
                     #[allow(clippy::type_complexity)]
                     let (result, mut _stats): (
                         ZiskExecutionResult,


### PR DESCRIPTION
With `v0.13.0`, when running `cargo-zisk server` without multi-process `mpi`, the prove handler panics because the `rank` is `None`.