### PR TITLE
chore(no_std): Replace `cfg.target` with `target.zisk_guest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ mem-planner-cpp = { path = "state-machines/mem-cpp" }
 sm-rom = { path = "state-machines/rom" }
 zisk-witness = { path = "witness-computation" }
 ziskclib = { path = "ziskclib" }
-ziskos = { path = "ziskos/entrypoint" }
+ziskos = { path = "ziskos/entrypoint", features = ["zisk_host"] }
 ziskos-hints = { path = "ziskos-hints" }
 circuit = { path = "tools/circuit" }
 zisk-sdk = { path = "sdk" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -801,16 +801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
-dependencies = [
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
 name = "curves"
 version = "0.16.0"
 source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-0.16.0#28ec794c611b5c53c7096c565da80bd0639f2fe9"
@@ -4732,11 +4722,8 @@ dependencies = [
 name = "ziskos"
 version = "0.16.0"
 dependencies = [
- "anyhow",
  "bincode",
- "bytes",
  "cfg-if",
- "ctor",
  "fields",
  "getrandom 0.2.17",
  "lazy_static",
@@ -4744,15 +4731,11 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "once_cell",
- "paste",
  "precompiles-helpers",
  "rand 0.8.5",
  "serde",
  "sha2",
  "tiny-keccak",
- "tokio",
- "zisk-common",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,7 +11,7 @@ opt-level = 0
 
 [workspace.dependencies]
 # Guest dependencies
-ziskos = { path = "../ziskos/entrypoint" }
+ziskos = { path = "../ziskos/entrypoint", default-features = false, features = ["zisk_guest"] }
 
 # Host dependencies
 zisk-sdk = { path = "../sdk" }

--- a/examples/sha-hasher/guest/Cargo.toml
+++ b/examples/sha-hasher/guest/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 byteorder = "1.5.0"
 sha2 = "0.10.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-ziskos = { path = "../../../ziskos/entrypoint" }
+ziskos = { path = "../../../ziskos/entrypoint", default-features = false, features = ["zisk_guest"] }

--- a/ziskos/entrypoint/Cargo.toml
+++ b/ziskos/entrypoint/Cargo.toml
@@ -29,20 +29,19 @@ fields = { git = "https://github.com/0xPolygonHermez/pil2-proofman.git", branch 
     "verify",
 ] }
 
-[target.'cfg(all(not(all(target_os = "zkvm", target_vendor = "zisk")), any(zisk_hints, zisk_hints_debug)))'.dependencies]
+# Host-only dependencies (activated by zisk_host feature)
 bytes = { version = "1.11.0", optional = true }
 once_cell = { version = "1.21.3", optional = true }
 paste = { version = "1.0", optional = true }
 zisk-common = { path = "../../common", optional = true }
 anyhow = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true}
-
-[target.'cfg(all(not(all(target_os = "zkvm", target_vendor = "zisk")), zisk_hints_metrics))'.dependencies]
+tokio = { workspace = true, optional = true }
 ctor = { version = "0.2", optional = true }
 
 [features]
-default = ["user-hints"]
-user-hints = ["dep:zisk-common", "dep:bytes", "dep:paste", "dep:once_cell", "dep:ctor", "dep:anyhow", "dep:tokio"]
+default = []
+zisk_guest = []
+zisk_host = ["dep:zisk-common", "dep:bytes", "dep:paste", "dep:once_cell", "dep:ctor", "dep:anyhow", "dep:tokio"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/ziskos/entrypoint/src/fcall.rs
+++ b/ziskos/entrypoint/src/fcall.rs
@@ -1,9 +1,9 @@
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 // fcall_get 0xFFE
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 pub fn ziskos_fcall_get() -> u64 {
     let value: u64;
     unsafe {

--- a/ziskos/entrypoint/src/hints/mod.rs
+++ b/ziskos/entrypoint/src/hints/mod.rs
@@ -291,7 +291,7 @@ pub(crate) fn check_main_thread() -> bool {
 #[inline(always)]
 pub fn hint_log<S: AsRef<str>>(msg: S) {
     // We check if hints are enable only for non-zisk targets, since in zisk targets hints are not used
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     if !HINT_BUFFER.is_enabled() {
         return;
     }

--- a/ziskos/entrypoint/src/memcpy_test.rs
+++ b/ziskos/entrypoint/src/memcpy_test.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod memcpy_tests {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     use super::ziskos::memcpy;
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     fn memcpy(dst: *mut u8, src: *const u8, len: usize) -> *mut u8 {
         unsafe {
             std::ptr::copy(src, dst, len);

--- a/ziskos/entrypoint/src/profile.rs
+++ b/ziskos/entrypoint/src/profile.rs
@@ -137,7 +137,7 @@ macro_rules! ziskos_profile_arguments {
     };
 }
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 const MAX_TAG_ID: u16 = 256;
@@ -150,7 +150,7 @@ fn check_tag_id<const TAG_ID: u16>() {
 ///
 /// # Arguments
 /// * `TAG_ID` - Unique identifier for the cost region (must fit in 12-bit immediate)
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_start<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
@@ -159,7 +159,7 @@ pub fn ziskos_profile_start<const TAG_ID: u16>() {
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_start<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
@@ -169,7 +169,7 @@ pub fn ziskos_profile_start<const TAG_ID: u16>() {
 ///
 /// # Arguments
 /// * `TAG_ID` - Unique identifier for the cost region (must match the start tag)
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_end<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
@@ -178,14 +178,14 @@ pub fn ziskos_profile_end<const TAG_ID: u16>() {
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_end<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
 }
 
 /// Records an absolute cost measurement
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_absolute<const TAG_ID: u16>() {
     unsafe {
@@ -193,14 +193,14 @@ pub fn ziskos_profile_absolute<const TAG_ID: u16>() {
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_absolute<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
 }
 
 /// Records a relative cost measurement
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_relative<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
@@ -209,14 +209,14 @@ pub fn ziskos_profile_relative<const TAG_ID: u16>() {
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_relative<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
 }
 
 /// Reset relative cost measurement
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_reset_relative<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
@@ -225,14 +225,14 @@ pub fn ziskos_profile_reset_relative<const TAG_ID: u16>() {
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_reset_relative<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
 }
 
 /// Counter of executions
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_counter<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
@@ -242,14 +242,14 @@ pub fn ziskos_profile_counter<const TAG_ID: u16>() {
 }
 
 /// Counter of executions
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_counter<const TAG_ID: u16>() {
     check_tag_id::<TAG_ID>();
 }
 
 /// Cost arguments
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_value<const TAG_ID: u16>(a: u64) {
     check_tag_id::<TAG_ID>();
@@ -258,14 +258,14 @@ pub fn ziskos_profile_value<const TAG_ID: u16>(a: u64) {
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_value<const TAG_ID: u16>(_a: u64) {
     check_tag_id::<TAG_ID>();
 }
 
 /// Cost arguments
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_argument<const TAG_ID: u16>(a: u64) {
     check_tag_id::<TAG_ID>();
@@ -274,14 +274,14 @@ pub fn ziskos_profile_argument<const TAG_ID: u16>(a: u64) {
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_argument<const TAG_ID: u16>(_a: u64) {
     check_tag_id::<TAG_ID>();
 }
 
 /// Cost arguments
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_2_arguments<const TAG_ID: u16>(a: u64, b: u64) {
     check_tag_id::<TAG_ID>();
@@ -298,14 +298,14 @@ pub fn ziskos_profile_2_arguments<const TAG_ID: u16>(a: u64, b: u64) {
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_2_arguments<const TAG_ID: u16>(_a: u64, _b: u64) {
     check_tag_id::<TAG_ID>();
 }
 
 /// Cost arguments
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 #[inline(always)]
 pub fn ziskos_profile_3_arguments<const TAG_ID: u16>(a: u64, b: u64, c: u64) {
     check_tag_id::<TAG_ID>();
@@ -325,7 +325,7 @@ pub fn ziskos_profile_3_arguments<const TAG_ID: u16>(a: u64, b: u64, c: u64) {
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[inline(always)]
 pub fn ziskos_profile_3_arguments<const TAG_ID: u16>(_a: u64, _b: u64, _c: u64) {
     check_tag_id::<TAG_ID>();

--- a/ziskos/entrypoint/src/syscalls/add256.rs
+++ b/ziskos/entrypoint/src/syscalls/add256.rs
@@ -1,9 +1,9 @@
 //! Add256 system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall_ret_u64;
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ pub extern "C" fn syscall_add256(
     params: &mut SyscallAdd256Params,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> u64 {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let cout = precompiles_helpers::add256(params.a, params.b, params.cin, params.c);
         #[cfg(feature = "hints")]
@@ -44,6 +44,6 @@ pub extern "C" fn syscall_add256(
         }
         cout
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall_ret_u64!(0x811, params)
 }

--- a/ziskos/entrypoint/src/syscalls/arith256.rs
+++ b/ziskos/entrypoint/src/syscalls/arith256.rs
@@ -1,9 +1,9 @@
 //! Arith256 system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
 #[derive(Debug)]
@@ -37,9 +37,9 @@ pub extern "C" fn syscall_arith256(
     params: &mut SyscallArith256Params,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x801, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         precompiles_helpers::arith256(params.a, params.b, params.c, params.dl, params.dh);
         #[cfg(feature = "hints")]

--- a/ziskos/entrypoint/src/syscalls/arith256_mod.rs
+++ b/ziskos/entrypoint/src/syscalls/arith256_mod.rs
@@ -1,9 +1,9 @@
 //! Arith256Mod system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
 #[derive(Debug)]
@@ -40,9 +40,9 @@ pub extern "C" fn syscall_arith256_mod(
     params: &mut SyscallArith256ModParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x802, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         precompiles_helpers::arith256_mod(params.a, params.b, params.c, params.module, params.d);
         #[cfg(feature = "hints")]

--- a/ziskos/entrypoint/src/syscalls/arith384_mod.rs
+++ b/ziskos/entrypoint/src/syscalls/arith384_mod.rs
@@ -1,9 +1,9 @@
 //! Arith384Mod system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
 #[derive(Debug)]
@@ -40,9 +40,9 @@ pub extern "C" fn syscall_arith384_mod(
     params: &mut SyscallArith384ModParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x80B, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         precompiles_helpers::arith384_mod(params.a, params.b, params.c, params.module, params.d);
         #[cfg(feature = "hints")]

--- a/ziskos/entrypoint/src/syscalls/bls12_381_complex_add.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_complex_add.rs
@@ -1,9 +1,9 @@
 //! syscall_bls12_381_complex_add system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::complex::SyscallComplex384;
@@ -40,9 +40,9 @@ pub extern "C" fn syscall_bls12_381_complex_add(
     params: &mut SyscallBls12_381ComplexAddParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x80E, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let f1 = [params.f1.x, params.f1.y].concat().try_into().unwrap();
         let f2 = [params.f2.x, params.f2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/bls12_381_complex_mul.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_complex_mul.rs
@@ -1,9 +1,9 @@
 //! syscall_bls12_381_complex_mul system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::complex::SyscallComplex384;
@@ -40,9 +40,9 @@ pub extern "C" fn syscall_bls12_381_complex_mul(
     params: &mut SyscallBls12_381ComplexMulParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x810, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let f1 = [params.f1.x, params.f1.y].concat().try_into().unwrap();
         let f2 = [params.f2.x, params.f2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/bls12_381_complex_sub.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_complex_sub.rs
@@ -1,9 +1,9 @@
 //! syscall_bls12_381_complex_sub system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::complex::SyscallComplex384;
@@ -40,9 +40,9 @@ pub extern "C" fn syscall_bls12_381_complex_sub(
     params: &mut SyscallBls12_381ComplexSubParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x80F, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let f1 = [params.f1.x, params.f1.y].concat().try_into().unwrap();
         let f2 = [params.f2.x, params.f2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/bls12_381_curve_add.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_curve_add.rs
@@ -1,9 +1,9 @@
 //! syscall_bls12_381_curve_add system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::point::SyscallPoint384;
@@ -39,9 +39,9 @@ pub extern "C" fn syscall_bls12_381_curve_add(
     params: &mut SyscallBls12_381CurveAddParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x80C, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let p1 = [params.p1.x, params.p1.y].concat().try_into().unwrap();
         let p2 = [params.p2.x, params.p2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/bls12_381_curve_dbl.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_curve_dbl.rs
@@ -1,9 +1,9 @@
 //! syscall_bls12_381_curve_dbl system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::point::SyscallPoint384;
@@ -31,9 +31,9 @@ pub extern "C" fn syscall_bls12_381_curve_dbl(
     p1: &mut SyscallPoint384,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x80D, p1);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let _p1 = [p1.x, p1.y].concat().try_into().unwrap();
         let mut p2: [u64; 12] = [0; 12];

--- a/ziskos/entrypoint/src/syscalls/bn254_complex_add.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_complex_add.rs
@@ -1,9 +1,9 @@
 //! syscall_bn254_complex_add system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::complex::SyscallComplex256;
@@ -40,9 +40,9 @@ pub extern "C" fn syscall_bn254_complex_add(
     params: &mut SyscallBn254ComplexAddParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x808, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let f1 = [params.f1.x, params.f1.y].concat().try_into().unwrap();
         let f2 = [params.f2.x, params.f2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/bn254_complex_mul.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_complex_mul.rs
@@ -1,9 +1,9 @@
 //! syscall_bn254_complex_mul system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::complex::SyscallComplex256;
@@ -40,9 +40,9 @@ pub extern "C" fn syscall_bn254_complex_mul(
     params: &mut SyscallBn254ComplexMulParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x80A, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let f1 = [params.f1.x, params.f1.y].concat().try_into().unwrap();
         let f2 = [params.f2.x, params.f2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/bn254_complex_sub.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_complex_sub.rs
@@ -1,9 +1,9 @@
 //! syscall_bn254_complex_sub system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::complex::SyscallComplex256;
@@ -40,9 +40,9 @@ pub extern "C" fn syscall_bn254_complex_sub(
     params: &mut SyscallBn254ComplexSubParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x809, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let f1 = [params.f1.x, params.f1.y].concat().try_into().unwrap();
         let f2 = [params.f2.x, params.f2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/bn254_curve_add.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_curve_add.rs
@@ -1,9 +1,9 @@
 //! syscall_bn254_curve_add system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::point::SyscallPoint256;
@@ -39,9 +39,9 @@ pub extern "C" fn syscall_bn254_curve_add(
     params: &mut SyscallBn254CurveAddParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x806, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let p1 = [params.p1.x, params.p1.y].concat().try_into().unwrap();
         let p2 = [params.p2.x, params.p2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/bn254_curve_dbl.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_curve_dbl.rs
@@ -1,9 +1,9 @@
 //! syscall_bn254_curve_dbl system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::point::SyscallPoint256;
@@ -31,9 +31,9 @@ pub extern "C" fn syscall_bn254_curve_dbl(
     p1: &mut SyscallPoint256,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x807, p1);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let _p1 = [p1.x, p1.y].concat().try_into().unwrap();
         let mut p2: [u64; 8] = [0; 8];

--- a/ziskos/entrypoint/src/syscalls/keccakf.rs
+++ b/ziskos/entrypoint/src/syscalls/keccakf.rs
@@ -1,12 +1,12 @@
 //! Keccak system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 use tiny_keccak::keccakf;
 
 /// Executes the Keccak256 permutation on the given state.
@@ -27,9 +27,9 @@ pub unsafe extern "C" fn syscall_keccak_f(
     state: *mut [u64; 25],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x800, state);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         // Call keccakf
         keccakf(unsafe { &mut *state });

--- a/ziskos/entrypoint/src/syscalls/poseidon2.rs
+++ b/ziskos/entrypoint/src/syscalls/poseidon2.rs
@@ -1,12 +1,12 @@
 //! Poseidon2 system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 use fields::{poseidon2_hash, Goldilocks, Poseidon16, PrimeField64};
 
 /// Executes the Poseidon2 permutation on the given state.
@@ -27,9 +27,9 @@ pub unsafe extern "C" fn syscall_poseidon2(
     state: *mut [u64; 16],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x812, state);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         // Get a mutable reference to the state
         let state: &mut [u64; 16] = unsafe { &mut *(state) };

--- a/ziskos/entrypoint/src/syscalls/secp256k1_add.rs
+++ b/ziskos/entrypoint/src/syscalls/secp256k1_add.rs
@@ -1,9 +1,9 @@
 //! Secp256k1Add system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::point::SyscallPoint256;
@@ -39,9 +39,9 @@ pub extern "C" fn syscall_secp256k1_add(
     params: &mut SyscallSecp256k1AddParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x803, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let p1 = [params.p1.x, params.p1.y].concat().try_into().unwrap();
         let p2 = [params.p2.x, params.p2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/secp256k1_dbl.rs
+++ b/ziskos/entrypoint/src/syscalls/secp256k1_dbl.rs
@@ -1,9 +1,9 @@
 //! syscall_secp256k1_dbl system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::point::SyscallPoint256;
@@ -31,9 +31,9 @@ pub extern "C" fn syscall_secp256k1_dbl(
     p1: &mut SyscallPoint256,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x804, p1);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let _p1 = [p1.x, p1.y].concat().try_into().unwrap();
         let mut p3: [u64; 8] = [0; 8];

--- a/ziskos/entrypoint/src/syscalls/secp256r1_add.rs
+++ b/ziskos/entrypoint/src/syscalls/secp256r1_add.rs
@@ -1,9 +1,9 @@
 //! Secp256r1Add system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::point::SyscallPoint256;
@@ -39,9 +39,9 @@ pub extern "C" fn syscall_secp256r1_add(
     params: &mut SyscallSecp256r1AddParams,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x815, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let p1 = [params.p1.x, params.p1.y].concat().try_into().unwrap();
         let p2 = [params.p2.x, params.p2.y].concat().try_into().unwrap();

--- a/ziskos/entrypoint/src/syscalls/secp256r1_dbl.rs
+++ b/ziskos/entrypoint/src/syscalls/secp256r1_dbl.rs
@@ -1,9 +1,9 @@
 //! syscall_secp256r1_dbl system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
 use super::point::SyscallPoint256;
@@ -31,9 +31,9 @@ pub extern "C" fn syscall_secp256r1_dbl(
     p1: &mut SyscallPoint256,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x816, p1);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let _p1 = [p1.x, p1.y].concat().try_into().unwrap();
         let mut p3: [u64; 8] = [0; 8];

--- a/ziskos/entrypoint/src/syscalls/sha256f.rs
+++ b/ziskos/entrypoint/src/syscalls/sha256f.rs
@@ -1,15 +1,15 @@
 //! Sha256 system call interception
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use core::arch::asm;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(feature = "zisk_guest")]
 use crate::ziskos_syscall;
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 use sha2::compress256;
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[allow(deprecated)]
 use sha2::digest::generic_array::{typenum::U64, GenericArray};
 
@@ -39,9 +39,9 @@ pub extern "C" fn syscall_sha256_f(
     params: &mut SyscallSha256Params,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     ziskos_syscall!(0x805, params);
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         sha256f(params.state, params.input);
 
@@ -52,7 +52,7 @@ pub extern "C" fn syscall_sha256_f(
     }
 }
 
-#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+#[cfg(not(feature = "zisk_guest"))]
 #[allow(deprecated)]
 fn sha256f(state: &mut [u64; 4], input: &[u64; 8]) {
     let state_u32: &mut [u32; 8] = unsafe { &mut *(state.as_mut_ptr() as *mut [u32; 8]) };

--- a/ziskos/entrypoint/src/zisklib/fcalls/big_int256_div.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/big_int256_div.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param};
         use super::FCALL_BIG_INT256_DIV_ID;
@@ -29,7 +29,7 @@ pub fn fcall_bigint256_div(
     b_value: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> ([u64; 4], [u64; 4]) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let (quotient, remainder) = big_int256_div(a_value, b_value);
         #[cfg(feature = "hints")]
@@ -41,7 +41,7 @@ pub fn fcall_bigint256_div(
 
         (quotient, remainder)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(a_value, 4);
         ziskos_fcall_param!(b_value, 4);

--- a/ziskos/entrypoint/src/zisklib/fcalls/big_int_div.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/big_int_div.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param};
         use super::FCALL_BIG_INT_DIV_ID;
@@ -26,7 +26,7 @@ pub fn fcall_division(
     rem: &mut [u64],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> (usize, usize) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let mut quo_vector: Vec<u64> = Vec::new();
         let mut rem_vector: Vec<u64> = Vec::new();
@@ -46,7 +46,7 @@ pub fn fcall_division(
 
         (len_quo, len_rem)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         let len_a = a_value.len() as usize;
         ziskos_fcall_param!(len_a, 1);

--- a/ziskos/entrypoint/src/zisklib/fcalls/bin_decomp.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bin_decomp.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param};
         use super::FCALL_BIN_DECOMP_ID;
@@ -16,7 +16,7 @@ pub fn fcall_bin_decomp(
     x_val: &[u64],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> (usize, Vec<u64>) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let len_x = x_val.len();
         let bits = bin_decomp(x_val, len_x);
@@ -31,7 +31,7 @@ pub fn fcall_bin_decomp(
 
         (len_bits, bits_u64)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         let len_x = x_val.len() as usize;
         ziskos_fcall_param!(len_x, 1);

--- a/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/fp.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/fp.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{
             ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param,
@@ -30,7 +30,7 @@ pub fn fcall_bls12_381_fp_inv(
     p_value: &[u64; 6],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 6] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let result: [u64; 6] = bls12_381_fp_inv(p_value);
         #[cfg(feature = "hints")]
@@ -40,7 +40,7 @@ pub fn fcall_bls12_381_fp_inv(
         }
         result
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 8);
         ziskos_fcall!(FCALL_BLS12_381_FP_INV_ID);
@@ -73,7 +73,7 @@ pub fn fcall_bls12_381_fp_sqrt(
     p_value: &[u64; 6],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 7] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let mut result: [u64; 7] = [0; 7];
         bls12_381_fp_sqrt(p_value, &mut result);
@@ -84,7 +84,7 @@ pub fn fcall_bls12_381_fp_sqrt(
         }
         result
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 8);
         ziskos_fcall!(FCALL_BLS12_381_FP_SQRT_ID);

--- a/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/fp2.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/fp2.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{
             ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param,
@@ -31,7 +31,7 @@ pub fn fcall_bls12_381_fp2_inv(
     p_value: &[u64; 12],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 12] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let result: [u64; 12] = bls12_381_fp2_inv(p_value);
         #[cfg(feature = "hints")]
@@ -41,7 +41,7 @@ pub fn fcall_bls12_381_fp2_inv(
         }
         result
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 12);
         ziskos_fcall!(FCALL_BLS12_381_FP2_INV_ID);
@@ -80,7 +80,7 @@ pub fn fcall_bls12_381_fp2_sqrt(
     p_value: &[u64; 12],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 13] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let result: [u64; 13] = bls12_381_fp2_sqrt_13(p_value);
         #[cfg(feature = "hints")]
@@ -90,7 +90,7 @@ pub fn fcall_bls12_381_fp2_sqrt(
         }
         result
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 16);
         ziskos_fcall!(FCALL_BLS12_381_FP2_SQRT_ID);

--- a/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/twist.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{
             ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param,
@@ -26,7 +26,7 @@ pub fn fcall_bls12_381_twist_add_line_coeffs(
     p2_value: &[u64; 24],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> ([u64; 12], [u64; 12]) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let x1: [u64; 12] = p1_value[0..12].try_into().unwrap();
         let y1: [u64; 12] = p1_value[12..24].try_into().unwrap();
@@ -43,7 +43,7 @@ pub fn fcall_bls12_381_twist_add_line_coeffs(
 
         (lambda, mu)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p1_value, 24);
         ziskos_fcall_param!(p2_value, 24);
@@ -94,7 +94,7 @@ pub fn fcall_bls12_381_twist_dbl_line_coeffs(
     p_value: &[u64; 24],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> ([u64; 12], [u64; 12]) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let x: [u64; 12] = p_value[0..12].try_into().unwrap();
         let y: [u64; 12] = p_value[12..24].try_into().unwrap();
@@ -107,7 +107,7 @@ pub fn fcall_bls12_381_twist_dbl_line_coeffs(
         }
         (lambda, mu)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 24);
         ziskos_fcall!(FCALL_BLS12_381_TWIST_DBL_LINE_COEFFS_ID);

--- a/ziskos/entrypoint/src/zisklib/fcalls/bn254/fp.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bn254/fp.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param, zisklib::FCALL_BN254_FP_INV_ID};
     } else {
@@ -27,7 +27,7 @@ pub fn fcall_bn254_fp_inv(
     p_value: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 4] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let result: [u64; 4] = bn254_fp_inv(p_value);
         #[cfg(feature = "hints")]
@@ -37,7 +37,7 @@ pub fn fcall_bn254_fp_inv(
         }
         result
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 4);
         ziskos_fcall!(FCALL_BN254_FP_INV_ID);

--- a/ziskos/entrypoint/src/zisklib/fcalls/bn254/fp2.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bn254/fp2.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param, zisklib::FCALL_BN254_FP2_INV_ID};
     } else {
@@ -27,7 +27,7 @@ pub fn fcall_bn254_fp2_inv(
     p_value: &[u64; 8],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 8] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let result: [u64; 8] = bn254_fp2_inv(p_value);
         #[cfg(feature = "hints")]
@@ -37,7 +37,7 @@ pub fn fcall_bn254_fp2_inv(
         }
         result
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 8);
         ziskos_fcall!(FCALL_BN254_FP2_INV_ID);

--- a/ziskos/entrypoint/src/zisklib/fcalls/bn254/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bn254/twist.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{
             ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param,
@@ -27,7 +27,7 @@ pub fn fcall_bn254_twist_add_line_coeffs(
     p2_value: &[u64; 16],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> ([u64; 8], [u64; 8]) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let x1: [u64; 8] = p1_value[0..8].try_into().unwrap();
         let y1: [u64; 8] = p1_value[8..16].try_into().unwrap();
@@ -42,7 +42,7 @@ pub fn fcall_bn254_twist_add_line_coeffs(
         }
         (lambda, mu)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p1_value, 16);
         ziskos_fcall_param!(p2_value, 16);
@@ -85,7 +85,7 @@ pub fn fcall_bn254_twist_dbl_line_coeffs(
     p_value: &[u64; 16],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> ([u64; 8], [u64; 8]) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let x1: [u64; 8] = p_value[0..8].try_into().unwrap();
         let y1: [u64; 8] = p_value[8..16].try_into().unwrap();
@@ -98,7 +98,7 @@ pub fn fcall_bn254_twist_dbl_line_coeffs(
         }
         (lambda, mu)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 16);
         ziskos_fcall!(FCALL_BN254_TWIST_DBL_LINE_COEFFS_ID);

--- a/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_256.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_256.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param};
         use super::FCALL_MSB_POS_256_ID;
@@ -16,7 +16,7 @@ pub fn fcall_msb_pos_256(
     y: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> (u64, u64) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let tmp: [u64; 8] = [x[0], x[1], x[2], x[3], y[0], y[1], y[2], y[3]];
         let (i, pos) = msb_pos_256(&tmp, 2);
@@ -28,7 +28,7 @@ pub fn fcall_msb_pos_256(
         }
         (i as u64, pos as u64)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(2, 1); // Number of inputs
         ziskos_fcall_param!(x, 4);
@@ -45,7 +45,7 @@ pub fn fcall_msb_pos_256_3(
     z: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> (u64, u64) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let tmp: [u64; 12] =
             [x[0], x[1], x[2], x[3], y[0], y[1], y[2], y[3], z[0], z[1], z[2], z[3]];
@@ -58,7 +58,7 @@ pub fn fcall_msb_pos_256_3(
         }
         (i as u64, pos as u64)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(3, 1); // Number of inputs
         ziskos_fcall_param!(x, 4);

--- a/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_384.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_384.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param};
         use super::FCALL_MSB_POS_384_ID;
@@ -16,7 +16,7 @@ pub fn fcall_msb_pos_384(
     y: &[u64; 6],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> (u64, u64) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let (i, pos) = msb_pos_384(x, y);
         #[cfg(feature = "hints")]
@@ -27,7 +27,7 @@ pub fn fcall_msb_pos_384(
         }
         (i as u64, pos as u64)
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(x, 8);
         ziskos_fcall_param!(y, 8);

--- a/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/ecdsa.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/ecdsa.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param, zisklib::FCALL_SECP256K1_ECDSA_VERIFY_ID};
     }
@@ -44,7 +44,7 @@ pub fn fcall_secp256k1_ecdsa_verify(
     s_value: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 8] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         use crate::zisklib::fcalls_impl;
 
@@ -68,7 +68,7 @@ pub fn fcall_secp256k1_ecdsa_verify(
 
         results
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(pk_value, 8);
         ziskos_fcall_param!(z_value, 4);

--- a/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/fn.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/fn.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param, zisklib::FCALL_SECP256K1_FN_INV_ID};
     } else {
@@ -29,7 +29,7 @@ pub fn fcall_secp256k1_fn_inv(
     p_value: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 4] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let mut result: [u64; 4] = [0; 4];
         secp256k1_fn_inv_c(p_value, &mut result);
@@ -40,7 +40,7 @@ pub fn fcall_secp256k1_fn_inv(
         }
         result
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 4);
         ziskos_fcall!(FCALL_SECP256K1_FN_INV_ID);
@@ -53,7 +53,7 @@ pub fn fcall_secp256k1_fn_inv_in_place(
     p_value: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let mut result: [u64; 4] = [0; 4];
         secp256k1_fn_inv_c(p_value, &mut result);
@@ -63,7 +63,7 @@ pub fn fcall_secp256k1_fn_inv_in_place(
             hints.extend_from_slice(&result);
         }
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 4);
         ziskos_fcall!(FCALL_SECP256K1_FN_INV_ID);

--- a/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/fp.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/fp.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{
             ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param,
@@ -34,7 +34,7 @@ pub fn fcall_secp256k1_fp_inv(
     p_value: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 4] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let mut result: [u64; 4] = [0; 4];
         secp256k1_fp_inv_c(p_value, &mut result);
@@ -45,7 +45,7 @@ pub fn fcall_secp256k1_fp_inv(
         }
         result
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 4);
         ziskos_fcall!(FCALL_SECP256K1_FP_INV_ID);
@@ -58,7 +58,7 @@ pub fn fcall_secp256k1_fp_inv_in_place(
     p_value: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let mut result: [u64; 4] = [0; 4];
         secp256k1_fp_inv_c(p_value, &mut result);
@@ -68,7 +68,7 @@ pub fn fcall_secp256k1_fp_inv_in_place(
             hints.extend_from_slice(&result);
         }
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 4);
         ziskos_fcall!(FCALL_SECP256K1_FP_INV_ID);
@@ -96,7 +96,7 @@ pub fn fcall_secp256k1_fp_sqrt(
     parity: u64,
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 5] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         let mut result: [u64; 5] = [0; 5];
         secp256k1_fp_sqrt(p_value, parity, &mut result);
@@ -107,7 +107,7 @@ pub fn fcall_secp256k1_fp_sqrt(
         }
         result
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(p_value, 4);
         ziskos_fcall_param!(parity, 1);

--- a/ziskos/entrypoint/src/zisklib/fcalls/secp256r1/ecdsa.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/secp256r1/ecdsa.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] {
+    if #[cfg(feature = "zisk_guest")] {
         use core::arch::asm;
         use crate::{ziskos_fcall, ziskos_fcall_get, ziskos_fcall_param, zisklib::FCALL_SECP256R1_ECDSA_VERIFY_ID};
     }
@@ -44,7 +44,7 @@ pub fn fcall_secp256r1_ecdsa_verify(
     s_value: &[u64; 4],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 8] {
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         use crate::zisklib::fcalls_impl;
 
@@ -68,7 +68,7 @@ pub fn fcall_secp256r1_ecdsa_verify(
 
         results
     }
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         ziskos_fcall_param!(pk_value, 8);
         ziskos_fcall_param!(z_value, 4);

--- a/ziskos/entrypoint/src/zisklib/lib/keccak256.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/keccak256.rs
@@ -3,12 +3,12 @@ use crate::syscalls::syscall_keccak_f;
 #[cfg(zisk_hints_debug)]
 use std::os::raw::c_char;
 
-#[cfg(all(not(all(target_os = "zkvm", target_vendor = "zisk")), zisk_hints))]
+#[cfg(all(not(feature = "zisk_guest"), zisk_hints))]
 extern "C" {
     fn hint_keccak256(input_ptr: *const u8, input_len: usize);
 }
 
-#[cfg(all(not(all(target_os = "zkvm", target_vendor = "zisk")), zisk_hints_debug))]
+#[cfg(all(not(feature = "zisk_guest"), zisk_hints_debug))]
 extern "C" {
     fn hint_log_c(msg: *const c_char);
 }
@@ -16,7 +16,7 @@ extern "C" {
 #[cfg(zisk_hints_debug)]
 pub fn hint_log<S: AsRef<str>>(msg: S) {
     // On native we call external C function to log hints, since it controls if hints are paused or not
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         use std::ffi::CString;
 
@@ -25,7 +25,7 @@ pub fn hint_log<S: AsRef<str>>(msg: S) {
         }
     }
     // On zkvm/zisk, we can just print directly
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         println!("{}", msg.as_ref());
     }
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: 
         hint_log(format!("hint_keccak256 (bytes: {:?}, len: {})", input_bytes, len));
     }
 
-    #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+    #[cfg(feature = "zisk_guest")]
     {
         keccak256_c(
             bytes,
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: 
         );
     }
 
-    #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+    #[cfg(not(feature = "zisk_guest"))]
     {
         use tiny_keccak::{Hasher, Keccak};
         const OUT_LEN: usize = 32;


### PR DESCRIPTION
Related to https://github.com/0xPolygonHermez/zisk/issues/793

In order to support rv64imac-unknown-none-elf or rv64im-unknown-none-elf in the future, ZiskOS would need to be no_std compatible -- This PR does some preparation to make it easier to migrate:

- cfg flags on `zisk_guest` and `zisk_host`: This makes it easier to still support rv64ima-unknown-zisk-elf. This forked rust compiler supports things like the std lib. In general, I think cfg flags on a feature is a bit cleaner in the source code. It is possible to have a build.rs that sets zisk_guest based off of target which would make it similar to what was happening before.
- Explicitly pass zisk_guest or zisk_host, making it easier to see what crates compile ziskos in host mode or guest mode