### PR TITLE
fix: make public_bytes_solidity() return raw bytes without LE→BE conversion

### DIFF
--- a/sdk/src/prover/mod.rs
+++ b/sdk/src/prover/mod.rs
@@ -511,21 +511,13 @@ impl ZiskPublics {
         bytes.to_vec()
     }
 
+    /// Returns the 256 bytes of public output data for Solidity verification.
+    ///
+    /// Bytes are returned in the same order the guest wrote them via [`io::write()`],
+    /// making `write()` a natural pass-through for raw byte sequences such as
+    /// ABI-encoded structs.
     pub fn public_bytes_solidity(&self) -> Vec<u8> {
-        let mut bytes = [0u8; ZISK_PUBLICS * 4];
-
-        for i in 0..ZISK_PUBLICS {
-            let start = i * 4;
-            let val32 = u32::from_le_bytes([
-                self.data[start],
-                self.data[start + 1],
-                self.data[start + 2],
-                self.data[start + 3],
-            ]);
-            bytes[i * 4..(i + 1) * 4].copy_from_slice(&val32.to_be_bytes());
-        }
-
-        bytes.to_vec()
+        self.data.clone()
     }
 
     pub fn hash_solidity(&self, program_vk: &ZiskProgramVK, vadcop_verkey: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
## Summary

`public_bytes_solidity()` was reversing every 4-byte chunk — `from_le_bytes` → `to_be_bytes` per register. This forced all guest programs to manually pre-swap bytes when writing ABI-encoded data for Solidity verification.

Changed to return `self.data.clone()` directly. The LE round-trip through `write()` → `ZiskPublics::new()` is identity, so `write()` becomes a clean pass-through.

## Change

One function in `sdk/src/prover/mod.rs`:

```rust
pub fn public_bytes_solidity(&self) -> Vec<u8> {
    self.data.clone()
}
```