### PR TITLE
fix: array square and mul bugs

### DIFF
--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/mul_long.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/mul_long.rs
@@ -55,7 +55,7 @@ pub fn mul_long(
 
     // Finish the first row
     for j in 1..len_b {
-        // Compute a[0]·b[j] + out[j]
+        // Compute a[0]·b[j] + out[j] and set out[j]
         let out_j = out[j];
         let mut params = SyscallArith256Params {
             a: a[0].as_limbs(),
@@ -70,16 +70,20 @@ pub fn mul_long(
             hints,
         );
 
-        // Propagate the carry
+        // Set out[j+1]
         out[j + 1] = U256::from_u64s(params.dh);
     }
 
     // Finish the remaining rows
+    let last_b_idx = len_b - 1;
     for i in 1..len_a {
-        let mut carry_flag = 0u64;
-        for j in 0..(len_b - 1) {
+        // Process all chunks except the last one
+        let mut carry = 0u64;
+        #[allow(clippy::needless_range_loop)]
+        for j in 0..last_b_idx {
             // Compute a[i]·b[j] + out[i + j]
-            let out_ij = out[i + j];
+            let k = i + j;
+            let out_ij = out[k];
             let mut params_arith = SyscallArith256Params {
                 a: a[i].as_limbs(),
                 b: b[j].as_limbs(),
@@ -93,34 +97,18 @@ pub fn mul_long(
                 hints,
             );
 
-            // Set the result
-            out[i + j] = U256::from_u64s(params_arith.dl);
+            // Set out[i+j]
+            out[k] = U256::from_u64s(params_arith.dl);
 
-            if carry_flag == 1 {
-                let mut params_add = SyscallAdd256Params {
-                    a: &params_arith.dh.clone(),
-                    b: U256::ZERO.as_limbs(),
-                    cin: 1,
-                    c: params_arith.dh,
-                };
-                let _carry = syscall_add256(
-                    &mut params_add,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
-
-                debug_assert!(_carry == 0, "Unexpected carry in intermediate addition");
-            }
-
-            // Update out[i+j+1] with carry
-            let out_ij1 = out[i + j + 1];
+            // Update out[i+j+1]
+            let out_ij1 = out[k + 1];
             let mut params_add = SyscallAdd256Params {
                 a: out_ij1.as_limbs(),
                 b: params_arith.dh,
-                cin: 0,
-                c: out[i + j + 1].as_limbs_mut(),
+                cin: carry,
+                c: out[k + 1].as_limbs_mut(),
             };
-            carry_flag = syscall_add256(
+            carry = syscall_add256(
                 &mut params_add,
                 #[cfg(feature = "hints")]
                 hints,
@@ -129,13 +117,14 @@ pub fn mul_long(
 
         // Last chunk isolated
 
-        // Compute a[i]·b[len_b - 1] + out[i + len_b - 1]
-        let out_ilb1 = out[i + len_b - 1];
+        // Compute a[i]·b[len_b - 1] + out[i + len_b - 1] and set out[i + len_b - 1]
+        let k = i + last_b_idx;
+        let out_ilb1 = out[k];
         let mut params_arith = SyscallArith256Params {
             a: a[i].as_limbs(),
-            b: b[len_b - 1].as_limbs(),
+            b: b[last_b_idx].as_limbs(),
             c: out_ilb1.as_limbs(),
-            dl: out[i + len_b - 1].as_limbs_mut(),
+            dl: out[k].as_limbs_mut(),
             dh: &mut [0, 0, 0, 0],
         };
         syscall_arith256(
@@ -144,7 +133,7 @@ pub fn mul_long(
             hints,
         );
 
-        if carry_flag == 1 {
+        if carry == 1 {
             let a_in = *params_arith.dh;
             let mut params_add = SyscallAdd256Params {
                 a: &a_in,
@@ -161,7 +150,7 @@ pub fn mul_long(
             debug_assert!(_carry == 0, "Unexpected carry in intermediate addition");
         }
 
-        // Set out[i+j+1] = carry
+        // Set out[i + len_b]
         out[i + len_b] = U256::from_u64s(params_arith.dh);
     }
 

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/square_long.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/square_long.rs
@@ -21,18 +21,16 @@ pub fn square_long(
     out: &mut [U256],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> usize {
-    //                                        a3    a2    a1      a0
-    //                                      * a3    a2    a1      a0
-    //         ------------------------------------------------------- 0
-    //                               Y       2*a0*a2   2*a0*a1  a0*a0
-    //         ------------------------------------------------------- 1
-    //               2*a1*a3+Z    2*a1*a2     a1*a1        X      0
-    //         ------------------------------------------------------- 2
-    //  Z   Y     2*a2*a3   a2*a2        X      X          0      0
-    //         ------------------------------------------------------- 3
-    //    a3*a3     X        X          X           0      0      0
-    //         ------------------------------------------------------- 4
-    //                          RESULT
+    //                         a2       a1      a0
+    //                     *   a2       a1      a0
+    // ----------------------------------------------
+    //                      2*a0*a2   2*a0*a1  a0*a0  0
+    // ----------------------------------------------
+    //           2*a1*a2     a1*a1       X       0    1
+    // ----------------------------------------------
+    //  a2*a2       X          X         0       0    2
+    // ----------------------------------------------
+    //                                                RESULT
 
     let len_a = a.len();
     #[cfg(debug_assertions)]
@@ -43,16 +41,17 @@ pub fn square_long(
         }
     }
 
-    // Step 1: Compute all diagonal terms a[i] * a[i]
-    for i in 0..len_a {
-        // Compute the diagonal:
-        //      a[i]·a[i] = dh·B + dl
-        // and set out[2 * i] = dl and out[2 * i + 1] = dh
+    // Compute all diagonal terms a[i] * a[i] for i in [0, len(a) - 1]
+    // with 0 <= a[i]·a[i] <= (B - 2)·B + 1
+    for (i, ai) in a.iter().enumerate() {
+        // Compute the diagonal a[i]·a[i] = dh·B + dl,
+        // and set out[2·i] = dl and out[2·i + 1] = dh
+        let k = 2 * i;
         let mut ai_ai = SyscallArith256Params {
-            a: a[i].as_limbs(),
-            b: a[i].as_limbs(),
+            a: ai.as_limbs(),
+            b: ai.as_limbs(),
             c: U256::ZERO.as_limbs(),
-            dl: out[2 * i].as_limbs_mut(),
+            dl: out[k].as_limbs_mut(),
             dh: &mut [0, 0, 0, 0],
         };
         syscall_arith256(
@@ -61,10 +60,11 @@ pub fn square_long(
             hints,
         );
 
-        out[2 * i + 1] = U256::from_u64s(ai_ai.dh);
+        out[k + 1] = U256::from_u64s(ai_ai.dh);
     }
 
     // Step 2: Compute all cross terms 2·a[i]·a[j] for i < j
+    //         with 0 <= 2·a[i]·a[j] <= B² + (B - 4)·B + 2
     for i in 0..len_a {
         for j in (i + 1)..len_a {
             // First compute a[i]·a[j] = h₁·B + l₁
@@ -84,138 +84,88 @@ pub fn square_long(
             // Double the result 2·a[i]·a[j]
 
             // Start by doubling the lower chunk: 2·l₁ = [1/0]·B + l₂
+            let mut low_chunk: [u64; 4] = [0, 0, 0, 0];
             let mut dbl_low =
-                SyscallAdd256Params { a: ai_aj.dl, b: ai_aj.dl, cin: 0, c: &mut [0, 0, 0, 0] };
-            let dbl_low_carry = syscall_add256(
+                SyscallAdd256Params { a: ai_aj.dl, b: ai_aj.dl, cin: 0, c: &mut low_chunk };
+            let carry = syscall_add256(
                 &mut dbl_low,
                 #[cfg(feature = "hints")]
                 hints,
             );
 
             // Next, double the higher chunk: 2·h₁·B = [1/0]·B² + h₂·B
+            let mut mid_chunk: [u64; 4] = [0, 0, 0, 0];
             let mut dbl_high =
-                SyscallAdd256Params { a: ai_aj.dh, b: ai_aj.dh, cin: 0, c: &mut [0, 0, 0, 0] };
-            let dbl_high_carry = syscall_add256(
+                SyscallAdd256Params { a: ai_aj.dh, b: ai_aj.dh, cin: carry, c: &mut mid_chunk };
+            let high_chunk = syscall_add256(
                 &mut dbl_high,
                 #[cfg(feature = "hints")]
                 hints,
             );
 
-            // If there's a carry from doubling the low part, add it to the high part
-            if dbl_low_carry != 0 {
-                let a_in = *dbl_high.c;
-                let mut add = SyscallAdd256Params {
-                    a: &a_in,
-                    b: U256::ZERO.as_limbs(),
-                    cin: 1,
-                    c: dbl_high.c,
-                };
-                let _carry = syscall_add256(
-                    &mut add,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+            // The result is expressed as: high_chunk·B² + mid_chunk·B + low_chunk
 
-                debug_assert!(_carry == 0, "Unexpected carry in intermediate addition");
-            }
+            // Now update out[i+j], out[i+j+1] and out[i+j+2]
+            let k = i + j;
 
-            // The result is expressed as: dbl_high.dh·B² + dbl_high.dl·B + dbl_low.dl
-
-            // Now update out[i+j], out[i+j+1] and out[i+j+2] with this result
-
-            // Update out[i+j]
-            let mut add_low = SyscallAdd256Params {
-                a: out[i + j].as_limbs(),
-                b: dbl_low.c,
+            // Update out[i+j] with the low chunk
+            let mut add = SyscallAdd256Params {
+                a: out[k].as_limbs(),
+                b: &low_chunk,
                 cin: 0,
                 c: &mut [0, 0, 0, 0],
             };
-            let add_low_carry = syscall_add256(
-                &mut add_low,
+            let mut carry = syscall_add256(
+                &mut add,
                 #[cfg(feature = "hints")]
                 hints,
             );
-            out[i + j] = U256::from_u64s(add_low.c);
+            out[k] = U256::from_u64s(add.c);
 
-            if add_low_carry != 0 {
-                let a_in = out[i + j + 1];
-                let mut add = SyscallAdd256Params {
-                    a: a_in.as_limbs(),
-                    b: U256::ZERO.as_limbs(),
-                    cin: 1,
-                    c: out[i + j + 1].as_limbs_mut(),
-                };
-                let add_carry = syscall_add256(
-                    &mut add,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
-
-                if add_carry != 0 {
-                    let a_in = out[i + j + 2];
-                    let mut add2 = SyscallAdd256Params {
-                        a: a_in.as_limbs(),
-                        b: U256::ZERO.as_limbs(),
-                        cin: 1,
-                        c: out[i + j + 2].as_limbs_mut(),
-                    };
-                    let _carry = syscall_add256(
-                        &mut add2,
-                        #[cfg(feature = "hints")]
-                        hints,
-                    );
-
-                    debug_assert!(_carry == 0, "Unexpected carry in intermediate addition");
-                }
-            }
-
-            // Update out[i+j+1]
-            let mut add_mid = SyscallAdd256Params {
-                a: out[i + j + 1].as_limbs(),
-                b: dbl_high.c,
-                cin: 0,
+            // Update out[i+j+1] with the middle chunk
+            let mut add = SyscallAdd256Params {
+                a: out[k + 1].as_limbs(),
+                b: &mid_chunk,
+                cin: carry,
                 c: &mut [0, 0, 0, 0],
             };
-            let add_mid_carry = syscall_add256(
-                &mut add_mid,
+            carry = syscall_add256(
+                &mut add,
                 #[cfg(feature = "hints")]
                 hints,
             );
-            out[i + j + 1] = U256::from_u64s(add_mid.c);
+            out[k + 1] = U256::from_u64s(add.c);
 
-            if add_mid_carry != 0 {
-                let a_in = out[i + j + 2];
+            // Update out[i+j+2] with the high chunk
+            let mut add = SyscallAdd256Params {
+                a: out[k + 2].as_limbs(),
+                b: &[high_chunk, 0, 0, 0],
+                cin: carry,
+                c: &mut [0, 0, 0, 0],
+            };
+            carry = syscall_add256(
+                &mut add,
+                #[cfg(feature = "hints")]
+                hints,
+            );
+            out[k + 2] = U256::from_u64s(add.c);
+
+            // If there's still a carry, propagate it to the next limbs
+            let mut idx = k + 3;
+            while carry != 0 {
                 let mut add = SyscallAdd256Params {
-                    a: a_in.as_limbs(),
+                    a: out[idx].as_limbs(),
                     b: U256::ZERO.as_limbs(),
-                    cin: 1,
-                    c: out[i + j + 2].as_limbs_mut(),
+                    cin: carry,
+                    c: &mut [0, 0, 0, 0],
                 };
-                let _carry = syscall_add256(
+                carry = syscall_add256(
                     &mut add,
                     #[cfg(feature = "hints")]
                     hints,
                 );
-
-                debug_assert!(_carry == 0, "Unexpected carry in intermediate addition");
-            }
-
-            // Update out[i+j+2]
-            if dbl_high_carry != 0 {
-                let a_in = out[i + j + 2];
-                let mut add = SyscallAdd256Params {
-                    a: a_in.as_limbs(),
-                    b: U256::ZERO.as_limbs(),
-                    cin: 1,
-                    c: out[i + j + 2].as_limbs_mut(),
-                };
-                let _carry = syscall_add256(
-                    &mut add,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
-
-                debug_assert!(_carry == 0, "Unexpected carry in intermediate addition");
+                out[idx] = U256::from_u64s(add.c);
+                idx += 1;
             }
         }
     }


### PR DESCRIPTION
This pull request refactors and simplifies the implementation of multi-limb multiplication and squaring in the `mul_long` and `square_long` functions. The changes improve clarity, consistency, and efficiency in how carries and intermediate results are handled during arithmetic operations. Moreover, it fixes two existing bugs.