### PR TITLE
fix bug with ram usage

### DIFF
--- a/emulator/src/elf_symbol_reader.rs
+++ b/emulator/src/elf_symbol_reader.rs
@@ -36,15 +36,29 @@ impl ElfSymbolReader {
         Ok(())
     }
 
-    pub fn load_from_file(&mut self, path: &str) -> Result<()> {
+    pub fn load_from_file(&mut self, path: &str, symbols: &[&str]) -> Result<Vec<u64>> {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file)? };
 
         match object::File::parse(&*mmap) {
             Ok(obj) => {
                 self.parse_symbols(&obj);
-                Ok(())
+                if symbols.is_empty() {
+                    Ok(vec![])
+                } else {
+                    Ok(self.get_symbols(&obj, symbols))
+                }
             }
+            Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        }
+    }
+
+    pub fn get_symbols_from_file(&mut self, path: &str, symbols: &[&str]) -> Result<Vec<u64>> {
+        let file = File::open(path)?;
+        let mmap = unsafe { Mmap::map(&file)? };
+
+        match object::File::parse(&*mmap) {
+            Ok(obj) => Ok(self.get_symbols(&obj, symbols)),
             Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
         }
     }
@@ -99,6 +113,23 @@ impl ElfSymbolReader {
             self.parse_function_symbol(&symbol);
             self.parse_cost_tag_symbol(&symbol);
         }
+    }
+
+    fn get_symbols(&mut self, obj: &object::File, symbols_to_load: &[&str]) -> Vec<u64> {
+        let mut count = symbols_to_load.len();
+        let mut result = vec![0u64; symbols_to_load.len()];
+        for symbol in obj.symbols() {
+            if count == 0 {
+                break;
+            }
+            if let Ok(name) = symbol.name() {
+                if let Some(idx) = symbols_to_load.iter().position(|&x| x == name) {
+                    result[idx] = symbol.address();
+                    count -= 1;
+                }
+            }
+        }
+        result
     }
 
     fn parse_cost_tag_symbol(&mut self, symbol: &Symbol<'_, '_>) {

--- a/emulator/src/emu.rs
+++ b/emulator/src/emu.rs
@@ -22,6 +22,7 @@ use zisk_core::{
 };
 
 pub const ZISK_PUBLICS: usize = 64;
+const HEAP_SYMBOLS: [&str; 3] = ["_kernel_heap_bottom", "_kernel_heap_top", "ZISK_BUMP_HEAP_POS"];
 
 /// ZisK emulator structure, containing the ZisK rom, the list of ZisK operations, and the
 /// execution context
@@ -1580,7 +1581,9 @@ impl<'a> Emu<'a> {
         self.ctx = self.create_emu_context(inputs.clone(), options);
 
         let mut elf = ElfSymbolReader::new();
-        println!("READ SYMBOLS={}", options.read_symbols);
+        let mut heap_top = 0u64;
+        let mut heap_bottom = 0u64;
+        let mut heap_pos_address = 0u64;
         if options.read_symbols {
             if let Some(elf_file) = &options.elf {
                 println!("Loading symbols from ELF file: {elf_file}");
@@ -1593,7 +1596,11 @@ impl<'a> Emu<'a> {
                     }
                 }
 
-                elf.load_from_file(elf_file).unwrap();
+                if let Ok(address) = elf.load_from_file(elf_file, &HEAP_SYMBOLS) {
+                    heap_bottom = address[0];
+                    heap_top = address[1];
+                    heap_pos_address = address[2];
+                }
                 let mut count = 0;
                 let mut roi_count = 0;
 
@@ -1658,6 +1665,14 @@ impl<'a> Emu<'a> {
                 self.ctx.stats.set_main_name(options.main_name.clone());
                 self.ctx.stats.set_use_thousands_sep(!options.no_thousands_sep);
                 self.ctx.stats.set_top_rois_filter(options.top_roi_filter);
+            }
+        } else if !options.is_fast() {
+            if let Some(elf_file) = &options.elf {
+                if let Ok(address) = elf.get_symbols_from_file(elf_file, &HEAP_SYMBOLS) {
+                    heap_bottom = address[0];
+                    heap_top = address[1];
+                    heap_pos_address = address[2];
+                }
             }
         }
         if options.coverage && !options.stats {
@@ -1815,6 +1830,12 @@ impl<'a> Emu<'a> {
 
         // Print stats report
         if self.ctx.do_stats {
+            if heap_pos_address != 0 {
+                let heap_pos = self.ctx.inst_ctx.mem.read(heap_pos_address, 8);
+                let heap_size = heap_top - heap_bottom;
+                let heap_used = heap_pos - heap_bottom;
+                self.ctx.stats.set_ram_usage(heap_size, heap_used);
+            }
             self.ctx.stats.update_costs();
             let report = self.ctx.stats.report(self.rom);
             println!("{report}");
@@ -1832,7 +1853,7 @@ impl<'a> Emu<'a> {
                         if let Some(roi_filter) = &options.roi_filter {
                             let _ = elf.set_roi_filter(roi_filter);
                         }
-                        elf.load_from_file(elf_file).ok();
+                        elf.load_from_file(elf_file, &[]).ok();
                         Some(elf)
                     } else {
                         None

--- a/emulator/src/mem_operations_stats.rs
+++ b/emulator/src/mem_operations_stats.rs
@@ -29,10 +29,7 @@ pub struct MemoryZoneStatsData {
     mread_byte: u64,
     /// Counter of byte writes where value was a byte (value & 0xFFFF_FFFF_FFFF_FF00 == 0)
     mwrite_byte: u64,
-    max_addr_read: u64,
-    max_addr_write: u64,
 }
-
 #[derive(Default, Debug, Clone)]
 pub struct MemoryOperationsStats {
     rom: MemoryZoneStatsData,
@@ -89,9 +86,6 @@ impl MemoryOperationsStats {
     pub fn get_cost(&self) -> u64 {
         self.rom.get_cost() + self.ram.get_cost() + self.input.get_cost()
     }
-    pub fn get_max_ram_address(&self) -> u64 {
-        self.ram.max_addr_read.max(self.ram.max_addr_write)
-    }
     pub fn add_delta(
         &mut self,
         reference: &MemoryOperationsStats,
@@ -123,7 +117,7 @@ impl MemoryZoneStatsData {
     pub fn memory_write(&mut self, address: u64, width: u64, value: u64) {
         // If the memory is alligned to 8 bytes, i.e. last 3 bits are zero, then increase the
         // aligned memory read counter
-        self.max_addr_write = self.max_addr_write.max(address + width - 1);
+
         if ((address & 0x07) == 0) && (width == 8) {
             self.mwrite_a += 1;
         } else {
@@ -148,7 +142,6 @@ impl MemoryZoneStatsData {
     pub fn memory_read(&mut self, address: u64, width: u64) {
         // If the memory is alligned to 8 bytes, i.e. last 3 bits are zero, then increase the
         // aligned memory read counter
-        self.max_addr_read = self.max_addr_read.max(address + width - 1);
         if ((address & 0x07) == 0) && (width == 8) {
             self.mread_a += 1;
         } else {
@@ -186,7 +179,5 @@ impl MemoryZoneStatsData {
         self.mwrite_na2 += current.mwrite_na2 - reference.mwrite_na2;
         self.mread_byte += current.mread_byte - reference.mread_byte;
         self.mwrite_byte += current.mwrite_byte - reference.mwrite_byte;
-        self.max_addr_read = self.max_addr_read.max(current.max_addr_read);
-        self.max_addr_write = self.max_addr_write.max(current.max_addr_write);
     }
 }

--- a/emulator/src/stats.rs
+++ b/emulator/src/stats.rs
@@ -15,7 +15,7 @@ use sm_arith::ArithFrops;
 use sm_binary::{BinaryBasicFrops, BinaryExtensionFrops};
 use zisk_core::{
     zisk_ops::{OpStats, ZiskOp},
-    ZiskInst, ZiskOperationType, ZiskRom, RAM_ADDR, REGS_IN_MAIN_TOTAL_NUMBER, SRC_IMM, SRC_REG,
+    ZiskInst, ZiskOperationType, ZiskRom, REGS_IN_MAIN_TOTAL_NUMBER, SRC_IMM, SRC_REG,
 };
 
 use crate::{
@@ -82,6 +82,8 @@ pub struct Stats {
     track_separator: String,
     use_thousands_sep: bool,
     top_rois_filter: bool,
+    ram_size: u64,
+    ram_used: u64,
     #[cfg(feature = "debug_stats_trace")]
     debug_step_stack: Vec<u64>,
     #[cfg(feature = "debug_stats_trace")]
@@ -124,6 +126,8 @@ impl Default for Stats {
             track_separator: ";".to_string(),
             use_thousands_sep: true,
             top_rois_filter: false,
+            ram_size: 0,
+            ram_used: 0,
             #[cfg(feature = "debug_stats_trace")]
             debug_step_stack: Vec::new(),
             #[cfg(feature = "debug_stats_trace")]
@@ -749,7 +753,9 @@ impl Stats {
         report.add_cost_perc("TOTAL", total_cost);
         report.ln();
         report.add_cost_perc("FROPS", self.frops_cost);
-        report.add_perc("RAM USAGE", self.costs.mops.get_max_ram_address() - RAM_ADDR + 1, 1 << 29);
+        if self.ram_size > 0 {
+            report.add_perc("RAM USAGE", self.ram_used, self.ram_size);
+        }
         report.title_count_cost_perc2("COST BY OPCODE", "COUNT", "COST", " RANK");
         self.report_opcodes(&mut report, &self.costs.ops, "OP", true);
 
@@ -767,7 +773,9 @@ impl Stats {
         }
 
         if !self.rois.is_empty() {
-            report.title_autowidth("TOP STEP FUNCTIONS (STEPS, % STEPS, CALLS, FUNCTION)");
+            report.title_autowidth(
+                "TOP STEP FUNCTIONS (STEPS, % STEPS, CALLS, STEPS/CALL, FUNCTION)",
+            );
 
             let top_step_rois = self.get_top_rois(true);
             for (index, _) in top_step_rois.iter() {
@@ -779,7 +787,7 @@ impl Stats {
                 report.add_top_step_calls_perc(&roi.name, steps, roi.calls);
             }
 
-            report.title_autowidth("TOP COST FUNCTIONS (COST, % COST, CALLS, FUNCTION)");
+            report.title_autowidth("TOP COST FUNCTIONS (COST, % COST, CALLS, COST/CALL, FUNCTION)");
 
             // Create a vector with ROI indices and their steps for sorting
             let top_cost_rois = self.get_top_rois(false);
@@ -1005,6 +1013,10 @@ impl Stats {
     }
     pub fn set_top_rois_filter(&mut self, value: bool) {
         self.top_rois_filter = value;
+    }
+    pub fn set_ram_usage(&mut self, ram_size: u64, ram_used: u64) {
+        self.ram_size = ram_size;
+        self.ram_used = ram_used;
     }
 
     /// Write disassembly to file with execution counts

--- a/emulator/src/stats_report.rs
+++ b/emulator/src/stats_report.rs
@@ -170,24 +170,23 @@ impl StatsReport {
         );
     }
 
-    pub fn add_top_cost_calls_perc(&mut self, label: &str, cost: u64, calls: usize) {
+    pub fn add_top_calls_perc(&mut self, label: &str, value: u64, calls: usize, total: f64) {
         self.output += &format!(
-            "{}{:>15} {:6.2}% {:>10} {label}\n",
+            "{}{:>15} {:6.2}% {:>10} {:>15} {label}\n",
             self.identation,
-            self.format_number(cost),
-            cost as f64 / self.cost_divisor,
-            self.format_number(calls as u64)
+            self.format_number(value),
+            value as f64 / total,
+            self.format_number(calls as u64),
+            self.format_number(value / calls as u64)
         );
     }
 
+    pub fn add_top_cost_calls_perc(&mut self, label: &str, cost: u64, calls: usize) {
+        self.add_top_calls_perc(label, cost, calls, self.cost_divisor)
+    }
+
     pub fn add_top_step_calls_perc(&mut self, label: &str, steps: u64, calls: usize) {
-        self.output += &format!(
-            "{}{:>15} {:6.2}% {:>10} {label}\n",
-            self.identation,
-            self.format_number(steps),
-            steps as f64 / self.step_divisor,
-            self.format_number(calls as u64)
-        );
+        self.add_top_calls_perc(label, steps, calls, self.step_divisor)
     }
 
     pub fn add_top_step_perc(&mut self, label: &str, cost: u64) {


### PR DESCRIPTION
Fix bug on ram usage. Fixed version uses values defined in link script and read the heap pos from memory. This feature is only available for default allocator (bump)