### PR TITLE
default allocator as inline in bump

### DIFF
--- a/ziskos/entrypoint/src/alloc/alloc.rs
+++ b/ziskos/entrypoint/src/alloc/alloc.rs
@@ -1,5 +1,5 @@
-static mut HEAP_POS: usize = 0;
-static mut HEAP_TOP: usize = 0;
+pub static mut HEAP_POS: usize = 0;
+pub static mut HEAP_TOP: usize = 0;
 
 #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
 #[no_mangle]
@@ -20,6 +20,12 @@ pub unsafe extern "C" fn init_sys_alloc() {
 #[no_mangle]
 #[inline(never)]
 pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u8 {
+    inline_bump_alloc_aligned(bytes, align)
+}
+
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[inline(always)]
+pub unsafe fn inline_bump_alloc_aligned(bytes: usize, align: usize) -> *mut u8 {
     // SAFETY: Single threaded, so nothing else can touch this while we're working.
     let mut heap_pos = unsafe { HEAP_POS };
 

--- a/ziskos/entrypoint/src/alloc/alloc.rs
+++ b/ziskos/entrypoint/src/alloc/alloc.rs
@@ -1,5 +1,10 @@
-pub static mut HEAP_POS: usize = 0;
-pub static mut HEAP_TOP: usize = 0;
+#[used]
+#[export_name = "ZISK_BUMP_HEAP_POS"]
+static mut HEAP_POS: usize = 0;
+
+#[used]
+#[export_name = "ZISK_BUMP_HEAP_TOP"]
+static mut HEAP_TOP: usize = 0;
 
 #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
 #[no_mangle]

--- a/ziskos/entrypoint/src/alloc/bump.rs
+++ b/ziskos/entrypoint/src/alloc/bump.rs
@@ -1,8 +1,6 @@
 use core::alloc::{GlobalAlloc, Layout};
 
-use crate::alloc::{
-    inline_bump_alloc_aligned, sys_alloc_aligned, sys_alloc_log
-};
+use crate::alloc::{inline_bump_alloc_aligned, sys_alloc_aligned, sys_alloc_log};
 use crate::ziskos_memcpy;
 
 #[global_allocator]

--- a/ziskos/entrypoint/src/alloc/bump.rs
+++ b/ziskos/entrypoint/src/alloc/bump.rs
@@ -1,6 +1,8 @@
 use core::alloc::{GlobalAlloc, Layout};
 
-use crate::alloc::{sys_alloc_aligned, sys_alloc_log};
+use crate::alloc::{
+    inline_bump_alloc_aligned, sys_alloc_aligned, sys_alloc_log
+};
 use crate::ziskos_memcpy;
 
 #[global_allocator]
@@ -10,10 +12,7 @@ pub struct BumpPointerAlloc;
 
 unsafe impl GlobalAlloc for BumpPointerAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        sys_alloc_aligned(layout.size(), layout.align())
-        // let ptr = sys_alloc_aligned(layout.size(), layout.align());
-        // sys_alloc_log(0, ptr, layout.size(), layout.align());
-        // ptr
+        inline_bump_alloc_aligned(layout.size(), layout.align())
     }
 
     unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
@@ -22,17 +21,13 @@ unsafe impl GlobalAlloc for BumpPointerAlloc {
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        self.alloc(layout)
+        inline_bump_alloc_aligned(layout.size(), layout.align())
     }
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let new_layout = Layout::from_size_align_unchecked(new_size, layout.align());
-
-        let new_ptr = self.alloc(new_layout);
-
-        if !new_ptr.is_null() {
-            let copy_size = layout.size().min(new_size);
-            ziskos_memcpy!(ptr: new_ptr, ptr, copy_size);
-        }
+        let new_ptr = inline_bump_alloc_aligned(new_size, layout.align());
+        // OOM => panic on allocation
+        let copy_size = layout.size().min(new_size);
+        ziskos_memcpy!(ptr: new_ptr, ptr, copy_size);
 
         new_ptr
     }


### PR DESCRIPTION
In Bump allocator, replace use inline call to default allocator. This optimization reduces around 0.5% of steps.