### PR TITLE
chore(no_std): make `sys_rand` related code `no_std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6198,6 +6207,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2",
+ "spin",
  "tiny-keccak",
  "tokio",
  "zisk-common",

--- a/ziskos/entrypoint/Cargo.toml
+++ b/ziskos/entrypoint/Cargo.toml
@@ -17,7 +17,8 @@ num-traits = { workspace = true }
 precompiles-helpers = { workspace = true }
 
 lazy_static = "1.5.0"
-rand = "0.8.5"
+spin = "0.9"
+rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 getrandom = { version = "0.2", features = ["custom"] }
 cfg-if = "1.0"
 tiny-keccak = { version = "2.0.0", features = ["keccak"] }


### PR DESCRIPTION
Related to https://github.com/0xPolygonHermez/zisk/issues/793

In order to support rv64imac-unknown-none-elf or rv64im-unknown-none-elf in the future, ZiskOS would need to be no_std compatible. The sys_rand related code was using StdRng and the Mutex from the standard lib.