### PR TITLE
fix: add bls range checks

### DIFF
--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
@@ -704,9 +704,10 @@ pub fn sigma_endomorphism_bls12_381(
 /// - `ret` must point to a valid `[u8; 96]` for the output
 ///
 /// Returns:
-/// - 0 = success (regular point)
-/// - 1 = success (point at infinity)
-/// - 2 = error (point not on curve)
+/// - [G1_ADD_SUCCESS] = success (result is valid and not infinity)
+/// - [G1_ADD_SUCCESS_INFINITY] = success (result is infinity)
+/// - [G1_ADD_ERR_NOT_IN_FIELD] = error (one of the input points has coordinates not in the field)
+/// - [G1_ADD_ERR_NOT_ON_CURVE] = error (one of the input points is not on the curve)
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_bls12_381_g1_add_c")]
 pub unsafe extern "C" fn bls12_381_g1_add_c(
@@ -753,10 +754,11 @@ pub unsafe extern "C" fn bls12_381_g1_add_c(
 /// - `ret` must point to a valid `[u8; 96]` for the output
 ///
 /// Returns:
-/// - 0 = success (regular point)
-/// - 1 = success (point at infinity)
-/// - 2 = error (point not on curve)
-/// - 3 = error (point not in subgroup)
+/// - [G1_MSM_SUCCESS] = success (result is valid and not infinity)
+/// - [G1_MSM_SUCCESS_INFINITY] = success (result is infinity)
+/// - [G1_MSM_ERR_NOT_IN_FIELD] = error (one of the input points has coordinates not in the field)
+/// - [G1_MSM_ERR_NOT_ON_CURVE] = error (one of the input points is not on the curve)
+/// - [G1_MSM_ERR_NOT_IN_SUBGROUP] = error (one of the input points is not in the subgroup)
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_bls12_381_g1_msm_c")]
 pub unsafe extern "C" fn bls12_381_g1_msm_c(

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
@@ -5,7 +5,7 @@ use crate::{
         syscall_bls12_381_curve_add, syscall_bls12_381_curve_dbl, SyscallBls12_381CurveAddParams,
         SyscallPoint384,
     },
-    zisklib::{eq, fcall_msb_pos_256, lt},
+    zisklib::{eq, fcall_msb_pos_256, is_zero, lt},
 };
 
 use super::{
@@ -17,18 +17,18 @@ use super::{
     fr::{reduce_fr_bls12_381, scalar_bytes_be_to_u64_le_bls12_381},
 };
 
-// TODO: Check what happens if scalar or ecc coordinates are bigger than the field size
-
 /// G1 add result codes
 const G1_ADD_SUCCESS: u8 = 0;
 const G1_ADD_SUCCESS_INFINITY: u8 = 1;
-const G1_ADD_ERR_NOT_ON_CURVE: u8 = 2;
+const G1_ADD_ERR_NOT_IN_FIELD: u8 = 2;
+const G1_ADD_ERR_NOT_ON_CURVE: u8 = 3;
 
 /// G1 MSM result codes
 const G1_MSM_SUCCESS: u8 = 0;
 const G1_MSM_SUCCESS_INFINITY: u8 = 1;
-const G1_MSM_ERR_NOT_ON_CURVE: u8 = 2;
-const G1_MSM_ERR_NOT_IN_SUBGROUP: u8 = 3;
+const G1_MSM_ERR_NOT_IN_FIELD: u8 = 2;
+const G1_MSM_ERR_NOT_ON_CURVE: u8 = 3;
+const G1_MSM_ERR_NOT_IN_SUBGROUP: u8 = 4;
 
 /// Decompresses a point on the BLS12-381 curve from 48 bytes
 ///
@@ -267,6 +267,12 @@ pub fn add_complete_bls12_381(
         return Ok(G1_IDENTITY);
     }
     if p1_is_inf {
+        // Validate p2 field elements and curve membership
+        let x2: [u64; 6] = p2[0..6].try_into().unwrap();
+        let y2: [u64; 6] = p2[6..12].try_into().unwrap();
+        if !lt(&x2, &P) || !lt(&y2, &P) {
+            return Err(G1_ADD_ERR_NOT_IN_FIELD);
+        }
         if !is_on_curve_bls12_381(
             p2,
             #[cfg(feature = "hints")]
@@ -278,6 +284,12 @@ pub fn add_complete_bls12_381(
     }
 
     if p2_is_inf {
+        // Validate p1 field elements and curve membership
+        let x1: [u64; 6] = p1[0..6].try_into().unwrap();
+        let y1: [u64; 6] = p1[6..12].try_into().unwrap();
+        if !lt(&x1, &P) || !lt(&y1, &P) {
+            return Err(G1_ADD_ERR_NOT_IN_FIELD);
+        }
         if !is_on_curve_bls12_381(
             p1,
             #[cfg(feature = "hints")]
@@ -288,13 +300,25 @@ pub fn add_complete_bls12_381(
         return Ok(*p1);
     }
 
-    // Both points are non-identity, validate both are on curve
+    // Both points are non-identity, validate both
+    let x1: [u64; 6] = p1[0..6].try_into().unwrap();
+    let y1: [u64; 6] = p1[6..12].try_into().unwrap();
+    if !lt(&x1, &P) || !lt(&y1, &P) {
+        return Err(G1_ADD_ERR_NOT_IN_FIELD);
+    }
     if !is_on_curve_bls12_381(
         p1,
         #[cfg(feature = "hints")]
         hints,
     ) {
         return Err(G1_ADD_ERR_NOT_ON_CURVE);
+    }
+
+    // Validate p2 field elements and curve membership
+    let x2: [u64; 6] = p2[0..6].try_into().unwrap();
+    let y2: [u64; 6] = p2[6..12].try_into().unwrap();
+    if !lt(&x2, &P) || !lt(&y2, &P) {
+        return Err(G1_ADD_ERR_NOT_IN_FIELD);
     }
     if !is_on_curve_bls12_381(
         p2,
@@ -581,14 +605,21 @@ pub fn msm_complete_bls12_381(
             continue;
         }
 
-        // Skip zero scalars
-        if reduce_fr_bls12_381(
+        // Reduce the scalar modulo the group order, and skip if the result is zero
+        let scalar = reduce_fr_bls12_381(
             scalar,
             #[cfg(feature = "hints")]
             hints,
-        ) == [0, 0, 0, 0]
-        {
+        );
+        if is_zero(&scalar) {
             continue;
+        }
+
+        // Verify point coordinates are in the field
+        let x: [u64; 6] = point[0..6].try_into().unwrap();
+        let y: [u64; 6] = point[6..12].try_into().unwrap();
+        if !lt(&x, &P) || !lt(&y, &P) {
+            return Err(G1_MSM_ERR_NOT_IN_FIELD);
         }
 
         // Verify point is on curve
@@ -612,7 +643,7 @@ pub fn msm_complete_bls12_381(
         // Compute P * k
         let product = scalar_mul_bls12_381(
             point,
-            scalar,
+            &scalar,
             #[cfg(feature = "hints")]
             hints,
         );

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/map_to_curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/map_to_curve.rs
@@ -3,7 +3,7 @@ use crate::zisklib::{eq, is_zero, lt};
 use super::{
     constants::{
         COFACTOR_G1, ISO_A_G1, ISO_A_G2, ISO_B_G1, ISO_B_G2, ISO_X_DEN_G1, ISO_X_DEN_G2,
-        ISO_X_NUM_G1, ISO_X_NUM_G2, ISO_Y_DEN_G1, ISO_Y_DEN_G2, ISO_Y_NUM_G1, ISO_Y_NUM_G2,
+        ISO_X_NUM_G1, ISO_X_NUM_G2, ISO_Y_DEN_G1, ISO_Y_DEN_G2, ISO_Y_NUM_G1, ISO_Y_NUM_G2, P,
         SWU_Z2_G1, SWU_Z_G1, SWU_Z_G2,
     },
     curve::{g1_u64_le_to_bytes_be_bls12_381, scalar_mul_bls12_381},
@@ -20,11 +20,24 @@ use super::{
     },
 };
 
+// G1 map to curve result codes
+const G1_MAP_TO_CURVE_SUCCESS: u8 = 0;
+const G1_MAP_TO_CURVE_ERR_NOT_IN_FIELD: u8 = 1;
+
+// G2 map to curve result codes
+const G2_MAP_TO_CURVE_SUCCESS: u8 = 0;
+const G2_MAP_TO_CURVE_ERR_NOT_IN_FIELD: u8 = 1;
+
 /// Maps a field element to a point on the BLS12-381 G1 curve
 pub fn map_to_curve_g1_bls12_381(
     u: &[u64; 6],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+) -> Result<[u64; 12], u8> {
+    // Verify input is in field
+    if !lt(u, &P) {
+        return Err(G1_MAP_TO_CURVE_ERR_NOT_IN_FIELD);
+    }
+
     // Step 1: Map to isogenous curve E' using simplified SWU
     let p_prime = map_to_curve_simple_swu_g1_bls12_381(
         u,
@@ -40,19 +53,26 @@ pub fn map_to_curve_g1_bls12_381(
     );
 
     // Step 3: Clear cofactor
-    scalar_mul_bls12_381(
+    Ok(scalar_mul_bls12_381(
         &p,
         &COFACTOR_G1,
         #[cfg(feature = "hints")]
         hints,
-    )
+    ))
 }
 
 /// Maps a field element in Fp2 to a point on the BLS12-381 G2 curve
 pub fn map_to_curve_g2_bls12_381(
     u: &[u64; 12],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+) -> Result<[u64; 24], u8> {
+    // Verify input is in field
+    let u_0: [u64; 6] = u[0..6].try_into().unwrap();
+    let u_1: [u64; 6] = u[6..12].try_into().unwrap();
+    if !lt(&u_0, &P) || !lt(&u_1, &P) {
+        return Err(G2_MAP_TO_CURVE_ERR_NOT_IN_FIELD);
+    }
+
     // Step 1: Map to isogenous curve E' using simplified SWU
     let p_prime = map_to_curve_simple_swu_g2_bls12_381(
         u,
@@ -68,11 +88,11 @@ pub fn map_to_curve_g2_bls12_381(
     );
 
     // Step 3: Clear cofactor
-    clear_cofactor_twist_bls12_381(
+    Ok(clear_cofactor_twist_bls12_381(
         &p,
         #[cfg(feature = "hints")]
         hints,
-    )
+    ))
 }
 
 /// Maps a field element u ∈ Fp to a point on the isogenous curve E'
@@ -662,15 +682,18 @@ pub unsafe extern "C" fn bls12_381_fp_to_g1_c(
     let u = bytes_be_to_u64_le_fp_bls12_381(fp_bytes);
 
     // Map to curve
-    let result = map_to_curve_g1_bls12_381(
+    let result = match map_to_curve_g1_bls12_381(
         &u,
         #[cfg(feature = "hints")]
         hints,
-    );
+    ) {
+        Ok(p) => p,
+        Err(code) => return code,
+    };
 
     // Encode result
     g1_u64_le_to_bytes_be_bls12_381(&result, ret_bytes);
-    0
+    G1_MAP_TO_CURVE_SUCCESS
 }
 
 /// BLS12-381 map Fp2 field element to G2 point
@@ -699,13 +722,16 @@ pub unsafe extern "C" fn bls12_381_fp2_to_g2_c(
     let u = bytes_be_to_u64_le_fp2_bls12_381(fp2_bytes);
 
     // Map to curve
-    let result = map_to_curve_g2_bls12_381(
+    let result = match map_to_curve_g2_bls12_381(
         &u,
         #[cfg(feature = "hints")]
         hints,
-    );
+    ) {
+        Ok(p) => p,
+        Err(code) => return code,
+    };
 
     // Encode result
     g2_u64_le_to_bytes_be_bls12_381(&result, ret_bytes);
-    0
+    G2_MAP_TO_CURVE_SUCCESS
 }

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/pairing.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/pairing.rs
@@ -100,21 +100,7 @@ pub fn pairing_batch_bls12_381(
     )
 }
 
-/// BLS12-381 pairing check with validation.
-///
-/// Validates all points are on curve and in subgroup.
-///
-/// # Arguments
-/// * `g1_points` - Slice of G1 points as [u64; 12]
-/// * `g2_points` - Slice of G2 points as [u64; 24]
-///
-/// # Returns
-/// * `Ok(true)` - Pairing check passed
-/// * `Ok(false)` - Pairing check failed
-/// * `Err(PAIRING_CHECK_ERR_G1_NOT_ON_CURVE)` - G1 point not on curve
-/// * `Err(PAIRING_CHECK_ERR_G1_NOT_IN_SUBGROUP)` - G1 point not in subgroup
-/// * `Err(PAIRING_CHECK_ERR_G2_NOT_ON_CURVE)` - G2 point not on curve
-/// * `Err(PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP)` - G2 point not in subgroup
+/// Pairing check with validation
 pub fn pairing_check_bls12_381(
     g1_points: &[[u64; 12]],
     g2_points: &[[u64; 24]],

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/pairing.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/pairing.rs
@@ -1,6 +1,6 @@
 //! Pairing over BLS12-381 curve
 
-use crate::zisklib::lib::utils::{eq, gt, is_one, lt};
+use crate::zisklib::lib::utils::{eq, is_one, lt};
 
 use super::{
     constants::{G1_IDENTITY, G2_IDENTITY, P, P_MINUS_ONE},
@@ -258,12 +258,14 @@ pub fn pairing_check_bls12_381(
 /// `pairs` must point to an array of `num_pairs * 288` bytes
 ///
 /// # Returns
-/// - 0 = pairing check passed
-/// - 1 = pairing check failed
-/// - 2 = error: G1 point not on curve
-/// - 3 = error: G1 point not in subgroup
-/// - 4 = error: G2 point not on curve
-/// - 5 = error: G2 point not in subgroup
+/// - [PAIRING_CHECK_SUCCESS] = pairing check passed
+/// - [PAIRING_CHECK_FAILED] = pairing check failed
+/// - [PAIRING_CHECK_ERR_G1_NOT_IN_FIELD] = error (at least one G1 point coordinate not in field)
+/// - [PAIRING_CHECK_ERR_G1_NOT_ON_CURVE] = error (at least one G1 point not on curve)
+/// - [PAIRING_CHECK_ERR_G1_NOT_IN_SUBGROUP] = error (at least one G1 point not in subgroup)
+/// - [PAIRING_CHECK_ERR_G2_NOT_IN_FIELD] = error (at least one G2 point coordinate not in field)
+/// - [PAIRING_CHECK_ERR_G2_NOT_ON_CURVE] = error (at least one G2 point not on curve)
+/// - [PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP] = error (at least one G2 point not in subgroup)
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_bls12_381_pairing_check_c")]
 pub unsafe extern "C" fn bls12_381_pairing_check_c(

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/pairing.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/pairing.rs
@@ -1,9 +1,9 @@
 //! Pairing over BLS12-381 curve
 
-use crate::zisklib::lib::utils::{eq, gt, is_one};
+use crate::zisklib::lib::utils::{eq, gt, is_one, lt};
 
 use super::{
-    constants::{G1_IDENTITY, G2_IDENTITY, P_MINUS_ONE},
+    constants::{G1_IDENTITY, G2_IDENTITY, P, P_MINUS_ONE},
     curve::{
         g1_bytes_be_to_u64_le_bls12_381, is_on_curve_bls12_381, is_on_subgroup_bls12_381,
         neg_bls12_381,
@@ -19,10 +19,12 @@ use super::{
 /// Pairing check result codes
 const PAIRING_CHECK_SUCCESS: u8 = 0;
 const PAIRING_CHECK_FAILED: u8 = 1;
-const PAIRING_CHECK_ERR_G1_NOT_ON_CURVE: u8 = 2;
-const PAIRING_CHECK_ERR_G1_NOT_IN_SUBGROUP: u8 = 3;
-const PAIRING_CHECK_ERR_G2_NOT_ON_CURVE: u8 = 4;
-const PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP: u8 = 5;
+const PAIRING_CHECK_ERR_G1_NOT_IN_FIELD: u8 = 2;
+const PAIRING_CHECK_ERR_G1_NOT_ON_CURVE: u8 = 3;
+const PAIRING_CHECK_ERR_G1_NOT_IN_SUBGROUP: u8 = 4;
+const PAIRING_CHECK_ERR_G2_NOT_IN_FIELD: u8 = 5;
+const PAIRING_CHECK_ERR_G2_NOT_ON_CURVE: u8 = 6;
+const PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP: u8 = 7;
 
 /// Optimal Ate Pairing e: G1 x G2 -> GT over the BLS12-381 curve
 /// where G1 = E(Fp)[r] = E(Fp), G2 = E'(Fp2)[r] and GT = μ_r (the r-th roots of unity over Fp12*)
@@ -127,28 +129,46 @@ pub fn pairing_check_bls12_381(
         let g1_is_inf = eq(g1, &G1_IDENTITY);
         let g2_is_inf = eq(g2, &G2_IDENTITY);
 
-        // If p = 𝒪 or q = 𝒪 => MillerLoop(P, 𝒪) = MillerLoop(𝒪, Q) = 1; we can skip
+        if g1_is_inf && g2_is_inf {
+            // If p = 𝒪 and q = 𝒪 => e(𝒪, 𝒪) = 1; we can skip
+            continue;
+        }
+
+        // If q = 𝒪 => MillerLoop(P, 𝒪) = 1; we can skip
         if g2_is_inf {
-            if !g1_is_inf {
-                if !is_on_curve_bls12_381(
-                    g1,
-                    #[cfg(feature = "hints")]
-                    hints,
-                ) {
-                    return Err(PAIRING_CHECK_ERR_G1_NOT_ON_CURVE);
-                }
-                if !is_on_subgroup_bls12_381(
-                    g1,
-                    #[cfg(feature = "hints")]
-                    hints,
-                ) {
-                    return Err(PAIRING_CHECK_ERR_G1_NOT_IN_SUBGROUP);
-                }
+            // Validate p1 field elements and curve membership
+            let x1: [u64; 6] = g1[0..6].try_into().unwrap();
+            let y1: [u64; 6] = g1[6..12].try_into().unwrap();
+            if !lt(&x1, &P) || !lt(&y1, &P) {
+                return Err(PAIRING_CHECK_ERR_G1_NOT_IN_FIELD);
+            }
+            if !is_on_curve_bls12_381(
+                g1,
+                #[cfg(feature = "hints")]
+                hints,
+            ) {
+                return Err(PAIRING_CHECK_ERR_G1_NOT_ON_CURVE);
+            }
+            if !is_on_subgroup_bls12_381(
+                g1,
+                #[cfg(feature = "hints")]
+                hints,
+            ) {
+                return Err(PAIRING_CHECK_ERR_G1_NOT_IN_SUBGROUP);
             }
             continue;
         }
 
+        // If p = 𝒪 => MillerLoop(𝒪, Q) = 1; we can skip
         if g1_is_inf {
+            // Validate p2 field elements and curve membership
+            let x2_0: [u64; 6] = g2[0..6].try_into().unwrap();
+            let x2_1: [u64; 6] = g2[6..12].try_into().unwrap();
+            let y2_0: [u64; 6] = g2[12..18].try_into().unwrap();
+            let y2_1: [u64; 6] = g2[18..24].try_into().unwrap();
+            if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
+                return Err(PAIRING_CHECK_ERR_G2_NOT_IN_FIELD);
+            }
             if !is_on_curve_twist_bls12_381(
                 g2,
                 #[cfg(feature = "hints")]
@@ -166,6 +186,12 @@ pub fn pairing_check_bls12_381(
             continue;
         }
 
+        // Both points are non-identity, validate both
+        let x1: [u64; 6] = g1[0..6].try_into().unwrap();
+        let y1: [u64; 6] = g1[6..12].try_into().unwrap();
+        if !lt(&x1, &P) || !lt(&y1, &P) {
+            return Err(PAIRING_CHECK_ERR_G1_NOT_IN_FIELD);
+        }
         if !is_on_curve_bls12_381(
             g1,
             #[cfg(feature = "hints")]
@@ -181,6 +207,13 @@ pub fn pairing_check_bls12_381(
             return Err(PAIRING_CHECK_ERR_G1_NOT_IN_SUBGROUP);
         }
 
+        let x2_0: [u64; 6] = g2[0..6].try_into().unwrap();
+        let x2_1: [u64; 6] = g2[6..12].try_into().unwrap();
+        let y2_0: [u64; 6] = g2[12..18].try_into().unwrap();
+        let y2_1: [u64; 6] = g2[18..24].try_into().unwrap();
+        if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
+            return Err(PAIRING_CHECK_ERR_G2_NOT_IN_FIELD);
+        }
         if !is_on_curve_twist_bls12_381(
             g2,
             #[cfg(feature = "hints")]

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
@@ -1,6 +1,6 @@
 //! Operations on the twist E': y² = x³ + 4·(1+u) of the BLS12-381 curve
 
-use crate::zisklib::{eq, fcall_msb_pos_256, lt};
+use crate::zisklib::{eq, fcall_msb_pos_256, is_zero, lt};
 
 use super::{
     constants::{
@@ -18,13 +18,15 @@ use super::{
 /// G2 add result codes
 pub const G2_ADD_SUCCESS: u8 = 0;
 pub const G2_ADD_SUCCESS_INFINITY: u8 = 1;
-pub const G2_ADD_ERR_NOT_ON_CURVE: u8 = 2;
+pub const G1_ADD_ERR_NOT_IN_FIELD: u8 = 2;
+pub const G2_ADD_ERR_NOT_ON_CURVE: u8 = 3;
 
 /// G2 MSM result codes
 pub const G2_MSM_SUCCESS: u8 = 0;
 pub const G2_MSM_SUCCESS_INFINITY: u8 = 1;
-pub const G2_MSM_ERR_NOT_ON_CURVE: u8 = 2;
-pub const G2_MSM_ERR_NOT_IN_SUBGROUP: u8 = 3;
+pub const G2_MSM_ERR_NOT_IN_FIELD: u8 = 2;
+pub const G2_MSM_ERR_NOT_ON_CURVE: u8 = 3;
+pub const G2_MSM_ERR_NOT_IN_SUBGROUP: u8 = 4;
 
 /// Decompresses a G2 point on the BLS12-381 twist from 96 bytes (compressed format).
 ///
@@ -478,7 +480,14 @@ pub fn add_complete_twist_bls12_381(
     }
 
     if p1_is_inf {
-        // Validate p2 is on curve
+        // Validate p2 field elements and curve membership
+        let x2_0: [u64; 6] = p2[0..6].try_into().unwrap();
+        let x2_1: [u64; 6] = p2[6..12].try_into().unwrap();
+        let y2_0: [u64; 6] = p2[12..18].try_into().unwrap();
+        let y2_1: [u64; 6] = p2[18..24].try_into().unwrap();
+        if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
+            return Err(G1_ADD_ERR_NOT_IN_FIELD);
+        }
         if !is_on_curve_twist_bls12_381(
             p2,
             #[cfg(feature = "hints")]
@@ -490,7 +499,14 @@ pub fn add_complete_twist_bls12_381(
     }
 
     if p2_is_inf {
-        // Validate p1 is on curve
+        // Validate p1 field elements and curve membership
+        let x1_0: [u64; 6] = p1[0..6].try_into().unwrap();
+        let x1_1: [u64; 6] = p1[6..12].try_into().unwrap();
+        let y1_0: [u64; 6] = p1[12..18].try_into().unwrap();
+        let y1_1: [u64; 6] = p1[18..24].try_into().unwrap();
+        if !lt(&x1_0, &P) || !lt(&x1_1, &P) || !lt(&y1_0, &P) || !lt(&y1_1, &P) {
+            return Err(G1_ADD_ERR_NOT_IN_FIELD);
+        }
         if !is_on_curve_twist_bls12_381(
             p1,
             #[cfg(feature = "hints")]
@@ -501,13 +517,28 @@ pub fn add_complete_twist_bls12_381(
         return Ok(*p1);
     }
 
-    // Both points are non-identity, validate both are on curve
+    // Both points are non-identity, validate both
+    let x1_0: [u64; 6] = p1[0..6].try_into().unwrap();
+    let x1_1: [u64; 6] = p1[6..12].try_into().unwrap();
+    let y1_0: [u64; 6] = p1[12..18].try_into().unwrap();
+    let y1_1: [u64; 6] = p1[18..24].try_into().unwrap();
+    if !lt(&x1_0, &P) || !lt(&x1_1, &P) || !lt(&y1_0, &P) || !lt(&y1_1, &P) {
+        return Err(G1_ADD_ERR_NOT_IN_FIELD);
+    }
     if !is_on_curve_twist_bls12_381(
         p1,
         #[cfg(feature = "hints")]
         hints,
     ) {
         return Err(G2_ADD_ERR_NOT_ON_CURVE);
+    }
+
+    let x2_0: [u64; 6] = p2[0..6].try_into().unwrap();
+    let x2_1: [u64; 6] = p2[6..12].try_into().unwrap();
+    let y2_0: [u64; 6] = p2[12..18].try_into().unwrap();
+    let y2_1: [u64; 6] = p2[18..24].try_into().unwrap();
+    if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
+        return Err(G1_ADD_ERR_NOT_IN_FIELD);
     }
     if !is_on_curve_twist_bls12_381(
         p2,
@@ -843,14 +874,23 @@ pub fn msm_complete_twist_bls12_381(
             continue;
         }
 
-        // Skip zero scalars
-        if reduce_fr_bls12_381(
+        // Reduce the scalar modulo the group order, and skip if the result is zero
+        let scalar = reduce_fr_bls12_381(
             scalar,
             #[cfg(feature = "hints")]
             hints,
-        ) == [0, 0, 0, 0]
-        {
+        );
+        if is_zero(&scalar) {
             continue;
+        }
+
+        // Verify point coordinates are in the field
+        let x_0: [u64; 6] = point[0..6].try_into().unwrap();
+        let x_1: [u64; 6] = point[6..12].try_into().unwrap();
+        let y_0: [u64; 6] = point[12..18].try_into().unwrap();
+        let y_1: [u64; 6] = point[18..24].try_into().unwrap();
+        if !lt(&x_0, &P) || !lt(&x_1, &P) || !lt(&y_0, &P) || !lt(&y_1, &P) {
+            return Err(G2_MSM_ERR_NOT_IN_FIELD);
         }
 
         // Verify point is on curve
@@ -874,7 +914,7 @@ pub fn msm_complete_twist_bls12_381(
         // Compute P * k
         let product = scalar_mul_twist_bls12_381(
             point,
-            scalar,
+            &scalar,
             #[cfg(feature = "hints")]
             hints,
         );

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
@@ -18,7 +18,7 @@ use super::{
 /// G2 add result codes
 pub const G2_ADD_SUCCESS: u8 = 0;
 pub const G2_ADD_SUCCESS_INFINITY: u8 = 1;
-pub const G1_ADD_ERR_NOT_IN_FIELD: u8 = 2;
+pub const G2_ADD_ERR_NOT_IN_FIELD: u8 = 2;
 pub const G2_ADD_ERR_NOT_ON_CURVE: u8 = 3;
 
 /// G2 MSM result codes
@@ -486,7 +486,7 @@ pub fn add_complete_twist_bls12_381(
         let y2_0: [u64; 6] = p2[12..18].try_into().unwrap();
         let y2_1: [u64; 6] = p2[18..24].try_into().unwrap();
         if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
-            return Err(G1_ADD_ERR_NOT_IN_FIELD);
+            return Err(G2_ADD_ERR_NOT_IN_FIELD);
         }
         if !is_on_curve_twist_bls12_381(
             p2,
@@ -505,7 +505,7 @@ pub fn add_complete_twist_bls12_381(
         let y1_0: [u64; 6] = p1[12..18].try_into().unwrap();
         let y1_1: [u64; 6] = p1[18..24].try_into().unwrap();
         if !lt(&x1_0, &P) || !lt(&x1_1, &P) || !lt(&y1_0, &P) || !lt(&y1_1, &P) {
-            return Err(G1_ADD_ERR_NOT_IN_FIELD);
+            return Err(G2_ADD_ERR_NOT_IN_FIELD);
         }
         if !is_on_curve_twist_bls12_381(
             p1,
@@ -523,7 +523,7 @@ pub fn add_complete_twist_bls12_381(
     let y1_0: [u64; 6] = p1[12..18].try_into().unwrap();
     let y1_1: [u64; 6] = p1[18..24].try_into().unwrap();
     if !lt(&x1_0, &P) || !lt(&x1_1, &P) || !lt(&y1_0, &P) || !lt(&y1_1, &P) {
-        return Err(G1_ADD_ERR_NOT_IN_FIELD);
+        return Err(G2_ADD_ERR_NOT_IN_FIELD);
     }
     if !is_on_curve_twist_bls12_381(
         p1,
@@ -538,7 +538,7 @@ pub fn add_complete_twist_bls12_381(
     let y2_0: [u64; 6] = p2[12..18].try_into().unwrap();
     let y2_1: [u64; 6] = p2[18..24].try_into().unwrap();
     if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
-        return Err(G1_ADD_ERR_NOT_IN_FIELD);
+        return Err(G2_ADD_ERR_NOT_IN_FIELD);
     }
     if !is_on_curve_twist_bls12_381(
         p2,
@@ -1026,9 +1026,10 @@ pub fn utf_endomorphism_twist_bls12_381(
 /// - `ret` must point to a valid `[u8; 192]` for the output
 ///
 /// Returns:
-/// - 0 = success (regular point)
-/// - 1 = success (point at infinity)
-/// - 2 = error (point not on curve)
+/// - [G2_ADD_SUCCESS] = success (regular point)
+/// - [G2_ADD_SUCCESS_INFINITY] = success (point at infinity)
+/// - [G2_ADD_ERR_NOT_IN_FIELD] = error (at least one point coordinate not in field)
+/// - [G2_ADD_ERR_NOT_ON_CURVE] = error (at least one point not on curve)
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_bls12_381_g2_add_c")]
 pub unsafe extern "C" fn bls12_381_g2_add_c(
@@ -1075,10 +1076,11 @@ pub unsafe extern "C" fn bls12_381_g2_add_c(
 /// - `ret` must point to a valid `[u8; 192]` for the output
 ///
 /// Returns:
-/// - 0 = success (regular point)
-/// - 1 = success (point at infinity)
-/// - 2 = error (point not on curve)
-/// - 3 = error (point not in subgroup)
+/// - [G2_MSM_SUCCESS] = success (regular point)
+/// - [G2_MSM_SUCCESS_INFINITY] = success (point at infinity)
+/// - [G2_MSM_ERR_NOT_IN_FIELD] = error (at least one point coordinate not in field)
+/// - [G2_MSM_ERR_NOT_ON_CURVE] = error (at least one point not on curve)
+/// - [G2_MSM_ERR_NOT_IN_SUBGROUP] = error (at least one point not in subgroup)
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_bls12_381_g2_msm_c")]
 pub unsafe extern "C" fn bls12_381_g2_msm_c(

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/curve.rs
@@ -19,7 +19,7 @@ use super::{
 /// G1 add result codes
 const G1_ADD_SUCCESS: u8 = 0;
 const G1_ADD_SUCCESS_INFINITY: u8 = 1;
-const G1_ADD_ERR_INVALID: u8 = 2;
+const G1_ADD_ERR_NOT_IN_FIELD: u8 = 2;
 const G1_ADD_ERR_NOT_ON_CURVE: u8 = 3;
 
 /// G1 mul result codes
@@ -125,7 +125,7 @@ pub fn add_complete_bn254(
         let x2: [u64; 4] = p2[0..4].try_into().unwrap();
         let y2: [u64; 4] = p2[4..8].try_into().unwrap();
         if !lt(&x2, &P) || !lt(&y2, &P) {
-            return Err(G1_ADD_ERR_INVALID);
+            return Err(G1_ADD_ERR_NOT_IN_FIELD);
         }
         if !is_on_curve_bn254(
             p2,
@@ -142,7 +142,7 @@ pub fn add_complete_bn254(
         let x1: [u64; 4] = p1[0..4].try_into().unwrap();
         let y1: [u64; 4] = p1[4..8].try_into().unwrap();
         if !lt(&x1, &P) || !lt(&y1, &P) {
-            return Err(G1_ADD_ERR_INVALID);
+            return Err(G1_ADD_ERR_NOT_IN_FIELD);
         }
         if !is_on_curve_bn254(
             p1,
@@ -158,7 +158,7 @@ pub fn add_complete_bn254(
     let x1: [u64; 4] = p1[0..4].try_into().unwrap();
     let y1: [u64; 4] = p1[4..8].try_into().unwrap();
     if !lt(&x1, &P) || !lt(&y1, &P) {
-        return Err(G1_ADD_ERR_INVALID);
+        return Err(G1_ADD_ERR_NOT_IN_FIELD);
     }
     if !is_on_curve_bn254(
         p1,
@@ -171,7 +171,7 @@ pub fn add_complete_bn254(
     let x2: [u64; 4] = p2[0..4].try_into().unwrap();
     let y2: [u64; 4] = p2[4..8].try_into().unwrap();
     if !lt(&x2, &P) || !lt(&y2, &P) {
-        return Err(G1_ADD_ERR_INVALID);
+        return Err(G1_ADD_ERR_NOT_IN_FIELD);
     }
     if !is_on_curve_bn254(
         p2,

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/pairing.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/pairing.rs
@@ -13,9 +13,9 @@ use super::{
 /// Pairing check result codes
 const PAIRING_CHECK_SUCCESS: u8 = 0;
 const PAIRING_CHECK_FAILED: u8 = 1;
-const PAIRING_CHECK_ERR_G1_INVALID: u8 = 2;
+const PAIRING_CHECK_ERR_G1_NOT_IN_FIELD: u8 = 2;
 const PAIRING_CHECK_ERR_G1_NOT_ON_CURVE: u8 = 3;
-const PAIRING_CHECK_ERR_G2_INVALID: u8 = 4;
+const PAIRING_CHECK_ERR_G2_NOT_IN_FIELD: u8 = 4;
 const PAIRING_CHECK_ERR_G2_NOT_ON_CURVE: u8 = 5;
 const PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP: u8 = 6;
 
@@ -120,9 +120,9 @@ pub fn pairing_batch_bn254(
 /// # Returns
 /// * `Ok(true)` - Pairing check passed (product of pairings == 1)
 /// * `Ok(false)` - Pairing check failed (product of pairings != 1)
-/// * `Err(PAIRING_CHECK_ERR_G1_INVALID)` - G1 field element not canonical (>= P)
+/// * `Err(PAIRING_CHECK_ERR_G1_NOT_IN_FIELD)` - G1 field element not canonical (>= P)
 /// * `Err(PAIRING_CHECK_ERR_G1_NOT_ON_CURVE)` - G1 point not on curve
-/// * `Err(PAIRING_CHECK_ERR_G2_INVALID)` - G2 field element not canonical (>= P)
+/// * `Err(PAIRING_CHECK_ERR_G2_NOT_IN_FIELD)` - G2 field element not canonical (>= P)
 /// * `Err(PAIRING_CHECK_ERR_G2_NOT_ON_CURVE)` - G2 point not on twist curve
 /// * `Err(PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP)` - G2 point not in subgroup
 pub fn pairing_check_bn254(
@@ -175,7 +175,7 @@ pub fn pairing_check_bn254(
         let x1: [u64; 4] = g1[0..4].try_into().unwrap();
         let y1: [u64; 4] = g1[4..8].try_into().unwrap();
         if !lt(&x1, &P) || !lt(&y1, &P) {
-            return Err(PAIRING_CHECK_ERR_G1_INVALID);
+            return Err(PAIRING_CHECK_ERR_G1_NOT_IN_FIELD);
         }
 
         // Verify G1 point is on curve
@@ -193,7 +193,7 @@ pub fn pairing_check_bn254(
         let y2_r: [u64; 4] = g2[8..12].try_into().unwrap();
         let y2_i: [u64; 4] = g2[12..16].try_into().unwrap();
         if !lt(&x2_r, &P) || !lt(&x2_i, &P) || !lt(&y2_r, &P) || !lt(&y2_i, &P) {
-            return Err(PAIRING_CHECK_ERR_G2_INVALID);
+            return Err(PAIRING_CHECK_ERR_G2_NOT_IN_FIELD);
         }
 
         // Verify G2 point is on twist curve


### PR DESCRIPTION
This pull request strengthens input validation for BLS12-381 curve operations by ensuring all point coordinates and field elements are checked to be within the field before curve membership or subgroup checks. It also updates result codes to reflect new error conditions for invalid field elements and propagates these checks across G1, G2, MSM, map-to-curve, and pairing operations.

These changes ensure that all curve-related operations fail early and clearly when given invalid field elements, improving safety and correctness.