### PR TITLE
fix: enable `precomp-blake2/packed` in `executor/packed`

### DIFF
--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -60,6 +60,7 @@ packed = [
     "precomp-keccakf/packed",
     "precomp-sha256f/packed",
     "precomp-poseidon2/packed",
+    "precomp-blake2/packed",
     "precomp-arith-eq/packed",
     "precomp-arith-eq-384/packed",
     "precomp-big-int/packed",


### PR DESCRIPTION
When using `zisk-sdk` with `gpu` feature on, it fails to prove the trace with `Blake2br` instance, after some digging I found that it's because `precomp-blake2/packed` is not enabled by `executor/packed`.

When building `cargo-zisk` in the `zisk` repo with `gpu` feature, it enables all the crates' `gpu` feature so this issue doesn't show up, this is only an issue for `zisk-sdk` user that enables `gpu` feature.