### PR TITLE
chore: use global buffer for syscall hints

### DIFF
--- a/precompiles/hints/src/hint_handlers.rs
+++ b/precompiles/hints/src/hint_handlers.rs
@@ -66,15 +66,12 @@ impl HintHandlers {
     /// The `data_len_bytes` parameter is used for hints that operate on byte arrays (e.g., SHA256, Keccak256)
     /// to indicate the actual length of the data in bytes, since the `data` field is a `Vec<u64>` and may contain padding.
     /// The BuiltInHint::Input is intentionally not handled here, as input hints require special handling and should be processed separately before dispatching to workers.
-    /// The dispatcher owns the hints buffer lifecycle: clear before, drain after.
     #[inline]
     fn dispatch_builtin(
         hint: BuiltInHint,
         data: Vec<u64>,
         data_len_bytes: usize,
     ) -> Result<Vec<u64>> {
-        ziskos_hints::hints_collect::hints_clear();
-
         let result = match hint {
             // SHA256 Hint Codes
             BuiltInHint::Sha256 => sha256_hint(&data, data_len_bytes),

--- a/precompiles/hints/src/hint_handlers.rs
+++ b/precompiles/hints/src/hint_handlers.rs
@@ -63,6 +63,9 @@ impl HintHandlers {
     }
 
     /// Dispatches built-in hints to their corresponding handler functions.
+    /// The `data_len_bytes` parameter is used for hints that operate on byte arrays (e.g., SHA256, Keccak256)
+    /// to indicate the actual length of the data in bytes, since the `data` field is a `Vec<u64>` and may contain padding.
+    /// The BuiltInHint::Input is intentionally not handled here, as input hints require special handling and should be processed separately before dispatching to workers.
     /// The dispatcher owns the hints buffer lifecycle: clear before, drain after.
     #[inline]
     fn dispatch_builtin(

--- a/precompiles/hints/src/hint_handlers.rs
+++ b/precompiles/hints/src/hint_handlers.rs
@@ -118,7 +118,7 @@ impl HintHandlers {
             ),
         };
 
-        // Always drain (resets DEPTH), even on error
+        // Always drain, even on error
         let hints = ziskos_hints::hints_collect::hints_drain();
         result?;
         Ok(hints)

--- a/precompiles/hints/src/hint_handlers.rs
+++ b/precompiles/hints/src/hint_handlers.rs
@@ -63,16 +63,16 @@ impl HintHandlers {
     }
 
     /// Dispatches built-in hints to their corresponding handler functions.
-    /// The `data_len_bytes` parameter is used for hints that operate on byte arrays (e.g., SHA256, Keccak256)
-    /// to indicate the actual length of the data in bytes, since the `data` field is a `Vec<u64>` and may contain padding.
-    /// The BuiltInHint::Input is intentionally not handled here, as input hints require special handling and should be processed separately before dispatching to workers.
+    /// The dispatcher owns the hints buffer lifecycle: clear before, drain after.
     #[inline]
     fn dispatch_builtin(
         hint: BuiltInHint,
         data: Vec<u64>,
         data_len_bytes: usize,
     ) -> Result<Vec<u64>> {
-        match hint {
+        ziskos_hints::hints_collect::hints_clear();
+
+        let result = match hint {
             // SHA256 Hint Codes
             BuiltInHint::Sha256 => sha256_hint(&data, data_len_bytes),
 
@@ -116,6 +116,11 @@ impl HintHandlers {
             BuiltInHint::Input => unreachable!(
                 "Input hints should be handled separately and not dispatched to workers"
             ),
-        }
+        };
+
+        // Always drain (resets DEPTH), even on error
+        let hints = ziskos_hints::hints_collect::hints_drain();
+        result?;
+        Ok(hints)
     }
 }

--- a/ziskos-hints/Cargo.toml
+++ b/ziskos-hints/Cargo.toml
@@ -2,7 +2,7 @@
 #
 # src/core/ is a symlink to ../../ziskos/entrypoint/src/ - same source, different features.
 # src/lib.rs wraps the symlinked source and adds hints-specific modules.
-# Exports C symbols with "hints_" prefix to avoid linker conflicts with ziskos.
+# Enables hints feature so syscalls write to a global thread-local buffer.
 # See README.md for details.
 
 [package]

--- a/ziskos-hints/src/handlers/blake2b.rs
+++ b/ziskos-hints/src/handlers/blake2b.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 /// Processes an `HINT_BLAKE2B_COMPRESS` hint.
 #[inline]
-pub fn blake2b_compress_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn blake2b_compress_hint(data: &[u64]) -> Result<()> {
     hint_fields![ROUNDS: 1, STATE: 8, MESSAGE: 16, OFFSET: 2, FINAL_BLOCK: 1];
 
     validate_hint_length(data, EXPECTED_LEN, "HINT_BLAKE2B_COMPRESS")?;
@@ -15,8 +15,7 @@ pub fn blake2b_compress_hint(data: &[u64]) -> Result<Vec<u64>> {
     let offset = data[OFFSET_OFFSET..OFFSET_OFFSET + OFFSET_SIZE].try_into().unwrap();
     let final_block = data[FINAL_BLOCK_OFFSET] != 0;
 
-    let mut hints = Vec::new();
-    zisklib::blake2b_compress(rounds, &mut state, message, offset, final_block, &mut hints);
+    zisklib::blake2b_compress(rounds, &mut state, message, offset, final_block);
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos-hints/src/handlers/bls381.rs
+++ b/ziskos-hints/src/handlers/bls381.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 /// Processes an `HINT_BLS12_381_G1_ADD` hint.
 #[inline]
-pub fn bls12_381_g1_add_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bls12_381_g1_add_hint(data: &[u64]) -> Result<()> {
     hint_fields![A: 96, B: 96];
 
     let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 8) };
@@ -14,18 +14,17 @@ pub fn bls12_381_g1_add_hint(data: &[u64]) -> Result<Vec<u64>> {
     let a: &[u8; A_SIZE] = bytes[A_OFFSET..A_OFFSET + A_SIZE].try_into().unwrap();
     let b: &[u8; B_SIZE] = bytes[B_OFFSET..B_OFFSET + B_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     let result: &mut [u8; 96] = &mut [0u8; 96];
     unsafe {
-        zisklib::bls12_381_g1_add_c(result.as_mut_ptr(), a.as_ptr(), b.as_ptr(), &mut hints);
+        zisklib::bls12_381_g1_add_c(result.as_mut_ptr(), a.as_ptr(), b.as_ptr());
     }
 
-    Ok(hints)
+    Ok(())
 }
 
 /// Processes an `HINT_BLS12_381_G1_MSM` hint.
 #[inline]
-pub fn bls12_381_g1_msm_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bls12_381_g1_msm_hint(data: &[u64]) -> Result<()> {
     if data.is_empty() {
         anyhow::bail!("HINT_BLS12_381_G1_MSM: data is empty");
     }
@@ -45,18 +44,17 @@ pub fn bls12_381_g1_msm_hint(data: &[u64]) -> Result<Vec<u64>> {
         std::slice::from_raw_parts(data.as_ptr().add(1) as *const u8, num_pairs * PAIR_SIZE_BYTES)
     };
 
-    let mut hints = Vec::new();
     let result: &mut [u8; 96] = &mut [0u8; 96];
     unsafe {
-        zisklib::bls12_381_g1_msm_c(result.as_mut_ptr(), bytes.as_ptr(), num_pairs, &mut hints);
+        zisklib::bls12_381_g1_msm_c(result.as_mut_ptr(), bytes.as_ptr(), num_pairs);
     }
 
-    Ok(hints)
+    Ok(())
 }
 
 /// Processes an `HINT_BLS12_381_G2_ADD` hint.
 #[inline]
-pub fn bls12_381_g2_add_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bls12_381_g2_add_hint(data: &[u64]) -> Result<()> {
     hint_fields![A: 192, B: 192];
 
     let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 8) };
@@ -66,18 +64,17 @@ pub fn bls12_381_g2_add_hint(data: &[u64]) -> Result<Vec<u64>> {
     let a: &[u8; A_SIZE] = bytes[A_OFFSET..A_OFFSET + A_SIZE].try_into().unwrap();
     let b: &[u8; B_SIZE] = bytes[B_OFFSET..B_OFFSET + B_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     let result: &mut [u8; 192] = &mut [0u8; 192];
     unsafe {
-        zisklib::bls12_381_g2_add_c(result.as_mut_ptr(), a.as_ptr(), b.as_ptr(), &mut hints);
+        zisklib::bls12_381_g2_add_c(result.as_mut_ptr(), a.as_ptr(), b.as_ptr());
     }
 
-    Ok(hints)
+    Ok(())
 }
 
 /// Processes an `HINT_BLS12_381_G2_MSM` hint.
 #[inline]
-pub fn bls12_381_g2_msm_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bls12_381_g2_msm_hint(data: &[u64]) -> Result<()> {
     if data.is_empty() {
         anyhow::bail!("HINT_BLS12_381_G1_MSM: data is empty");
     }
@@ -97,18 +94,17 @@ pub fn bls12_381_g2_msm_hint(data: &[u64]) -> Result<Vec<u64>> {
         std::slice::from_raw_parts(data.as_ptr().add(1) as *const u8, num_pairs * PAIR_SIZE_BYTES)
     };
 
-    let mut hints = Vec::new();
     let result: &mut [u8; 192] = &mut [0u8; 192];
     unsafe {
-        zisklib::bls12_381_g2_msm_c(result.as_mut_ptr(), bytes.as_ptr(), num_pairs, &mut hints);
+        zisklib::bls12_381_g2_msm_c(result.as_mut_ptr(), bytes.as_ptr(), num_pairs);
     }
 
-    Ok(hints)
+    Ok(())
 }
 
 /// Processes an `HINT_BLS12_381_PAIRING_CHECK` hint.
 #[inline]
-pub fn bls12_381_pairing_check_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bls12_381_pairing_check_hint(data: &[u64]) -> Result<()> {
     if data.is_empty() {
         anyhow::bail!("HINT_BLS12_381_G1_MSM: data is empty");
     }
@@ -128,46 +124,43 @@ pub fn bls12_381_pairing_check_hint(data: &[u64]) -> Result<Vec<u64>> {
         std::slice::from_raw_parts(data.as_ptr().add(1) as *const u8, num_pairs * PAIR_SIZE_BYTES)
     };
 
-    let mut hints = Vec::new();
     unsafe {
-        zisklib::bls12_381_pairing_check_c(pairs.as_ptr(), num_pairs, &mut hints);
+        zisklib::bls12_381_pairing_check_c(pairs.as_ptr(), num_pairs);
     }
 
-    Ok(hints)
+    Ok(())
 }
 
 /// Processes an `HINT_BLS12_381_FP_TO_G1` hint.
 #[inline]
-pub fn bls12_381_fp_to_g1_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bls12_381_fp_to_g1_hint(data: &[u64]) -> Result<()> {
     hint_fields![FP: 6];
 
     validate_hint_length(data, EXPECTED_LEN, "HINT_BLS12_381_FP_TO_G1")?;
 
     let fp: &[u64; FP_SIZE] = data[FP_OFFSET..FP_OFFSET + FP_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     let result: &mut [u8; 96] = &mut [0u8; 96];
     unsafe {
-        zisklib::bls12_381_fp_to_g1_c(result.as_mut_ptr(), fp.as_ptr() as *const u8, &mut hints);
+        zisklib::bls12_381_fp_to_g1_c(result.as_mut_ptr(), fp.as_ptr() as *const u8);
     }
 
-    Ok(hints)
+    Ok(())
 }
 
 /// Processes an `HINT_BLS12_381_FP2_TO_G2` hint.
 #[inline]
-pub fn bls12_381_fp2_to_g2_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bls12_381_fp2_to_g2_hint(data: &[u64]) -> Result<()> {
     hint_fields![FP2: 12];
 
     validate_hint_length(data, EXPECTED_LEN, "HINT_BLS12_381_FP2_TO_G2")?;
 
     let fp2: &[u64; FP2_SIZE] = data[FP2_OFFSET..FP2_OFFSET + FP2_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     let result: &mut [u8; 192] = &mut [0u8; 192];
     unsafe {
-        zisklib::bls12_381_fp2_to_g2_c(result.as_mut_ptr(), fp2.as_ptr() as *const u8, &mut hints);
+        zisklib::bls12_381_fp2_to_g2_c(result.as_mut_ptr(), fp2.as_ptr() as *const u8);
     }
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos-hints/src/handlers/bn254.rs
+++ b/ziskos-hints/src/handlers/bn254.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 /// Processes an `HINT_BN254_G1_ADD` hint.
 #[inline]
-pub fn bn254_g1_add_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bn254_g1_add_hint(data: &[u64]) -> Result<()> {
     hint_fields![P1: 64, P2: 64];
 
     let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 8) };
@@ -14,18 +14,17 @@ pub fn bn254_g1_add_hint(data: &[u64]) -> Result<Vec<u64>> {
     let p1: &[u8; P1_SIZE] = bytes[P1_OFFSET..P1_OFFSET + P1_SIZE].try_into().unwrap();
     let p2: &[u8; P2_SIZE] = bytes[P2_OFFSET..P2_OFFSET + P2_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     let result: &mut [u8; 64] = &mut [0u8; 64];
     unsafe {
-        zisklib::bn254_g1_add_c(p1.as_ptr(), p2.as_ptr(), result.as_mut_ptr(), &mut hints);
+        zisklib::bn254_g1_add_c(p1.as_ptr(), p2.as_ptr(), result.as_mut_ptr());
     }
 
-    Ok(hints)
+    Ok(())
 }
 
 /// Processes an `HINT_BN254_G1_MUL` hint.
 #[inline]
-pub fn bn254_g1_mul_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bn254_g1_mul_hint(data: &[u64]) -> Result<()> {
     hint_fields![POINT: 64, SCALAR: 32];
 
     let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 8) };
@@ -37,18 +36,17 @@ pub fn bn254_g1_mul_hint(data: &[u64]) -> Result<Vec<u64>> {
     let scalar: &[u8; SCALAR_SIZE] =
         bytes[SCALAR_OFFSET..SCALAR_OFFSET + SCALAR_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     let result: &mut [u8; 64] = &mut [0u8; 64];
     unsafe {
-        zisklib::bn254_g1_mul_c(point.as_ptr(), scalar.as_ptr(), result.as_mut_ptr(), &mut hints);
+        zisklib::bn254_g1_mul_c(point.as_ptr(), scalar.as_ptr(), result.as_mut_ptr());
     }
 
-    Ok(hints)
+    Ok(())
 }
 
 /// Processes an `HINT_BN254_PAIRING_CHECK` hint.
 #[inline]
-pub fn bn254_pairing_check_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn bn254_pairing_check_hint(data: &[u64]) -> Result<()> {
     const G1_WORDS: usize = 8;
     const G2_WORDS: usize = 16;
     const PAIR_WORDS: usize = G1_WORDS + G2_WORDS;
@@ -65,10 +63,9 @@ pub fn bn254_pairing_check_hint(data: &[u64]) -> Result<Vec<u64>> {
 
     let pairs_data = &data[1..];
 
-    let mut hints = Vec::new();
     unsafe {
-        zisklib::bn254_pairing_check_c(pairs_data.as_ptr() as *const u8, num_pairs, &mut hints);
+        zisklib::bn254_pairing_check_c(pairs_data.as_ptr() as *const u8, num_pairs);
     }
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos-hints/src/handlers/keccak256.rs
+++ b/ziskos-hints/src/handlers/keccak256.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 /// Processes an `HINT_KECCAK256` hint.
 #[inline]
-pub fn keccak256_hint(data: &[u64], data_len_bytes: usize) -> Result<Vec<u64>> {
+pub fn keccak256_hint(data: &[u64], data_len_bytes: usize) -> Result<()> {
     let data_len_words = data_len_bytes.div_ceil(8);
 
     if data.len() != data_len_words {
@@ -18,8 +18,7 @@ pub fn keccak256_hint(data: &[u64], data_len_bytes: usize) -> Result<Vec<u64>> {
 
     let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data_len_bytes) };
 
-    let mut hints = Vec::new();
-    zisklib::keccak256(bytes, &mut hints);
+    zisklib::keccak256(bytes);
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos-hints/src/handlers/kzg.rs
+++ b/ziskos-hints/src/handlers/kzg.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 /// Processes an `HINT_VERIFY_KZG_PROOF` hint.
 #[inline]
-pub fn verify_kzg_proof_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn verify_kzg_proof_hint(data: &[u64]) -> Result<()> {
     hint_fields![Z: 32, Y: 32, COMMITMENT: 48, PROOF: 48];
 
     let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 8) };
@@ -18,16 +18,9 @@ pub fn verify_kzg_proof_hint(data: &[u64]) -> Result<Vec<u64>> {
     let proof: &[u8; PROOF_SIZE] =
         bytes[PROOF_OFFSET..PROOF_OFFSET + PROOF_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     unsafe {
-        zisklib::verify_kzg_proof_c(
-            z.as_ptr(),
-            y.as_ptr(),
-            commitment.as_ptr(),
-            proof.as_ptr(),
-            &mut hints,
-        )
+        zisklib::verify_kzg_proof_c(z.as_ptr(), y.as_ptr(), commitment.as_ptr(), proof.as_ptr())
     };
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos-hints/src/handlers/modexp.rs
+++ b/ziskos-hints/src/handlers/modexp.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 // Processes a `MODEXP` hint.
 #[inline]
-pub fn modexp_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn modexp_hint(data: &[u64]) -> Result<()> {
     let mut pos = 0;
     let (base, base_len) = read_field_bytes(data, &mut pos)?;
     let (exp, exp_len) = read_field_bytes(data, &mut pos)?;
@@ -21,7 +21,6 @@ pub fn modexp_hint(data: &[u64]) -> Result<Vec<u64>> {
         );
     }
 
-    let mut hints = Vec::new();
     let mut result = vec![0u8; modulus_len];
     unsafe {
         zisklib::modexp_bytes_c(
@@ -32,9 +31,8 @@ pub fn modexp_hint(data: &[u64]) -> Result<Vec<u64>> {
             modulus.as_ptr(),
             modulus_len,
             result.as_mut_ptr(),
-            &mut hints,
         );
     }
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos-hints/src/handlers/ripemd160.rs
+++ b/ziskos-hints/src/handlers/ripemd160.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 /// Processes a `HINT_RIPEMD160` hint.
 #[inline]
-pub fn ripemd160_hint(data: &[u64], data_len_bytes: usize) -> Result<Vec<u64>> {
+pub fn ripemd160_hint(data: &[u64], data_len_bytes: usize) -> Result<()> {
     let data_len_words = data_len_bytes.div_ceil(8);
 
     if data.len() != data_len_words {
@@ -18,8 +18,7 @@ pub fn ripemd160_hint(data: &[u64], data_len_bytes: usize) -> Result<Vec<u64>> {
 
     let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data_len_bytes) };
 
-    let mut hints = Vec::new();
-    zisklib::ripemd160(bytes, &mut hints);
+    zisklib::ripemd160(bytes);
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos-hints/src/handlers/secp256k1.rs
+++ b/ziskos-hints/src/handlers/secp256k1.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 /// Processes a `HINT_SECP256K1_ECDSA_VERIFY` hint.
 /// Generates witness for `zkvm_secp256k1_verify` by running the verify computation.
 #[inline]
-pub fn secp256k1_ecdsa_verify_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn secp256k1_ecdsa_verify_hint(data: &[u64]) -> Result<()> {
     hint_fields![SIG: 8, MSG: 4, PK: 8];
 
     validate_hint_length(data, EXPECTED_LEN, "HINT_SECP256K1_ECDSA_VERIFY")?;
@@ -16,22 +16,20 @@ pub fn secp256k1_ecdsa_verify_hint(data: &[u64]) -> Result<Vec<u64>> {
     let msg: &[u64; MSG_SIZE] = data[MSG_OFFSET..MSG_OFFSET + MSG_SIZE].try_into().unwrap();
     let pk: &[u64; PK_SIZE] = data[PK_OFFSET..PK_OFFSET + PK_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     unsafe {
         zisklib::secp256k1_ecdsa_verify_c(
             sig.as_ptr() as *const u8,
             msg.as_ptr() as *const u8,
             pk.as_ptr() as *const u8,
-            &mut hints,
         );
     }
 
-    Ok(hints)
+    Ok(())
 }
 
 /// Processes a `HINT_SECP256K1_ECRECOVER` hint.
 #[inline]
-pub fn secp256k1_ecrecover_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn secp256k1_ecrecover_hint(data: &[u64]) -> Result<()> {
     hint_fields![SIG: 8, RECID: 1, MSG: 4];
 
     validate_hint_length(data, EXPECTED_LEN, "HINT_SECP256K1_ECRECOVER")?;
@@ -40,7 +38,6 @@ pub fn secp256k1_ecrecover_hint(data: &[u64]) -> Result<Vec<u64>> {
     let recid: u8 = data[RECID_OFFSET] as u8;
     let msg: &[u64; MSG_SIZE] = data[MSG_OFFSET..MSG_OFFSET + MSG_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     let result: &mut [u8; 64] = &mut [0u8; 64];
     unsafe {
         zisklib::secp256k1_ecdsa_recover_c(
@@ -48,9 +45,8 @@ pub fn secp256k1_ecrecover_hint(data: &[u64]) -> Result<Vec<u64>> {
             recid,
             msg.as_ptr() as *const u8,
             result.as_mut_ptr(),
-            &mut hints,
         );
     }
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos-hints/src/handlers/secp256r1.rs
+++ b/ziskos-hints/src/handlers/secp256r1.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 /// Processes an `HINT_SECP256R1_ECDSA_VERIFY` hint.
 #[inline]
-pub fn secp256r1_ecdsa_verify_hint(data: &[u64]) -> Result<Vec<u64>> {
+pub fn secp256r1_ecdsa_verify_hint(data: &[u64]) -> Result<()> {
     hint_fields![MSG: 4, SIG: 8, PK: 8];
 
     validate_hint_length(data, EXPECTED_LEN, "HINT_SECP256R1_ECDSA_VERIFY")?;
@@ -15,15 +15,13 @@ pub fn secp256r1_ecdsa_verify_hint(data: &[u64]) -> Result<Vec<u64>> {
     let sig: &[u64; SIG_SIZE] = data[SIG_OFFSET..SIG_OFFSET + SIG_SIZE].try_into().unwrap();
     let pk: &[u64; PK_SIZE] = data[PK_OFFSET..PK_OFFSET + PK_SIZE].try_into().unwrap();
 
-    let mut hints = Vec::new();
     unsafe {
         zisklib::secp256r1_ecdsa_verify_c(
             msg.as_ptr() as *const u8,
             sig.as_ptr() as *const u8,
             pk.as_ptr() as *const u8,
-            &mut hints,
         );
     }
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos-hints/src/handlers/sha256.rs
+++ b/ziskos-hints/src/handlers/sha256.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 /// Processes an `HINT_SHA256` hint.
 #[inline]
-pub fn sha256_hint(data: &[u64], data_len_bytes: usize) -> Result<Vec<u64>> {
+pub fn sha256_hint(data: &[u64], data_len_bytes: usize) -> Result<()> {
     let data_len_words = data_len_bytes.div_ceil(8);
 
     if data.len() != data_len_words {
@@ -18,8 +18,7 @@ pub fn sha256_hint(data: &[u64], data_len_bytes: usize) -> Result<Vec<u64>> {
 
     let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data_len_bytes) };
 
-    let mut hints = Vec::new();
-    zisklib::sha256(bytes, &mut hints);
+    zisklib::sha256(bytes);
 
-    Ok(hints)
+    Ok(())
 }

--- a/ziskos/entrypoint/src/hints_collect.rs
+++ b/ziskos/entrypoint/src/hints_collect.rs
@@ -1,0 +1,46 @@
+#[cfg(feature = "hints")]
+use std::cell::{Cell, RefCell};
+
+#[cfg(feature = "hints")]
+thread_local! {
+    static BUFFER: RefCell<Vec<u64>> = RefCell::new(Vec::with_capacity(64));
+    static DEPTH: Cell<u32> = Cell::new(0);
+}
+
+/// Append a single u64 to the hints buffer.
+#[cfg(feature = "hints")]
+#[inline(always)]
+pub fn hints_push(val: u64) {
+    BUFFER.with(|b| b.borrow_mut().push(val));
+}
+
+/// Append a slice of u64 values to the hints buffer.
+#[cfg(feature = "hints")]
+#[inline(always)]
+pub fn hints_extend(slice: &[u64]) {
+    BUFFER.with(|b| b.borrow_mut().extend_from_slice(slice));
+}
+
+/// Clear the hints buffer and begin a collection scope.
+/// Panics if called while another scope is active (reentrant call).
+#[cfg(feature = "hints")]
+#[inline]
+pub fn hints_clear() {
+    DEPTH.with(|d| {
+        assert_eq!(
+            d.get(),
+            0,
+            "hints_clear: reentrant call detected — nested handler invocations are not supported"
+        );
+        d.set(1);
+    });
+    BUFFER.with(|b| b.borrow_mut().clear());
+}
+
+/// Drain all collected hints, end the collection scope, and return them.
+#[cfg(feature = "hints")]
+#[inline]
+pub fn hints_drain() -> Vec<u64> {
+    DEPTH.with(|d| d.set(0));
+    BUFFER.with(|b| std::mem::replace(&mut *b.borrow_mut(), Vec::with_capacity(64)))
+}

--- a/ziskos/entrypoint/src/hints_collect.rs
+++ b/ziskos/entrypoint/src/hints_collect.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "hints")]
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 
 #[cfg(feature = "hints")]
 thread_local! {
     static BUFFER: RefCell<Vec<u64>> = RefCell::new(Vec::with_capacity(64));
-    static DEPTH: Cell<u32> = const { Cell::new(0) };
 }
 
 /// Append a single u64 to the hints buffer.
@@ -21,26 +20,9 @@ pub fn hints_extend(slice: &[u64]) {
     BUFFER.with(|b| b.borrow_mut().extend_from_slice(slice));
 }
 
-/// Clear the hints buffer and begin a collection scope.
-/// Panics if called while another scope is active (reentrant call).
-#[cfg(feature = "hints")]
-#[inline]
-pub fn hints_clear() {
-    DEPTH.with(|d| {
-        assert_eq!(
-            d.get(),
-            0,
-            "hints_clear: reentrant call detected — nested handler invocations are not supported"
-        );
-        d.set(1);
-    });
-    BUFFER.with(|b| b.borrow_mut().clear());
-}
-
-/// Drain all collected hints, end the collection scope, and return them.
+/// Drain all collected hints and return them.
 #[cfg(feature = "hints")]
 #[inline]
 pub fn hints_drain() -> Vec<u64> {
-    DEPTH.with(|d| d.set(0));
     BUFFER.with(|b| std::mem::replace(&mut *b.borrow_mut(), Vec::with_capacity(64)))
 }

--- a/ziskos/entrypoint/src/hints_collect.rs
+++ b/ziskos/entrypoint/src/hints_collect.rs
@@ -4,7 +4,7 @@ use std::cell::{Cell, RefCell};
 #[cfg(feature = "hints")]
 thread_local! {
     static BUFFER: RefCell<Vec<u64>> = RefCell::new(Vec::with_capacity(64));
-    static DEPTH: Cell<u32> = Cell::new(0);
+    static DEPTH: Cell<u32> = const { Cell::new(0) };
 }
 
 /// Append a single u64 to the hints buffer.

--- a/ziskos/entrypoint/src/lib.rs
+++ b/ziskos/entrypoint/src/lib.rs
@@ -16,6 +16,7 @@ mod profile;
 pub use fcall::*;
 pub mod io;
 pub use profile::*;
+pub mod hints_collect;
 pub mod syscalls;
 pub mod zisklib;
 pub mod ziskos_definitions;

--- a/ziskos/entrypoint/src/syscalls/add256.rs
+++ b/ziskos/entrypoint/src/syscalls/add256.rs
@@ -30,17 +30,14 @@ pub struct SyscallAdd256Params<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_add256")]
-pub extern "C" fn syscall_add256(
-    params: &mut SyscallAdd256Params,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u64 {
+pub extern "C" fn syscall_add256(params: &mut SyscallAdd256Params) -> u64 {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let cout = precompiles_helpers::add256(params.a, params.b, params.cin, params.c);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(params.c);
-            hints.push(cout);
+            crate::hints_collect::hints_extend(params.c);
+            crate::hints_collect::hints_push(cout);
         }
         cout
     }

--- a/ziskos/entrypoint/src/syscalls/arith256.rs
+++ b/ziskos/entrypoint/src/syscalls/arith256.rs
@@ -33,10 +33,7 @@ pub struct SyscallArith256Params<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_arith256")]
-pub extern "C" fn syscall_arith256(
-    params: &mut SyscallArith256Params,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_arith256(params: &mut SyscallArith256Params) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_ARITH256_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -44,8 +41,8 @@ pub extern "C" fn syscall_arith256(
         precompiles_helpers::arith256(params.a, params.b, params.c, params.dl, params.dh);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(params.dl);
-            hints.extend_from_slice(params.dh);
+            crate::hints_collect::hints_extend(params.dl);
+            crate::hints_collect::hints_extend(params.dh);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/arith256_mod.rs
+++ b/ziskos/entrypoint/src/syscalls/arith256_mod.rs
@@ -36,10 +36,7 @@ pub struct SyscallArith256ModParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_arith256_mod")]
-pub extern "C" fn syscall_arith256_mod(
-    params: &mut SyscallArith256ModParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_arith256_mod(params: &mut SyscallArith256ModParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_ARITH256_MOD_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -47,7 +44,7 @@ pub extern "C" fn syscall_arith256_mod(
         precompiles_helpers::arith256_mod(params.a, params.b, params.c, params.module, params.d);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(params.d);
+            crate::hints_collect::hints_extend(params.d);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/arith384_mod.rs
+++ b/ziskos/entrypoint/src/syscalls/arith384_mod.rs
@@ -36,10 +36,7 @@ pub struct SyscallArith384ModParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_arith384_mod")]
-pub extern "C" fn syscall_arith384_mod(
-    params: &mut SyscallArith384ModParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_arith384_mod(params: &mut SyscallArith384ModParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_ARITH384_MOD_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -47,7 +44,7 @@ pub extern "C" fn syscall_arith384_mod(
         precompiles_helpers::arith384_mod(params.a, params.b, params.c, params.module, params.d);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(params.d);
+            crate::hints_collect::hints_extend(params.d);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/blake2br.rs
+++ b/ziskos/entrypoint/src/syscalls/blake2br.rs
@@ -20,10 +20,7 @@ pub struct SyscallBlake2bRoundParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_blake2b_round")]
-pub extern "C" fn syscall_blake2b_round(
-    params: &mut SyscallBlake2bRoundParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_blake2b_round(params: &mut SyscallBlake2bRoundParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BLAKE2B_ROUND_ID, params);
 
@@ -33,7 +30,7 @@ pub extern "C" fn syscall_blake2b_round(
 
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(params.state);
+            crate::hints_collect::hints_extend(params.state);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bls12_381_complex_add.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_complex_add.rs
@@ -36,10 +36,7 @@ pub struct SyscallBls12_381ComplexAddParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bls12_381_complex_add")]
-pub extern "C" fn syscall_bls12_381_complex_add(
-    params: &mut SyscallBls12_381ComplexAddParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bls12_381_complex_add(params: &mut SyscallBls12_381ComplexAddParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BLS12_381_COMPLEX_ADD_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -52,7 +49,7 @@ pub extern "C" fn syscall_bls12_381_complex_add(
         params.f1.y.copy_from_slice(&f3[6..12]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&f3);
+            crate::hints_collect::hints_extend(&f3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bls12_381_complex_mul.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_complex_mul.rs
@@ -36,10 +36,7 @@ pub struct SyscallBls12_381ComplexMulParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bls12_381_complex_mul")]
-pub extern "C" fn syscall_bls12_381_complex_mul(
-    params: &mut SyscallBls12_381ComplexMulParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bls12_381_complex_mul(params: &mut SyscallBls12_381ComplexMulParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BLS12_381_COMPLEX_MUL_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -52,7 +49,7 @@ pub extern "C" fn syscall_bls12_381_complex_mul(
         params.f1.y.copy_from_slice(&f3[6..12]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&f3);
+            crate::hints_collect::hints_extend(&f3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bls12_381_complex_sub.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_complex_sub.rs
@@ -36,10 +36,7 @@ pub struct SyscallBls12_381ComplexSubParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bls12_381_complex_sub")]
-pub extern "C" fn syscall_bls12_381_complex_sub(
-    params: &mut SyscallBls12_381ComplexSubParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bls12_381_complex_sub(params: &mut SyscallBls12_381ComplexSubParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BLS12_381_COMPLEX_SUB_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -52,7 +49,7 @@ pub extern "C" fn syscall_bls12_381_complex_sub(
         params.f1.y.copy_from_slice(&f3[6..12]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&f3);
+            crate::hints_collect::hints_extend(&f3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bls12_381_curve_add.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_curve_add.rs
@@ -35,10 +35,7 @@ pub struct SyscallBls12_381CurveAddParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bls12_381_curve_add")]
-pub extern "C" fn syscall_bls12_381_curve_add(
-    params: &mut SyscallBls12_381CurveAddParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bls12_381_curve_add(params: &mut SyscallBls12_381CurveAddParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BLS12_381_CURVE_ADD_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -51,7 +48,7 @@ pub extern "C" fn syscall_bls12_381_curve_add(
         params.p1.y.copy_from_slice(&p3[6..12]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&p3);
+            crate::hints_collect::hints_extend(&p3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bls12_381_curve_dbl.rs
+++ b/ziskos/entrypoint/src/syscalls/bls12_381_curve_dbl.rs
@@ -27,10 +27,7 @@ use super::point::SyscallPoint384;
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bls12_381_curve_dbl")]
-pub extern "C" fn syscall_bls12_381_curve_dbl(
-    p1: &mut SyscallPoint384,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bls12_381_curve_dbl(p1: &mut SyscallPoint384) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BLS12_381_CURVE_DBL_ID, p1);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -42,7 +39,7 @@ pub extern "C" fn syscall_bls12_381_curve_dbl(
         p1.y.copy_from_slice(&p2[6..12]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&p2);
+            crate::hints_collect::hints_extend(&p2);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bn254_complex_add.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_complex_add.rs
@@ -36,10 +36,7 @@ pub struct SyscallBn254ComplexAddParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bn254_complex_add")]
-pub extern "C" fn syscall_bn254_complex_add(
-    params: &mut SyscallBn254ComplexAddParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bn254_complex_add(params: &mut SyscallBn254ComplexAddParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BN254_COMPLEX_ADD_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -52,7 +49,7 @@ pub extern "C" fn syscall_bn254_complex_add(
         params.f1.y.copy_from_slice(&f3[4..8]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&f3);
+            crate::hints_collect::hints_extend(&f3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bn254_complex_mul.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_complex_mul.rs
@@ -36,10 +36,7 @@ pub struct SyscallBn254ComplexMulParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bn254_complex_mul")]
-pub extern "C" fn syscall_bn254_complex_mul(
-    params: &mut SyscallBn254ComplexMulParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bn254_complex_mul(params: &mut SyscallBn254ComplexMulParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BN254_COMPLEX_MUL_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -52,7 +49,7 @@ pub extern "C" fn syscall_bn254_complex_mul(
         params.f1.y.copy_from_slice(&f3[4..8]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&f3);
+            crate::hints_collect::hints_extend(&f3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bn254_complex_sub.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_complex_sub.rs
@@ -36,10 +36,7 @@ pub struct SyscallBn254ComplexSubParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bn254_complex_sub")]
-pub extern "C" fn syscall_bn254_complex_sub(
-    params: &mut SyscallBn254ComplexSubParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bn254_complex_sub(params: &mut SyscallBn254ComplexSubParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BN254_COMPLEX_SUB_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -52,7 +49,7 @@ pub extern "C" fn syscall_bn254_complex_sub(
         params.f1.y.copy_from_slice(&f3[4..8]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&f3);
+            crate::hints_collect::hints_extend(&f3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bn254_curve_add.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_curve_add.rs
@@ -35,10 +35,7 @@ pub struct SyscallBn254CurveAddParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bn254_curve_add")]
-pub extern "C" fn syscall_bn254_curve_add(
-    params: &mut SyscallBn254CurveAddParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bn254_curve_add(params: &mut SyscallBn254CurveAddParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BN254_CURVE_ADD_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -51,7 +48,7 @@ pub extern "C" fn syscall_bn254_curve_add(
         params.p1.y.copy_from_slice(&p3[4..8]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&p3);
+            crate::hints_collect::hints_extend(&p3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/bn254_curve_dbl.rs
+++ b/ziskos/entrypoint/src/syscalls/bn254_curve_dbl.rs
@@ -27,10 +27,7 @@ use super::point::SyscallPoint256;
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_bn254_curve_dbl")]
-pub extern "C" fn syscall_bn254_curve_dbl(
-    p1: &mut SyscallPoint256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_bn254_curve_dbl(p1: &mut SyscallPoint256) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_BN254_CURVE_DBL_ID, p1);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -42,7 +39,7 @@ pub extern "C" fn syscall_bn254_curve_dbl(
         p1.y.copy_from_slice(&p2[4..8]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&p2);
+            crate::hints_collect::hints_extend(&p2);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/keccakf.rs
+++ b/ziskos/entrypoint/src/syscalls/keccakf.rs
@@ -23,10 +23,7 @@ use tiny_keccak::keccakf;
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_keccak_f")]
-pub unsafe extern "C" fn syscall_keccak_f(
-    state: *mut [u64; 25],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub unsafe extern "C" fn syscall_keccak_f(state: *mut [u64; 25]) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_KECCAKF_ID, state);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -37,7 +34,7 @@ pub unsafe extern "C" fn syscall_keccak_f(
         // Store results in hints vector
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(unsafe { &*state });
+            crate::hints_collect::hints_extend(unsafe { &*state });
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/poseidon2.rs
+++ b/ziskos/entrypoint/src/syscalls/poseidon2.rs
@@ -23,10 +23,7 @@ use fields::{poseidon2_hash, Goldilocks, Poseidon16, PrimeField64};
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_poseidon2")]
-pub unsafe extern "C" fn syscall_poseidon2(
-    state: *mut [u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub unsafe extern "C" fn syscall_poseidon2(state: *mut [u64; 16]) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_POSEIDON2_ID, state);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -44,7 +41,7 @@ pub unsafe extern "C" fn syscall_poseidon2(
         #[cfg(feature = "hints")]
         {
             // For hints, we store the new state in the hints vector
-            hints.extend_from_slice(state);
+            crate::hints_collect::hints_extend(state);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/secp256k1_add.rs
+++ b/ziskos/entrypoint/src/syscalls/secp256k1_add.rs
@@ -35,10 +35,7 @@ pub struct SyscallSecp256k1AddParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_secp256k1_add")]
-pub extern "C" fn syscall_secp256k1_add(
-    params: &mut SyscallSecp256k1AddParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_secp256k1_add(params: &mut SyscallSecp256k1AddParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_SECP256K1_ADD_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -51,7 +48,7 @@ pub extern "C" fn syscall_secp256k1_add(
         params.p1.y.copy_from_slice(&p3[4..8]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&p3);
+            crate::hints_collect::hints_extend(&p3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/secp256k1_dbl.rs
+++ b/ziskos/entrypoint/src/syscalls/secp256k1_dbl.rs
@@ -27,10 +27,7 @@ use super::point::SyscallPoint256;
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_secp256k1_dbl")]
-pub extern "C" fn syscall_secp256k1_dbl(
-    p1: &mut SyscallPoint256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_secp256k1_dbl(p1: &mut SyscallPoint256) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_SECP256K1_DBL_ID, p1);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -42,7 +39,7 @@ pub extern "C" fn syscall_secp256k1_dbl(
         p1.y.copy_from_slice(&p3[4..8]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&p3);
+            crate::hints_collect::hints_extend(&p3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/secp256r1_add.rs
+++ b/ziskos/entrypoint/src/syscalls/secp256r1_add.rs
@@ -35,10 +35,7 @@ pub struct SyscallSecp256r1AddParams<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_secp256r1_add")]
-pub extern "C" fn syscall_secp256r1_add(
-    params: &mut SyscallSecp256r1AddParams,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_secp256r1_add(params: &mut SyscallSecp256r1AddParams) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_SECP256R1_ADD_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -51,7 +48,7 @@ pub extern "C" fn syscall_secp256r1_add(
         params.p1.y.copy_from_slice(&p3[4..8]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&p3);
+            crate::hints_collect::hints_extend(&p3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/secp256r1_dbl.rs
+++ b/ziskos/entrypoint/src/syscalls/secp256r1_dbl.rs
@@ -27,10 +27,7 @@ use super::point::SyscallPoint256;
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_secp256r1_dbl")]
-pub extern "C" fn syscall_secp256r1_dbl(
-    p1: &mut SyscallPoint256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_secp256r1_dbl(p1: &mut SyscallPoint256) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_SECP256R1_DBL_ID, p1);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -42,7 +39,7 @@ pub extern "C" fn syscall_secp256r1_dbl(
         p1.y.copy_from_slice(&p3[4..8]);
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(&p3);
+            crate::hints_collect::hints_extend(&p3);
         }
     }
 }

--- a/ziskos/entrypoint/src/syscalls/sha256f.rs
+++ b/ziskos/entrypoint/src/syscalls/sha256f.rs
@@ -35,10 +35,7 @@ pub struct SyscallSha256Params<'a> {
 #[allow(unused_variables)]
 #[cfg_attr(not(feature = "hints"), no_mangle)]
 #[cfg_attr(feature = "hints", export_name = "hints_syscall_sha256_f")]
-pub extern "C" fn syscall_sha256_f(
-    params: &mut SyscallSha256Params,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub extern "C" fn syscall_sha256_f(params: &mut SyscallSha256Params) {
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     ziskos_syscall!(zisk_definitions::SYSCALL_SHA256F_ID, params);
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
@@ -47,7 +44,7 @@ pub extern "C" fn syscall_sha256_f(
 
         #[cfg(feature = "hints")]
         {
-            hints.extend_from_slice(params.state);
+            crate::hints_collect::hints_extend(params.state);
         }
     }
 }

--- a/ziskos/entrypoint/src/zisklib/fcalls/big_int256_div.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/big_int256_div.rs
@@ -28,19 +28,15 @@ cfg_if! {
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_bigint256_div(
-    a_value: &[u64; 4],
-    b_value: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> ([u64; 4], [u64; 4]) {
+pub fn fcall_bigint256_div(a_value: &[u64; 4], b_value: &[u64; 4]) -> ([u64; 4], [u64; 4]) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let (quotient, remainder) = big_int256_div(a_value, b_value);
         #[cfg(feature = "hints")]
         {
-            hints.push(8);
-            hints.extend_from_slice(&quotient);
-            hints.extend_from_slice(&remainder);
+            crate::hints_collect::hints_push(8);
+            crate::hints_collect::hints_extend(&quotient);
+            crate::hints_collect::hints_extend(&remainder);
         }
 
         (quotient, remainder)

--- a/ziskos/entrypoint/src/zisklib/fcalls/big_int_div.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/big_int_div.rs
@@ -26,7 +26,6 @@ pub fn fcall_division(
     b_value: &[u64],
     quo: &mut [u64],
     rem: &mut [u64],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> (usize, usize) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
@@ -39,11 +38,11 @@ pub fn fcall_division(
         let len_rem = rem_vector.len();
         #[cfg(feature = "hints")]
         {
-            hints.push(len_quo as u64 + len_rem as u64 + 2);
-            hints.push(len_quo as u64);
-            hints.extend_from_slice(&quo_vector);
-            hints.push(len_rem as u64);
-            hints.extend_from_slice(&rem_vector);
+            crate::hints_collect::hints_push(len_quo as u64 + len_rem as u64 + 2);
+            crate::hints_collect::hints_push(len_quo as u64);
+            crate::hints_collect::hints_extend(&quo_vector);
+            crate::hints_collect::hints_push(len_rem as u64);
+            crate::hints_collect::hints_extend(&rem_vector);
         }
 
         (len_quo, len_rem)

--- a/ziskos/entrypoint/src/zisklib/fcalls/bin_decomp.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bin_decomp.rs
@@ -14,10 +14,7 @@ cfg_if! {
 
 /// Computes the binary decomposition of a NON-ZERO unsigned integer `x` into its bits.
 #[allow(unused_variables)]
-pub fn fcall_bin_decomp(
-    x_val: &[u64],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> (usize, Vec<u64>) {
+pub fn fcall_bin_decomp(x_val: &[u64]) -> (usize, Vec<u64>) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let len_x = x_val.len();
@@ -26,9 +23,9 @@ pub fn fcall_bin_decomp(
         let bits_u64: Vec<u64> = bits.into_iter().map(|b| b as u64).collect();
         #[cfg(feature = "hints")]
         {
-            hints.push(len_bits as u64 + 1);
-            hints.push(len_bits as u64);
-            hints.extend_from_slice(&bits_u64);
+            crate::hints_collect::hints_push(len_bits as u64 + 1);
+            crate::hints_collect::hints_push(len_bits as u64);
+            crate::hints_collect::hints_extend(&bits_u64);
         }
 
         (len_bits, bits_u64)

--- a/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/fp.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/fp.rs
@@ -30,17 +30,14 @@ cfg_if! {
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_bls12_381_fp_inv(
-    p_value: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 6] {
+pub fn fcall_bls12_381_fp_inv(p_value: &[u64; 6]) -> [u64; 6] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let result: [u64; 6] = bls12_381_fp_inv(p_value);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
         result
     }
@@ -83,18 +80,15 @@ pub fn fcall_bls12_381_fp_inv(
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_bls12_381_fp_sqrt(
-    p_value: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 7] {
+pub fn fcall_bls12_381_fp_sqrt(p_value: &[u64; 6]) -> [u64; 7] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let mut result: [u64; 7] = [0; 7];
         bls12_381_fp_sqrt(p_value, &mut result);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
         result
     }

--- a/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/fp2.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/fp2.rs
@@ -31,17 +31,14 @@ cfg_if! {
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_bls12_381_fp2_inv(
-    p_value: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn fcall_bls12_381_fp2_inv(p_value: &[u64; 12]) -> [u64; 12] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let result: [u64; 12] = bls12_381_fp2_inv(p_value);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
         result
     }
@@ -90,17 +87,14 @@ pub fn fcall_bls12_381_fp2_inv(
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_bls12_381_fp2_sqrt(
-    p_value: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 13] {
+pub fn fcall_bls12_381_fp2_sqrt(p_value: &[u64; 12]) -> [u64; 13] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let result: [u64; 13] = bls12_381_fp2_sqrt_13(p_value);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
         result
     }

--- a/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bls12_381/twist.rs
@@ -28,7 +28,6 @@ cfg_if! {
 pub fn fcall_bls12_381_twist_add_line_coeffs(
     p1_value: &[u64; 24],
     p2_value: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> ([u64; 12], [u64; 12]) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
@@ -40,9 +39,9 @@ pub fn fcall_bls12_381_twist_add_line_coeffs(
             bls12_381_twist_add_line_coeffs(&x1, &y1, &x2, &y2);
         #[cfg(feature = "hints")]
         {
-            hints.push(24);
-            hints.extend_from_slice(&lambda);
-            hints.extend_from_slice(&mu);
+            crate::hints_collect::hints_push(24);
+            crate::hints_collect::hints_extend(&lambda);
+            crate::hints_collect::hints_extend(&mu);
         }
 
         (lambda, mu)
@@ -106,10 +105,7 @@ pub fn fcall_bls12_381_twist_add_line_coeffs(
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_bls12_381_twist_dbl_line_coeffs(
-    p_value: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> ([u64; 12], [u64; 12]) {
+pub fn fcall_bls12_381_twist_dbl_line_coeffs(p_value: &[u64; 24]) -> ([u64; 12], [u64; 12]) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let x: [u64; 12] = p_value[0..12].try_into().unwrap();
@@ -117,9 +113,9 @@ pub fn fcall_bls12_381_twist_dbl_line_coeffs(
         let (lambda, mu): ([u64; 12], [u64; 12]) = bls12_381_twist_dbl_line_coeffs(&x, &y);
         #[cfg(feature = "hints")]
         {
-            hints.push(24);
-            hints.extend_from_slice(&lambda);
-            hints.extend_from_slice(&mu);
+            crate::hints_collect::hints_push(24);
+            crate::hints_collect::hints_extend(&lambda);
+            crate::hints_collect::hints_extend(&mu);
         }
         (lambda, mu)
     }

--- a/ziskos/entrypoint/src/zisklib/fcalls/bn254/fp.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bn254/fp.rs
@@ -27,17 +27,14 @@ cfg_if! {
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_bn254_fp_inv(
-    p_value: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn fcall_bn254_fp_inv(p_value: &[u64; 4]) -> [u64; 4] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let result: [u64; 4] = bn254_fp_inv(p_value);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
         result
     }

--- a/ziskos/entrypoint/src/zisklib/fcalls/bn254/fp2.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bn254/fp2.rs
@@ -27,17 +27,14 @@ cfg_if! {
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_bn254_fp2_inv(
-    p_value: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 8] {
+pub fn fcall_bn254_fp2_inv(p_value: &[u64; 8]) -> [u64; 8] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let result: [u64; 8] = bn254_fp2_inv(p_value);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
         result
     }

--- a/ziskos/entrypoint/src/zisklib/fcalls/bn254/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/bn254/twist.rs
@@ -29,7 +29,6 @@ cfg_if! {
 pub fn fcall_bn254_twist_add_line_coeffs(
     p1_value: &[u64; 16],
     p2_value: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> ([u64; 8], [u64; 8]) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
@@ -40,9 +39,9 @@ pub fn fcall_bn254_twist_add_line_coeffs(
         let (lambda, mu): ([u64; 8], [u64; 8]) = bn254_twist_add_line_coeffs(&x1, &y1, &x2, &y2);
         #[cfg(feature = "hints")]
         {
-            hints.push(16);
-            hints.extend_from_slice(&lambda);
-            hints.extend_from_slice(&mu);
+            crate::hints_collect::hints_push(16);
+            crate::hints_collect::hints_extend(&lambda);
+            crate::hints_collect::hints_extend(&mu);
         }
         (lambda, mu)
     }
@@ -97,10 +96,7 @@ pub fn fcall_bn254_twist_add_line_coeffs(
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_bn254_twist_dbl_line_coeffs(
-    p_value: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> ([u64; 8], [u64; 8]) {
+pub fn fcall_bn254_twist_dbl_line_coeffs(p_value: &[u64; 16]) -> ([u64; 8], [u64; 8]) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let x1: [u64; 8] = p_value[0..8].try_into().unwrap();
@@ -108,9 +104,9 @@ pub fn fcall_bn254_twist_dbl_line_coeffs(
         let (lambda, mu): ([u64; 8], [u64; 8]) = bn254_twist_dbl_line_coeffs(&x1, &y1);
         #[cfg(feature = "hints")]
         {
-            hints.push(16);
-            hints.extend_from_slice(&lambda);
-            hints.extend_from_slice(&mu);
+            crate::hints_collect::hints_push(16);
+            crate::hints_collect::hints_extend(&lambda);
+            crate::hints_collect::hints_extend(&mu);
         }
         (lambda, mu)
     }

--- a/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_256.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_256.rs
@@ -11,20 +11,16 @@ cfg_if! {
 }
 
 #[allow(unused_variables)]
-pub fn fcall_msb_pos_256(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> (u64, u64) {
+pub fn fcall_msb_pos_256(x: &[u64; 4], y: &[u64; 4]) -> (u64, u64) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let tmp: [u64; 8] = [x[0], x[1], x[2], x[3], y[0], y[1], y[2], y[3]];
         let (i, pos) = msb_pos_256(&tmp, 2);
         #[cfg(feature = "hints")]
         {
-            hints.push(2);
-            hints.push(i as u64);
-            hints.push(pos as u64);
+            crate::hints_collect::hints_push(2);
+            crate::hints_collect::hints_push(i as u64);
+            crate::hints_collect::hints_push(pos as u64);
         }
         (i as u64, pos as u64)
     }
@@ -39,12 +35,7 @@ pub fn fcall_msb_pos_256(
 }
 
 #[allow(unused_variables)]
-pub fn fcall_msb_pos_256_3(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    z: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> (u64, u64) {
+pub fn fcall_msb_pos_256_3(x: &[u64; 4], y: &[u64; 4], z: &[u64; 4]) -> (u64, u64) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let tmp: [u64; 12] =
@@ -52,9 +43,9 @@ pub fn fcall_msb_pos_256_3(
         let (i, pos) = msb_pos_256(&tmp, 3);
         #[cfg(feature = "hints")]
         {
-            hints.push(2);
-            hints.push(i as u64);
-            hints.push(pos as u64);
+            crate::hints_collect::hints_push(2);
+            crate::hints_collect::hints_push(i as u64);
+            crate::hints_collect::hints_push(pos as u64);
         }
         (i as u64, pos as u64)
     }

--- a/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_384.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_384.rs
@@ -11,19 +11,15 @@ cfg_if! {
 }
 
 #[allow(unused_variables)]
-pub fn fcall_msb_pos_384(
-    x: &[u64; 6],
-    y: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> (u64, u64) {
+pub fn fcall_msb_pos_384(x: &[u64; 6], y: &[u64; 6]) -> (u64, u64) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let (i, pos) = msb_pos_384(x, y);
         #[cfg(feature = "hints")]
         {
-            hints.push(2);
-            hints.push(i as u64);
-            hints.push(pos as u64);
+            crate::hints_collect::hints_push(2);
+            crate::hints_collect::hints_push(i as u64);
+            crate::hints_collect::hints_push(pos as u64);
         }
         (i as u64, pos as u64)
     }

--- a/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/ecdsa.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/ecdsa.rs
@@ -46,7 +46,6 @@ pub fn fcall_secp256k1_ecdsa_verify(
     z_value: &[u64; 4],
     r_value: &[u64; 4],
     s_value: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 8] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
@@ -66,8 +65,8 @@ pub fn fcall_secp256k1_ecdsa_verify(
         // Hint the result
         #[cfg(feature = "hints")]
         {
-            hints.push(results.len() as u64);
-            hints.extend_from_slice(&results);
+            crate::hints_collect::hints_push(results.len() as u64);
+            crate::hints_collect::hints_extend(&results);
         }
 
         results

--- a/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/fn.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/fn.rs
@@ -29,18 +29,15 @@ cfg_if! {
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_secp256k1_fn_inv(
-    p_value: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn fcall_secp256k1_fn_inv(p_value: &[u64; 4]) -> [u64; 4] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let mut result: [u64; 4] = [0; 4];
         secp256k1_fn_inv_c(p_value, &mut result);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
         result
     }
@@ -62,18 +59,15 @@ pub fn fcall_secp256k1_fn_inv(
 }
 
 #[allow(unused_variables)]
-pub fn fcall_secp256k1_fn_inv_in_place(
-    p_value: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub fn fcall_secp256k1_fn_inv_in_place(p_value: &[u64; 4]) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let mut result: [u64; 4] = [0; 4];
         secp256k1_fn_inv_c(p_value, &mut result);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
     }
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]

--- a/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/fp.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/secp256k1/fp.rs
@@ -36,18 +36,15 @@ cfg_if! {
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_secp256k1_fp_inv(
-    p_value: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn fcall_secp256k1_fp_inv(p_value: &[u64; 4]) -> [u64; 4] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let mut result: [u64; 4] = [0; 4];
         secp256k1_fp_inv_c(p_value, &mut result);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
         result
     }
@@ -69,18 +66,15 @@ pub fn fcall_secp256k1_fp_inv(
 }
 
 #[allow(unused_variables)]
-pub fn fcall_secp256k1_fp_inv_in_place(
-    p_value: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub fn fcall_secp256k1_fp_inv_in_place(p_value: &[u64; 4]) {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let mut result: [u64; 4] = [0; 4];
         secp256k1_fp_inv_c(p_value, &mut result);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
     }
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
@@ -106,19 +100,15 @@ pub fn fcall_secp256k1_fp_inv_in_place(
 /// Note that this is a *free-input call*, meaning the Zisk VM does not automatically verify the correctness
 /// of the result. It is the caller's responsibility to ensure it.
 #[allow(unused_variables)]
-pub fn fcall_secp256k1_fp_sqrt(
-    p_value: &[u64; 4],
-    parity: u64,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 5] {
+pub fn fcall_secp256k1_fp_sqrt(p_value: &[u64; 4], parity: u64) -> [u64; 5] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
         let mut result: [u64; 5] = [0; 5];
         secp256k1_fp_sqrt(p_value, parity, &mut result);
         #[cfg(feature = "hints")]
         {
-            hints.push(result.len() as u64);
-            hints.extend_from_slice(&result);
+            crate::hints_collect::hints_push(result.len() as u64);
+            crate::hints_collect::hints_extend(&result);
         }
         result
     }

--- a/ziskos/entrypoint/src/zisklib/fcalls/secp256r1/ecdsa.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/secp256r1/ecdsa.rs
@@ -46,7 +46,6 @@ pub fn fcall_secp256r1_ecdsa_verify(
     z_value: &[u64; 4],
     r_value: &[u64; 4],
     s_value: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 8] {
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
     {
@@ -66,8 +65,8 @@ pub fn fcall_secp256r1_ecdsa_verify(
         // Hint the result
         #[cfg(feature = "hints")]
         {
-            hints.push(results.len() as u64);
-            hints.extend_from_slice(&results);
+            crate::hints_collect::hints_push(results.len() as u64);
+            crate::hints_collect::hints_extend(&results);
         }
 
         results

--- a/ziskos/entrypoint/src/zisklib/lib/arith256.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/arith256.rs
@@ -1,17 +1,8 @@
 use crate::syscalls::{syscall_arith256_mod, SyscallArith256ModParams};
 
-pub fn mulmod256(
-    a: &[u64; 4],
-    b: &[u64; 4],
-    m: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn mulmod256(a: &[u64; 4], b: &[u64; 4], m: &[u64; 4]) -> [u64; 4] {
     let mut params = SyscallArith256ModParams { a, b, c: &[0u64; 4], module: m, d: &mut [0u64; 4] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
@@ -31,7 +22,6 @@ pub unsafe extern "C" fn mulmod256_c(
     b_ptr: *const u8,
     m_ptr: *const u8,
     result_ptr: *mut u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
     let a_bytes = std::slice::from_raw_parts(a_ptr, 32);
     let b_bytes = std::slice::from_raw_parts(b_ptr, 32);
@@ -42,13 +32,7 @@ pub unsafe extern "C" fn mulmod256_c(
     let b = be_bytes_to_u64_4(b_bytes.try_into().unwrap());
     let m = be_bytes_to_u64_4(m_bytes.try_into().unwrap());
 
-    let result = mulmod256(
-        &a,
-        &b,
-        &m,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let result = mulmod256(&a, &b, &m);
 
     // Convert result back to big-endian bytes
     let result_bytes = std::slice::from_raw_parts_mut(result_ptr, 32);

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/add_agtb.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/add_agtb.rs
@@ -11,12 +11,7 @@ use super::U256;
 ///
 /// # Returns
 /// The number of limbs in the result
-pub fn add_agtb(
-    a: &[U256],
-    b: &[U256],
-    out: &mut [U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> usize {
+pub fn add_agtb(a: &[U256], b: &[U256], out: &mut [U256]) -> usize {
     let len_a = a.len();
     let len_b = b.len();
     #[cfg(debug_assertions)]
@@ -38,11 +33,7 @@ pub fn add_agtb(
         cin: 0,
         c: out[0].as_limbs_mut(),
     };
-    let mut carry = syscall_add256(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut carry = syscall_add256(&mut params);
 
     for i in 1..len_b {
         // Compute a[i] + b[i] + carry
@@ -52,11 +43,7 @@ pub fn add_agtb(
             cin: carry,
             c: out[i].as_limbs_mut(),
         };
-        carry = syscall_add256(
-            &mut params,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        carry = syscall_add256(&mut params);
     }
 
     for i in len_b..len_a {
@@ -68,11 +55,7 @@ pub fn add_agtb(
                 cin: 1,
                 c: out[i].as_limbs_mut(),
             };
-            carry = syscall_add256(
-                &mut params,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            carry = syscall_add256(&mut params);
         } else {
             // Directly copy a[i] to out[i]
             out[i] = a[i];

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/add_short.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/add_short.rs
@@ -11,12 +11,7 @@ use super::U256;
 ///
 /// # Returns
 /// The number of limbs in the result
-pub fn add_short(
-    a: &[U256],
-    b: &U256,
-    out: &mut [U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> usize {
+pub fn add_short(a: &[U256], b: &U256, out: &mut [U256]) -> usize {
     let len_a = a.len();
     #[cfg(debug_assertions)]
     {
@@ -33,11 +28,7 @@ pub fn add_short(
         cin: 0,
         c: out[0].as_limbs_mut(),
     };
-    let mut carry = syscall_add256(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut carry = syscall_add256(&mut params);
 
     for i in 1..len_a {
         if carry == 1 {
@@ -48,11 +39,7 @@ pub fn add_short(
                 cin: 1,
                 c: out[i].as_limbs_mut(),
             };
-            carry = syscall_add256(
-                &mut params,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            carry = syscall_add256(&mut params);
         } else {
             // Directly copy a[i] to out[i]
             out[i] = a[i];

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/div_long.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/div_long.rs
@@ -16,11 +16,7 @@ use super::{add_agtb, mul_long, U256};
 ///
 /// # Note
 /// Not optimal for `len(b) == 1`, use `div_short` instead
-pub fn div_long(
-    a: &[U256],
-    b: &[U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> (Vec<U256>, Vec<U256>) {
+pub fn div_long(a: &[U256], b: &[U256]) -> (Vec<U256>, Vec<U256>) {
     let len_a = a.len();
     let len_b = b.len();
     #[cfg(debug_assertions)]
@@ -49,14 +45,7 @@ pub fn div_long(
     // Hint the quotient and remainder
     let mut quo_flat = vec![0u64; len_a * 4];
     let mut rem_flat = vec![0u64; len_b * 4];
-    let (limbs_quo, limbs_rem) = fcall_division(
-        a_flat,
-        b_flat,
-        &mut quo_flat,
-        &mut rem_flat,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (limbs_quo, limbs_rem) = fcall_division(a_flat, b_flat, &mut quo_flat, &mut rem_flat);
     let quo = U256::flat_to_slice(&quo_flat[..limbs_quo]);
     let rem = U256::flat_to_slice(&rem_flat[..limbs_rem]);
 
@@ -78,13 +67,7 @@ pub fn div_long(
 
     // Multiply the quotient by b
     let mut q_b = vec![U256::ZERO; len_a + 1]; // The +1 is because mul_long is a general purpose function
-    let q_b_len = mul_long(
-        quo,
-        b,
-        &mut q_b,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let q_b_len = mul_long(quo, b, &mut q_b);
 
     // Check 1 <= len(r)
     let len_rem = rem.len();
@@ -99,13 +82,7 @@ pub fn div_long(
         assert!(U256::lt_slices(rem, b), "Remainder must be less than divisor");
 
         let mut q_b_r = vec![U256::ZERO; len_a + 1]; // The +1 is because add_agtb is a general purpose function
-        let q_b_r_len = add_agtb(
-            &q_b[..q_b_len],
-            rem,
-            &mut q_b_r,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let q_b_r_len = add_agtb(&q_b[..q_b_len], rem, &mut q_b_r);
         assert!(U256::eq_slices(a, &q_b_r[..q_b_r_len]), "a != q·b + r");
     }
 

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/div_short.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/div_short.rs
@@ -11,11 +11,7 @@ use super::{add_short, mul_short, U256};
 ///
 /// # Returns
 /// A tuple of (quotient, remainder) where a = q × b + r
-pub fn div_short(
-    a: &[U256],
-    b: &U256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> (Vec<U256>, U256) {
+pub fn div_short(a: &[U256], b: &U256) -> (Vec<U256>, U256) {
     let len_a = a.len();
     #[cfg(debug_assertions)]
     {
@@ -43,14 +39,7 @@ pub fn div_short(
     // Hint the quotient and remainder
     let mut quo_flat = vec![0u64; len_a * 4];
     let mut rem_flat = [0u64; 4];
-    let (limbs_quo, _) = fcall_division(
-        a_flat,
-        b.as_limbs(),
-        &mut quo_flat,
-        &mut rem_flat,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (limbs_quo, _) = fcall_division(a_flat, b.as_limbs(), &mut quo_flat, &mut rem_flat);
     let quo = U256::flat_to_slice(&quo_flat[..limbs_quo]);
     let rem = U256::from_u64s(&rem_flat);
 
@@ -64,13 +53,7 @@ pub fn div_short(
 
     // Multiply the quotient by b
     let mut q_b = vec![U256::ZERO; len_a + 1]; // The +1 is because mul_short is a general purpose function
-    let q_b_len = mul_short(
-        quo,
-        b,
-        &mut q_b,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let q_b_len = mul_short(quo, b, &mut q_b);
 
     if rem.is_zero() {
         // If the remainder is zero, then a must be equal to q·b
@@ -80,13 +63,7 @@ pub fn div_short(
         assert!(rem.lt(b), "Remainder must be less than divisor");
 
         let mut q_b_r = vec![U256::ZERO; len_a + 1]; // The +1 is because add_short is a general purpose function
-        let q_b_r_len = add_short(
-            &q_b[..q_b_len],
-            &rem,
-            &mut q_b_r,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let q_b_r_len = add_short(&q_b[..q_b_len], &rem, &mut q_b_r);
         assert!(U256::eq_slices(a, &q_b_r[..q_b_r_len]), "a != q·b + r");
     }
 

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/modexp.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/modexp.rs
@@ -13,12 +13,7 @@ use super::{
 /// Modular exponentiation of three large numbers
 ///
 /// It assumes that modulus > 0 and len(base),len(exp),len(modulus) > 0
-pub fn modexp(
-    base: &[U256],
-    exp: &[u64],
-    modulus: &[U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Vec<U256> {
+pub fn modexp(base: &[U256], exp: &[u64], modulus: &[U256]) -> Vec<U256> {
     let len_b = base.len();
     let len_e = exp.len();
     let len_m = modulus.len();
@@ -70,47 +65,21 @@ pub fn modexp(
 
     // We can assume from now on that base,modulus > 1 and exp > 0
     if len_m == 1 {
-        modexp_short(
-            base,
-            exp,
-            &modulus[0],
-            #[cfg(feature = "hints")]
-            hints,
-        )
+        modexp_short(base, exp, &modulus[0])
     } else {
-        modexp_long(
-            base,
-            exp,
-            modulus,
-            #[cfg(feature = "hints")]
-            hints,
-        )
+        modexp_long(base, exp, modulus)
     }
 }
 
 /// Short modexp when modulus fits in a single U256
-fn modexp_short(
-    base: &[U256],
-    exp: &[u64],
-    modulus: &U256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Vec<U256> {
+fn modexp_short(base: &[U256], exp: &[u64], modulus: &U256) -> Vec<U256> {
     let len_e = exp.len();
 
     // Compute base = base (mod modulus)
-    let base = rem_short_init(
-        base,
-        modulus,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let base = rem_short_init(base, modulus);
 
     // Hint exponent bits
-    let (len, bits) = fcall_bin_decomp(
-        exp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (len, bits) = fcall_bin_decomp(exp);
 
     // We should recompose the exponent from bits to verify correctness
     let mut rec_exp = vec![0u64; len_e];
@@ -132,24 +101,11 @@ fn modexp_short(
         }
 
         // Compute out = out² (mod modulus)
-        out = square_and_reduce_short(
-            &out,
-            modulus,
-            &mut scratch,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        out = square_and_reduce_short(&out, modulus, &mut scratch);
 
         if bit == 1 {
             // Compute out = (out * base) (mod modulus)
-            out = mul_and_reduce_short(
-                &out,
-                &base,
-                modulus,
-                &mut scratch,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            out = mul_and_reduce_short(&out, &base, modulus, &mut scratch);
 
             // Recompose the exponent
             let bits_pos = len - 1 - bit_idx;
@@ -165,29 +121,15 @@ fn modexp_short(
 }
 
 /// Long modexp when modulus requires multiple U256 limbs
-fn modexp_long(
-    base: &[U256],
-    exp: &[u64],
-    modulus: &[U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Vec<U256> {
+fn modexp_long(base: &[U256], exp: &[u64], modulus: &[U256]) -> Vec<U256> {
     let len_e = exp.len();
     let len_m = modulus.len();
 
     // Compute base = base (mod modulus)
-    let base = rem_long_init(
-        base,
-        modulus,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let base = rem_long_init(base, modulus);
 
     // Hint exponent bits
-    let (len, bits) = fcall_bin_decomp(
-        exp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (len, bits) = fcall_bin_decomp(exp);
 
     // We should recompose the exponent from bits to verify correctness
     let mut rec_exp = vec![0u64; len_e];
@@ -209,24 +151,11 @@ fn modexp_long(
         }
 
         // Compute out = out² (mod modulus)
-        out = square_and_reduce_long(
-            &out,
-            modulus,
-            &mut scratch,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        out = square_and_reduce_long(&out, modulus, &mut scratch);
 
         if bit == 1 {
             // Compute out = (out * base) (mod modulus)
-            out = mul_and_reduce_long(
-                &out,
-                &base,
-                modulus,
-                &mut scratch,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            out = mul_and_reduce_long(&out, &base, modulus, &mut scratch);
 
             // Recompose the exponent
             let bits_pos = len - 1 - bit_idx;
@@ -262,7 +191,6 @@ pub(crate) unsafe fn modexp_bytes_c(
     modulus_ptr: *const u8,
     modulus_len: usize,
     result_ptr: *mut u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> usize {
     let base_bytes = std::slice::from_raw_parts(base_ptr, base_len);
     let exp_bytes = std::slice::from_raw_parts(exp_ptr, exp_len);
@@ -273,13 +201,7 @@ pub(crate) unsafe fn modexp_bytes_c(
     let exp_u64 = bytes_be_to_u64_le(exp_bytes);
     let modulus_u256 = bytes_be_to_u256_le(modulus_bytes);
 
-    let result_u256 = modexp(
-        &base_u256,
-        &exp_u64,
-        &modulus_u256,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let result_u256 = modexp(&base_u256, &exp_u64, &modulus_u256);
 
     // Convert result back to big-endian bytes with proper length
     let result = std::slice::from_raw_parts_mut(result_ptr, modulus_len);

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/mul_long.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/mul_long.rs
@@ -16,12 +16,7 @@ use super::{mul_short, rem_long, LongScratch, U256};
 ///
 /// # Note
 /// Not optimal for `len(b) == 1`, use `mul_short` instead
-pub fn mul_long(
-    a: &[U256],
-    b: &[U256],
-    out: &mut [U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> usize {
+pub fn mul_long(a: &[U256], b: &[U256], out: &mut [U256]) -> usize {
     let len_a = a.len();
     let len_b = b.len();
     #[cfg(debug_assertions)]
@@ -44,11 +39,7 @@ pub fn mul_long(
         dl: out[0].as_limbs_mut(),
         dh: &mut [0, 0, 0, 0],
     };
-    syscall_arith256(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256(&mut params);
 
     // Propagate the carry
     out[1] = U256::from_u64s(params.dh);
@@ -64,11 +55,7 @@ pub fn mul_long(
             dl: out[j].as_limbs_mut(),
             dh: &mut [0, 0, 0, 0],
         };
-        syscall_arith256(
-            &mut params,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_arith256(&mut params);
 
         // Set out[j+1]
         out[j + 1] = U256::from_u64s(params.dh);
@@ -91,11 +78,7 @@ pub fn mul_long(
                 dl: &mut [0, 0, 0, 0],
                 dh: &mut [0, 0, 0, 0],
             };
-            syscall_arith256(
-                &mut params_arith,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            syscall_arith256(&mut params_arith);
 
             // Set out[i+j]
             out[k] = U256::from_u64s(params_arith.dl);
@@ -108,11 +91,7 @@ pub fn mul_long(
                 cin: carry,
                 c: out[k + 1].as_limbs_mut(),
             };
-            carry = syscall_add256(
-                &mut params_add,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            carry = syscall_add256(&mut params_add);
         }
 
         // Last chunk isolated
@@ -127,11 +106,7 @@ pub fn mul_long(
             dl: out[k].as_limbs_mut(),
             dh: &mut [0, 0, 0, 0],
         };
-        syscall_arith256(
-            &mut params_arith,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_arith256(&mut params_arith);
 
         if carry == 1 {
             let a_in = *params_arith.dh;
@@ -141,11 +116,7 @@ pub fn mul_long(
                 cin: 1,
                 c: params_arith.dh,
             };
-            let _carry = syscall_add256(
-                &mut params_add,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let _carry = syscall_add256(&mut params_add);
 
             debug_assert!(_carry == 0, "Unexpected carry in intermediate addition");
         }
@@ -175,7 +146,6 @@ pub fn mul_and_reduce_long(
     b: &[U256],
     modulus: &[U256],
     scratch: &mut LongScratch,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> Vec<U256> {
     #[cfg(debug_assertions)]
     {
@@ -185,28 +155,10 @@ pub fn mul_and_reduce_long(
     }
 
     let mul_len = if b.len() == 1 {
-        mul_short(
-            a,
-            &b[0],
-            &mut scratch.mul,
-            #[cfg(feature = "hints")]
-            hints,
-        )
+        mul_short(a, &b[0], &mut scratch.mul)
     } else {
-        mul_long(
-            a,
-            b,
-            &mut scratch.mul,
-            #[cfg(feature = "hints")]
-            hints,
-        )
+        mul_long(a, b, &mut scratch.mul)
     };
 
-    rem_long(
-        &scratch.mul[..mul_len],
-        modulus,
-        &mut scratch.rem,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    rem_long(&scratch.mul[..mul_len], modulus, &mut scratch.rem)
 }

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/mul_short.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/mul_short.rs
@@ -11,12 +11,7 @@ use super::{rem_short, ShortScratch, U256};
 ///
 /// # Returns
 /// The number of limbs in the result
-pub fn mul_short(
-    a: &[U256],
-    b: &U256,
-    out: &mut [U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> usize {
+pub fn mul_short(a: &[U256], b: &U256, out: &mut [U256]) -> usize {
     let len_a = a.len();
     #[cfg(debug_assertions)]
     {
@@ -37,11 +32,7 @@ pub fn mul_short(
             dl: out[i].as_limbs_mut(),
             dh: carry.as_limbs_mut(),
         };
-        syscall_arith256(
-            &mut params,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_arith256(&mut params);
     }
 
     if carry.is_zero() {
@@ -56,11 +47,7 @@ pub fn mul_short(
 ///
 /// # Returns
 /// A tuple of (result array, number of limbs used)
-pub fn mul_short_one_limb(
-    a: &U256,
-    b: &U256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> ([U256; 2], usize) {
+pub fn mul_short_one_limb(a: &U256, b: &U256) -> ([U256; 2], usize) {
     let mut out = [U256::ZERO; 2];
 
     // Compute a * b
@@ -72,11 +59,7 @@ pub fn mul_short_one_limb(
         dl: out[0].as_limbs_mut(),
         dh: &mut dh,
     };
-    syscall_arith256(
-        &mut mul_params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256(&mut mul_params);
 
     let len = if dh == [0u64; 4] {
         1
@@ -100,25 +83,13 @@ pub fn mul_and_reduce_short(
     b: &U256,
     modulus: &U256,
     scratch: &mut ShortScratch,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> U256 {
     #[cfg(debug_assertions)]
     {
         assert!(!modulus.is_zero(), "Input 'modulus' must not be zero");
     }
 
-    let (mul, len) = mul_short_one_limb(
-        a,
-        b,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (mul, len) = mul_short_one_limb(a, b);
 
-    rem_short(
-        &mul[..len],
-        modulus,
-        scratch,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    rem_short(&mul[..len], modulus, scratch)
 }

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/rem_long.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/rem_long.rs
@@ -17,11 +17,7 @@ use super::{add_agtb, mul_long, RemLongScratch, U256};
 /// # Note
 /// Use this for the first reduction when `a` can be arbitrarily large.
 /// For subsequent reductions in a loop, use `rem_long` with scratch space.
-pub fn rem_long_init(
-    a: &[U256],
-    b: &[U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Vec<U256> {
+pub fn rem_long_init(a: &[U256], b: &[U256]) -> Vec<U256> {
     let len_a = a.len();
     let len_b = b.len();
     #[cfg(debug_assertions)]
@@ -50,30 +46,14 @@ pub fn rem_long_init(
     // Hint the quotient and remainder
     let mut quo_flat = vec![0u64; len_a * 4];
     let mut rem_flat = vec![0u64; len_b * 4];
-    let (limbs_quo, limbs_rem) = fcall_division(
-        a_flat,
-        b_flat,
-        &mut quo_flat,
-        &mut rem_flat,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (limbs_quo, limbs_rem) = fcall_division(a_flat, b_flat, &mut quo_flat, &mut rem_flat);
     let quo = U256::flat_to_slice(&quo_flat[..limbs_quo]);
     let rem = U256::flat_to_slice(&rem_flat[..limbs_rem]);
 
     // Verify the division
     let mut q_b = vec![U256::ZERO; len_a + 1]; // The +1 is because mul_long and add_agtb are a general purpose functions
     let mut q_b_r = vec![U256::ZERO; len_a + 1];
-    verify_division(
-        a,
-        b,
-        quo,
-        rem,
-        &mut q_b,
-        &mut q_b_r,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    verify_division(a, b, quo, rem, &mut q_b, &mut q_b_r);
 
     rem.to_vec()
 }
@@ -90,12 +70,7 @@ pub fn rem_long_init(
 ///
 /// # Note
 /// Not optimal for `len(b) == 1`, use `rem_short` instead
-pub fn rem_long(
-    a: &[U256],
-    b: &[U256],
-    scratch: &mut RemLongScratch,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Vec<U256> {
+pub fn rem_long(a: &[U256], b: &[U256], scratch: &mut RemLongScratch) -> Vec<U256> {
     #[cfg(debug_assertions)]
     {
         let len_a = a.len();
@@ -122,28 +97,12 @@ pub fn rem_long(
     let b_flat = U256::slice_to_flat(b);
 
     // Hint the quotient and remainder
-    let (limbs_quo, limbs_rem) = fcall_division(
-        a_flat,
-        b_flat,
-        &mut scratch.quo,
-        &mut scratch.rem,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (limbs_quo, limbs_rem) = fcall_division(a_flat, b_flat, &mut scratch.quo, &mut scratch.rem);
     let quo = U256::flat_to_slice(&scratch.quo[..limbs_quo]);
     let rem = U256::flat_to_slice(&scratch.rem[..limbs_rem]);
 
     // Verify the division
-    verify_division(
-        a,
-        b,
-        quo,
-        rem,
-        &mut scratch.q_b,
-        &mut scratch.q_b_r,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    verify_division(a, b, quo, rem, &mut scratch.q_b, &mut scratch.q_b_r);
 
     rem.to_vec()
 }
@@ -157,7 +116,6 @@ fn verify_division(
     rem: &[U256],
     q_b: &mut [U256],
     q_b_r: &mut [U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
     let len_a = a.len();
     let len_b = b.len();
@@ -178,13 +136,7 @@ fn verify_division(
     assert!(!quo[len_quo - 1].is_zero(), "Quotient must not have leading zeros");
 
     // Multiply the quotient by b
-    let q_b_len = mul_long(
-        quo,
-        b,
-        q_b,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let q_b_len = mul_long(quo, b, q_b);
 
     // Check 1 <= len(r)
     assert!(len_rem > 0, "Remainder must have at least one limb");
@@ -197,13 +149,7 @@ fn verify_division(
 
         assert!(U256::lt_slices(rem, b), "Remainder must be less than divisor");
 
-        let q_b_r_len = add_agtb(
-            &q_b[..q_b_len],
-            rem,
-            q_b_r,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let q_b_r_len = add_agtb(&q_b[..q_b_len], rem, q_b_r);
         assert!(U256::eq_slices(a, &q_b_r[..q_b_r_len]), "a != q·b + r");
     }
 }

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/rem_short.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/rem_short.rs
@@ -15,11 +15,7 @@ use super::{add_short, mul_short, ShortScratch, U256};
 /// # Note
 /// Use this for the first reduction when `a` can be arbitrarily large.
 /// For subsequent reductions in a loop, use `rem_short` with scratch space.
-pub fn rem_short_init(
-    a: &[U256],
-    b: &U256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> U256 {
+pub fn rem_short_init(a: &[U256], b: &U256) -> U256 {
     let len_a = a.len();
     #[cfg(debug_assertions)]
     {
@@ -47,30 +43,14 @@ pub fn rem_short_init(
     // Hint the quotient and remainder
     let mut quo_flat = vec![0u64; len_a * 4];
     let mut rem_flat = [0u64; 4];
-    let (limbs_quo, _) = fcall_division(
-        a_flat,
-        b.as_limbs(),
-        &mut quo_flat,
-        &mut rem_flat,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (limbs_quo, _) = fcall_division(a_flat, b.as_limbs(), &mut quo_flat, &mut rem_flat);
     let quo = U256::flat_to_slice(&quo_flat[..limbs_quo]);
     let rem = U256::from_u64s(&rem_flat);
 
     // Verify the division
     let mut q_b = vec![U256::ZERO; len_a + 1]; // The +1 is because mul_long and add_agtb are a general purpose functions
     let mut q_b_r = vec![U256::ZERO; len_a + 1];
-    verify_division(
-        a,
-        b,
-        quo,
-        &rem,
-        &mut q_b,
-        &mut q_b_r,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    verify_division(a, b, quo, &rem, &mut q_b, &mut q_b_r);
 
     rem
 }
@@ -84,12 +64,7 @@ pub fn rem_short_init(
 ///
 /// # Returns
 /// The remainder: a mod b
-pub fn rem_short(
-    a: &[U256],
-    b: &U256,
-    scratch: &mut ShortScratch,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> U256 {
+pub fn rem_short(a: &[U256], b: &U256, scratch: &mut ShortScratch) -> U256 {
     let len_a = a.len();
     #[cfg(debug_assertions)]
     {
@@ -115,28 +90,12 @@ pub fn rem_short(
     let a_flat = U256::slice_to_flat(a);
 
     // Hint the quotient and remainder
-    let (limbs_quo, _) = fcall_division(
-        a_flat,
-        b.as_limbs(),
-        &mut scratch.quo,
-        &mut scratch.rem,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (limbs_quo, _) = fcall_division(a_flat, b.as_limbs(), &mut scratch.quo, &mut scratch.rem);
     let quo = U256::flat_to_slice(&scratch.quo[..limbs_quo]);
     let rem = U256::from_u64s(&scratch.rem);
 
     // Verify the division
-    verify_division(
-        a,
-        b,
-        quo,
-        &rem,
-        &mut scratch.q_b,
-        &mut scratch.q_b_r,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    verify_division(a, b, quo, &rem, &mut scratch.q_b, &mut scratch.q_b_r);
 
     rem
 }
@@ -150,7 +109,6 @@ fn verify_division(
     rem: &U256,
     q_b: &mut [U256],
     q_b_r: &mut [U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
     let len_a = a.len();
     let len_quo = quo.len();
@@ -161,13 +119,7 @@ fn verify_division(
     assert!(!quo[len_quo - 1].is_zero(), "Quotient must not have leading zeros");
 
     // Multiply the quotient by b
-    let q_b_len = mul_short(
-        quo,
-        b,
-        q_b,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let q_b_len = mul_short(quo, b, q_b);
 
     if rem.is_zero() {
         // If the remainder is zero, then a must be equal to q·b
@@ -176,13 +128,7 @@ fn verify_division(
         // If the remainder is non-zero, then we should check that a must be equal to q·b + r and r < b
         assert!(rem.lt(b), "Remainder must be less than divisor");
 
-        let q_b_r_len = add_short(
-            &q_b[..q_b_len],
-            rem,
-            q_b_r,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let q_b_r_len = add_short(&q_b[..q_b_len], rem, q_b_r);
         assert!(U256::eq_slices(a, &q_b_r[..q_b_r_len]), "a != q·b + r");
     }
 }

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/square_long.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/square_long.rs
@@ -16,11 +16,7 @@ use super::{rem_long, LongScratch, U256};
 ///
 /// # Note
 /// Not optimal for `len(a) == 1`, use `square_short` instead
-pub fn square_long(
-    a: &[U256],
-    out: &mut [U256],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> usize {
+pub fn square_long(a: &[U256], out: &mut [U256]) -> usize {
     //                         a2       a1      a0
     //                     *   a2       a1      a0
     // ----------------------------------------------
@@ -54,11 +50,7 @@ pub fn square_long(
             dl: out[k].as_limbs_mut(),
             dh: &mut [0, 0, 0, 0],
         };
-        syscall_arith256(
-            &mut ai_ai,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_arith256(&mut ai_ai);
 
         out[k + 1] = U256::from_u64s(ai_ai.dh);
     }
@@ -75,11 +67,7 @@ pub fn square_long(
                 dl: &mut [0, 0, 0, 0],
                 dh: &mut [0, 0, 0, 0],
             };
-            syscall_arith256(
-                &mut ai_aj,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            syscall_arith256(&mut ai_aj);
 
             // Double the result 2·a[i]·a[j]
 
@@ -87,21 +75,13 @@ pub fn square_long(
             let mut low_chunk: [u64; 4] = [0, 0, 0, 0];
             let mut dbl_low =
                 SyscallAdd256Params { a: ai_aj.dl, b: ai_aj.dl, cin: 0, c: &mut low_chunk };
-            let carry = syscall_add256(
-                &mut dbl_low,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let carry = syscall_add256(&mut dbl_low);
 
             // Next, double the higher chunk: 2·h₁·B = [1/0]·B² + h₂·B
             let mut mid_chunk: [u64; 4] = [0, 0, 0, 0];
             let mut dbl_high =
                 SyscallAdd256Params { a: ai_aj.dh, b: ai_aj.dh, cin: carry, c: &mut mid_chunk };
-            let high_chunk = syscall_add256(
-                &mut dbl_high,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let high_chunk = syscall_add256(&mut dbl_high);
 
             // The result is expressed as: high_chunk·B² + mid_chunk·B + low_chunk
 
@@ -115,11 +95,7 @@ pub fn square_long(
                 cin: 0,
                 c: &mut [0, 0, 0, 0],
             };
-            let mut carry = syscall_add256(
-                &mut add,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let mut carry = syscall_add256(&mut add);
             out[k] = U256::from_u64s(add.c);
 
             // Update out[i+j+1] with the middle chunk
@@ -129,11 +105,7 @@ pub fn square_long(
                 cin: carry,
                 c: &mut [0, 0, 0, 0],
             };
-            carry = syscall_add256(
-                &mut add,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            carry = syscall_add256(&mut add);
             out[k + 1] = U256::from_u64s(add.c);
 
             // Update out[i+j+2] with the high chunk
@@ -143,11 +115,7 @@ pub fn square_long(
                 cin: carry,
                 c: &mut [0, 0, 0, 0],
             };
-            carry = syscall_add256(
-                &mut add,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            carry = syscall_add256(&mut add);
             out[k + 2] = U256::from_u64s(add.c);
 
             // If there's still a carry, propagate it to the next limbs
@@ -159,11 +127,7 @@ pub fn square_long(
                     cin: carry,
                     c: &mut [0, 0, 0, 0],
                 };
-                carry = syscall_add256(
-                    &mut add,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                carry = syscall_add256(&mut add);
                 out[idx] = U256::from_u64s(add.c);
                 idx += 1;
             }
@@ -190,7 +154,6 @@ pub fn square_and_reduce_long(
     a: &[U256],
     modulus: &[U256],
     scratch: &mut LongScratch,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> Vec<U256> {
     #[cfg(debug_assertions)]
     {
@@ -199,18 +162,7 @@ pub fn square_and_reduce_long(
         assert!(!modulus[len_m - 1].is_zero(), "Input 'modulus' must not have leading zeros");
     }
 
-    let sq_len = square_long(
-        a,
-        &mut scratch.mul,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let sq_len = square_long(a, &mut scratch.mul);
 
-    rem_long(
-        &scratch.mul[..sq_len],
-        modulus,
-        &mut scratch.rem,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    rem_long(&scratch.mul[..sq_len], modulus, &mut scratch.rem)
 }

--- a/ziskos/entrypoint/src/zisklib/lib/array_lib/square_short.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/array_lib/square_short.rs
@@ -9,10 +9,7 @@ use super::{rem_short, ShortScratch, U256};
 ///
 /// # Returns
 /// A tuple of (result array, number of limbs used)
-pub fn square_short(
-    a: &U256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> ([U256; 2], usize) {
+pub fn square_short(a: &U256) -> ([U256; 2], usize) {
     #[cfg(debug_assertions)]
     {
         assert!(!a.is_zero(), "Input 'a' must not have leading zeros");
@@ -29,11 +26,7 @@ pub fn square_short(
         dl: out[0].as_limbs_mut(),
         dh: &mut dh,
     };
-    syscall_arith256(
-        &mut sq_params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256(&mut sq_params);
 
     let len = if dh == [0u64; 4] {
         1
@@ -52,28 +45,13 @@ pub fn square_short(
 ///
 /// # Returns
 /// The remainder: a² mod modulus
-pub fn square_and_reduce_short(
-    a: &U256,
-    modulus: &U256,
-    scratch: &mut ShortScratch,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> U256 {
+pub fn square_and_reduce_short(a: &U256, modulus: &U256, scratch: &mut ShortScratch) -> U256 {
     #[cfg(debug_assertions)]
     {
         assert!(!modulus.is_zero(), "Input 'modulus' must not be zero");
     }
 
-    let (sq, len) = square_short(
-        a,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (sq, len) = square_short(a);
 
-    rem_short(
-        &sq[..len],
-        modulus,
-        scratch,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    rem_short(&sq[..len], modulus, scratch)
 }

--- a/ziskos/entrypoint/src/zisklib/lib/blake2b.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/blake2b.rs
@@ -12,14 +12,7 @@ const IV: [u64; 8] = [
     0x5BE0CD19137E2179,
 ];
 
-pub fn blake2b_compress(
-    rounds: u32,
-    h: &mut [u64; 8],
-    m: &[u64; 16],
-    t: &[u64; 2],
-    f: bool,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub fn blake2b_compress(rounds: u32, h: &mut [u64; 8], m: &[u64; 16], t: &[u64; 2], f: bool) {
     let mut v = [0u64; 16];
 
     v[..8].copy_from_slice(h);
@@ -33,13 +26,7 @@ pub fn blake2b_compress(
     }
 
     for r in 0..rounds {
-        blake2b_round(
-            &mut v,
-            m,
-            r,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        blake2b_round(&mut v, m, r);
     }
 
     for i in 0..8 {
@@ -47,18 +34,9 @@ pub fn blake2b_compress(
     }
 }
 
-fn blake2b_round(
-    v: &mut [u64; 16],
-    m: &[u64; 16],
-    round: u32,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+fn blake2b_round(v: &mut [u64; 16], m: &[u64; 16], round: u32) {
     let mut params = SyscallBlake2bRoundParams { index: (round % 10) as u64, state: v, input: m };
-    syscall_blake2b_round(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_blake2b_round(&mut params);
 }
 
 /// C-compatible wrapper for full Blake2b compression function
@@ -74,7 +52,6 @@ pub(crate) unsafe fn blake2b_compress_c(
     message: *const u64,
     offset: *const u64,
     final_block: u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) {
     // Parse state
     let state_slice = core::slice::from_raw_parts_mut(state, 8);
@@ -88,13 +65,5 @@ pub(crate) unsafe fn blake2b_compress_c(
     let offset_slice = core::slice::from_raw_parts(offset, 2);
     let offset_array: &[u64; 2] = &*(offset_slice.as_ptr() as *const [u64; 2]);
 
-    blake2b_compress(
-        rounds,
-        state_array,
-        message_array,
-        offset_array,
-        final_block != 0,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    blake2b_compress(rounds, state_array, message_array, offset_array, final_block != 0);
 }

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
@@ -36,10 +36,7 @@ const G1_MSM_ERR_NOT_IN_SUBGROUP: u8 = 4;
 /// - Bit 7 (0x80): Compression flag (must be 1 for compressed)
 /// - Bit 6 (0x40): Infinity flag (1 = point at infinity)
 /// - Bit 5 (0x20): Sign flag (1 = y is lexicographically largest)
-pub fn decompress_bls12_381(
-    input: &[u8; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 12], &'static str> {
+pub fn decompress_bls12_381(input: &[u8; 48]) -> Result<[u64; 12], &'static str> {
     let flags = input[0];
 
     // Check compression bit
@@ -83,39 +80,17 @@ pub fn decompress_bls12_381(
     }
 
     // Calculate the y-coordinate of the point: y = sqrt(x³ + 4)
-    let x_sq = square_fp_bls12_381(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_cb = mul_fp_bls12_381(
-        &x_sq,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_sq = add_fp_bls12_381(
-        &x_cb,
-        &E_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let x_sq = square_fp_bls12_381(&x);
+    let x_cb = mul_fp_bls12_381(&x_sq, &x);
+    let y_sq = add_fp_bls12_381(&x_cb, &E_B);
 
-    let (y, has_sqrt) = sqrt_fp_bls12_381(
-        &y_sq,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (y, has_sqrt) = sqrt_fp_bls12_381(&y_sq);
     if !has_sqrt {
         return Err("No square root exists - point not on curve");
     }
 
     // Determine the sign of y, which is (lexicographically) done by checking if y > -y
-    let y_neg = neg_fp_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y_neg = neg_fp_bls12_381(&y);
     let y_is_larger = lt(&y_neg, &y);
 
     // Select the correct y based on sign bit
@@ -129,93 +104,39 @@ pub fn decompress_bls12_381(
 }
 
 /// Check if a non-zero point `p` is on the BLS12-381 curve
-pub fn is_on_curve_bls12_381(
-    p: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+pub fn is_on_curve_bls12_381(p: &[u64; 12]) -> bool {
     let x: [u64; 6] = p[0..6].try_into().unwrap();
     let y: [u64; 6] = p[6..12].try_into().unwrap();
 
     // p in E iff y² == x³ + 4
-    let lhs = square_fp_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut rhs = square_fp_bls12_381(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = mul_fp_bls12_381(
-        &rhs,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = add_fp_bls12_381(
-        &rhs,
-        &E_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let lhs = square_fp_bls12_381(&y);
+    let mut rhs = square_fp_bls12_381(&x);
+    rhs = mul_fp_bls12_381(&rhs, &x);
+    rhs = add_fp_bls12_381(&rhs, &E_B);
     eq(&lhs, &rhs)
 }
 
 /// Check if a non-zero point `p` is on the BLS12-381 subgroup
-pub fn is_on_subgroup_bls12_381(
-    p: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+pub fn is_on_subgroup_bls12_381(p: &[u64; 12]) -> bool {
     // p in subgroup iff:
     //          ((x²-1)/3)(2·σ(P) - P - σ²(P)) == σ²(P)
     // where σ(x,y) = (ɣ·x,y)
 
     // Compute σ(P), σ²(P)
-    let sigma1 = sigma_endomorphism_bls12_381(
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let rhs = sigma_endomorphism_bls12_381(
-        &sigma1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let sigma1 = sigma_endomorphism_bls12_381(p);
+    let rhs = sigma_endomorphism_bls12_381(&sigma1);
 
     // Compute lhs = ((x²-1)/3)(2·σ(P) - P - σ²(P))
-    let mut lhs = dbl_bls12_381(
-        &sigma1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lhs = sub_bls12_381(
-        &lhs,
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lhs = sub_bls12_381(
-        &lhs,
-        &rhs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lhs = scalar_mul_by_x2div3_bls12_381(
-        &lhs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut lhs = dbl_bls12_381(&sigma1);
+    lhs = sub_bls12_381(&lhs, p);
+    lhs = sub_bls12_381(&lhs, &rhs);
+    lhs = scalar_mul_by_x2div3_bls12_381(&lhs);
 
     eq(&lhs, &rhs)
 }
 
 /// Adds two non-zero points `p1` and `p2` on the BLS12-381 curve
-pub fn add_bls12_381(
-    p1: &[u64; 12],
-    p2: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn add_bls12_381(p1: &[u64; 12], p2: &[u64; 12]) -> [u64; 12] {
     let x1: [u64; 6] = p1[0..6].try_into().unwrap();
     let y1: [u64; 6] = p1[6..12].try_into().unwrap();
     let x2: [u64; 6] = p2[0..6].try_into().unwrap();
@@ -226,11 +147,7 @@ pub fn add_bls12_381(
         // Is y1 == y2?
         if eq(&y1, &y2) {
             // Compute the doubling
-            return dbl_bls12_381(
-                p1,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            return dbl_bls12_381(p1);
         } else {
             // Return 𝒪
             return G1_IDENTITY;
@@ -241,11 +158,7 @@ pub fn add_bls12_381(
     let mut p1 = SyscallPoint384 { x: x1, y: y1 };
     let p2 = SyscallPoint384 { x: x2, y: y2 };
     let mut params = SyscallBls12_381CurveAddParams { p1: &mut p1, p2: &p2 };
-    syscall_bls12_381_curve_add(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_curve_add(&mut params);
 
     let mut result = [0u64; 12];
     result[0..6].copy_from_slice(&p1.x);
@@ -254,11 +167,7 @@ pub fn add_bls12_381(
 }
 
 /// Adds two points `p1` and `p2` on the BLS12-381 curve
-pub fn add_complete_bls12_381(
-    p1: &[u64; 12],
-    p2: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 12], u8> {
+pub fn add_complete_bls12_381(p1: &[u64; 12], p2: &[u64; 12]) -> Result<[u64; 12], u8> {
     let p1_is_inf = *p1 == G1_IDENTITY;
     let p2_is_inf = *p2 == G1_IDENTITY;
 
@@ -273,11 +182,7 @@ pub fn add_complete_bls12_381(
         if !lt(&x2, &P) || !lt(&y2, &P) {
             return Err(G1_ADD_ERR_NOT_IN_FIELD);
         }
-        if !is_on_curve_bls12_381(
-            p2,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_bls12_381(p2) {
             return Err(G1_ADD_ERR_NOT_ON_CURVE);
         }
         return Ok(*p2);
@@ -290,11 +195,7 @@ pub fn add_complete_bls12_381(
         if !lt(&x1, &P) || !lt(&y1, &P) {
             return Err(G1_ADD_ERR_NOT_IN_FIELD);
         }
-        if !is_on_curve_bls12_381(
-            p1,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_bls12_381(p1) {
             return Err(G1_ADD_ERR_NOT_ON_CURVE);
         }
         return Ok(*p1);
@@ -306,11 +207,7 @@ pub fn add_complete_bls12_381(
     if !lt(&x1, &P) || !lt(&y1, &P) {
         return Err(G1_ADD_ERR_NOT_IN_FIELD);
     }
-    if !is_on_curve_bls12_381(
-        p1,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !is_on_curve_bls12_381(p1) {
         return Err(G1_ADD_ERR_NOT_ON_CURVE);
     }
 
@@ -320,33 +217,20 @@ pub fn add_complete_bls12_381(
     if !lt(&x2, &P) || !lt(&y2, &P) {
         return Err(G1_ADD_ERR_NOT_IN_FIELD);
     }
-    if !is_on_curve_bls12_381(
-        p2,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !is_on_curve_bls12_381(p2) {
         return Err(G1_ADD_ERR_NOT_ON_CURVE);
     }
 
     // Otherwise, perform regular addition
-    Ok(add_bls12_381(
-        p1,
-        p2,
-        #[cfg(feature = "hints")]
-        hints,
-    ))
+    Ok(add_bls12_381(p1, p2))
 }
 
 /// Negation of a non-zero point `p` on the BLS12-381 curve
-pub fn neg_bls12_381(p: &[u64; 12], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 12] {
+pub fn neg_bls12_381(p: &[u64; 12]) -> [u64; 12] {
     let x: [u64; 6] = p[0..6].try_into().unwrap();
     let y: [u64; 6] = p[6..12].try_into().unwrap();
 
-    let y_neg = neg_fp_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y_neg = neg_fp_bls12_381(&y);
     let mut result = [0u64; 12];
     result[0..6].copy_from_slice(&x);
     result[6..12].copy_from_slice(&y_neg);
@@ -354,13 +238,9 @@ pub fn neg_bls12_381(p: &[u64; 12], #[cfg(feature = "hints")] hints: &mut Vec<u6
 }
 
 /// Doubling of a non-zero point `p` on the BLS12-381 curve
-pub fn dbl_bls12_381(p: &[u64; 12], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 12] {
+pub fn dbl_bls12_381(p: &[u64; 12]) -> [u64; 12] {
     let mut p = SyscallPoint384 { x: p[0..6].try_into().unwrap(), y: p[6..12].try_into().unwrap() };
-    syscall_bls12_381_curve_dbl(
-        &mut p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_curve_dbl(&mut p);
 
     let mut result = [0u64; 12];
     result[0..6].copy_from_slice(&p.x);
@@ -369,39 +249,22 @@ pub fn dbl_bls12_381(p: &[u64; 12], #[cfg(feature = "hints")] hints: &mut Vec<u6
 }
 
 /// Subtraction of two non-zero points `p1` and `p2` on the BLS12-381 curve
-pub fn sub_bls12_381(
-    p1: &[u64; 12],
-    p2: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn sub_bls12_381(p1: &[u64; 12], p2: &[u64; 12]) -> [u64; 12] {
     let x2: [u64; 6] = p2[0..6].try_into().unwrap();
     let y2: [u64; 6] = p2[6..12].try_into().unwrap();
 
     // P1 - P2 = P1 + (-P2)
-    let y2_neg = neg_fp_bls12_381(
-        &y2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y2_neg = neg_fp_bls12_381(&y2);
 
     let mut p2_neg = [0u64; 12];
     p2_neg[0..6].copy_from_slice(&x2);
     p2_neg[6..12].copy_from_slice(&y2_neg);
 
-    add_bls12_381(
-        p1,
-        &p2_neg,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    add_bls12_381(p1, &p2_neg)
 }
 
 /// Subtraction of two points `p1` and `p2` on the BLS12-381 curve
-pub fn sub_complete_bls12_381(
-    p1: &[u64; 12],
-    p2: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn sub_complete_bls12_381(p1: &[u64; 12], p2: &[u64; 12]) -> [u64; 12] {
     let p1_is_inf = *p1 == G1_IDENTITY;
     let p2_is_inf = *p2 == G1_IDENTITY;
 
@@ -411,31 +274,18 @@ pub fn sub_complete_bls12_381(
         return G1_IDENTITY;
     } else if p1_is_inf {
         // O - P2 = -P2
-        return neg_bls12_381(
-            p2,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        return neg_bls12_381(p2);
     } else if p2_is_inf {
         // P1 - O = P1
         return *p1;
     }
 
     // Perform regular subtraction: P1 - P2 = P1 + (-P2)
-    sub_bls12_381(
-        p1,
-        p2,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    sub_bls12_381(p1, p2)
 }
 
 /// Multiplies a non-zero point `p` on the BLS12-381 curve by a scalar `k` on the BLS12-381 scalar field
-pub fn scalar_mul_bls12_381(
-    p: &[u64; 12],
-    k: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn scalar_mul_bls12_381(p: &[u64; 12], k: &[u64; 4]) -> [u64; 12] {
     // Direct cases: k = 0, k = 1, k = 2
     match k {
         [0, 0, 0, 0] => {
@@ -448,11 +298,7 @@ pub fn scalar_mul_bls12_381(
         }
         [2, 0, 0, 0] => {
             // Return 2p
-            return dbl_bls12_381(
-                p,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            return dbl_bls12_381(p);
         }
         _ => {}
     }
@@ -461,12 +307,7 @@ pub fn scalar_mul_bls12_381(
     // Hint the length the binary representations of k
     // We will verify the output by recomposing k
     // Moreover, we should check that the first received bit is 1
-    let (max_limb, max_bit) = fcall_msb_pos_256(
-        k,
-        &[0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (max_limb, max_bit) = fcall_msb_pos_256(k, &[0, 0, 0, 0]);
 
     // Perform the loop, based on the binary representation of k
 
@@ -499,21 +340,13 @@ pub fn scalar_mul_bls12_381(
     for i in (0..=limb).rev() {
         for j in (0..=bit).rev() {
             // Always double
-            syscall_bls12_381_curve_dbl(
-                &mut q,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            syscall_bls12_381_curve_dbl(&mut q);
 
             // Get the next bit b of k.
             // If b == 1, we should add P to Q, otherwise start the next iteration
             if ((k[i] >> j) & 1) == 1 {
                 let mut params = SyscallBls12_381CurveAddParams { p1: &mut q, p2: &p };
-                syscall_bls12_381_curve_add(
-                    &mut params,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                syscall_bls12_381_curve_add(&mut params);
 
                 // Reconstruct k
                 k_rec[i] |= 1 << j;
@@ -533,29 +366,17 @@ pub fn scalar_mul_bls12_381(
 }
 
 /// Scalar multiplication of a non-zero point `p` by a binary scalar `k`
-pub fn scalar_mul_bin_bls12_381(
-    p: &[u64; 12],
-    k: &[u8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn scalar_mul_bin_bls12_381(p: &[u64; 12], k: &[u8]) -> [u64; 12] {
     let x1: [u64; 6] = p[0..6].try_into().unwrap();
     let y1: [u64; 6] = p[6..12].try_into().unwrap();
     let p = SyscallPoint384 { x: x1, y: y1 };
 
     let mut r = SyscallPoint384 { x: x1, y: y1 };
     for &bit in k.iter().skip(1) {
-        syscall_bls12_381_curve_dbl(
-            &mut r,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_bls12_381_curve_dbl(&mut r);
         if bit == 1 {
             let mut params = SyscallBls12_381CurveAddParams { p1: &mut r, p2: &p };
-            syscall_bls12_381_curve_add(
-                &mut params,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            syscall_bls12_381_curve_add(&mut params);
         }
     }
 
@@ -566,10 +387,7 @@ pub fn scalar_mul_bin_bls12_381(
 }
 
 /// Scalar multiplication of a non-zero point by (x²-1)/3
-pub fn scalar_mul_by_x2div3_bls12_381(
-    p: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn scalar_mul_by_x2div3_bls12_381(p: &[u64; 12]) -> [u64; 12] {
     /// Family parameter (X²-1)/3
     const X2DIV3_BIN_BE: [u8; 126] = [
         1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -579,22 +397,13 @@ pub fn scalar_mul_by_x2div3_bls12_381(
         0, 1, 0, 1, 0, 1,
     ];
 
-    scalar_mul_bin_bls12_381(
-        p,
-        &X2DIV3_BIN_BE,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    scalar_mul_bin_bls12_381(p, &X2DIV3_BIN_BE)
 }
 
 /// Multi-Scalar Multiplication (MSM) for BLS12-381 G1 points
 /// It computes k1·P1 + k2·P2 + ... + kn·Pn
 // TODO: This is a naive implementation, one can improve it by using, e.g., a windowed strategies!
-pub fn msm_complete_bls12_381(
-    points: &[[u64; 12]],
-    scalars: &[[u64; 4]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 12], u8> {
+pub fn msm_complete_bls12_381(points: &[[u64; 12]], scalars: &[[u64; 4]]) -> Result<[u64; 12], u8> {
     assert_eq!(points.len(), scalars.len());
 
     let mut acc = G1_IDENTITY;
@@ -606,11 +415,7 @@ pub fn msm_complete_bls12_381(
         }
 
         // Reduce the scalar modulo the group order, and skip if the result is zero
-        let scalar = reduce_fr_bls12_381(
-            scalar,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let scalar = reduce_fr_bls12_381(scalar);
         if is_zero(&scalar) {
             continue;
         }
@@ -623,30 +428,17 @@ pub fn msm_complete_bls12_381(
         }
 
         // Verify point is on curve
-        if !is_on_curve_bls12_381(
-            point,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_bls12_381(point) {
             return Err(G1_MSM_ERR_NOT_ON_CURVE);
         }
 
         // Verify point is in subgroup
-        if !is_on_subgroup_bls12_381(
-            point,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_subgroup_bls12_381(point) {
             return Err(G1_MSM_ERR_NOT_IN_SUBGROUP);
         }
 
         // Compute P * k
-        let product = scalar_mul_bls12_381(
-            point,
-            &scalar,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let product = scalar_mul_bls12_381(point, &scalar);
 
         // Skip if product is infinity
         if product == G1_IDENTITY {
@@ -658,12 +450,7 @@ pub fn msm_complete_bls12_381(
             acc = product;
             acc_is_inf = false;
         } else {
-            acc = add_bls12_381(
-                &acc,
-                &product,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            acc = add_bls12_381(&acc, &product);
             acc_is_inf = acc == G1_IDENTITY;
         }
     }
@@ -674,19 +461,11 @@ pub fn msm_complete_bls12_381(
 /// Compute the sigma endomorphism σ of a non-zero point `p`, defined as:
 ///              σ : E(Fp)  ->  E(Fp)
 ///                  (x,y) |-> (ɣ·x,y)
-pub fn sigma_endomorphism_bls12_381(
-    p: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn sigma_endomorphism_bls12_381(p: &[u64; 12]) -> [u64; 12] {
     let mut x: [u64; 6] = p[0..6].try_into().unwrap();
     let y: [u64; 6] = p[6..12].try_into().unwrap();
 
-    x = mul_fp_bls12_381(
-        &x,
-        &GAMMA,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    x = mul_fp_bls12_381(&x, &GAMMA);
     let mut result = [0u64; 12];
     result[0..6].copy_from_slice(&x);
     result[6..12].copy_from_slice(&y);
@@ -709,12 +488,7 @@ pub fn sigma_endomorphism_bls12_381(
 /// - [G1_ADD_ERR_NOT_IN_FIELD] = error (one of the input points has coordinates not in the field)
 /// - [G1_ADD_ERR_NOT_ON_CURVE] = error (one of the input points is not on the curve)
 #[inline]
-pub(crate) unsafe fn bls12_381_g1_add_c(
-    ret: *mut u8,
-    a: *const u8,
-    b: *const u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bls12_381_g1_add_c(ret: *mut u8, a: *const u8, b: *const u8) -> u8 {
     let a_bytes: &[u8; 96] = &*(a as *const [u8; 96]);
     let b_bytes: &[u8; 96] = &*(b as *const [u8; 96]);
     let ret_bytes: &mut [u8; 96] = &mut *(ret as *mut [u8; 96]);
@@ -724,12 +498,7 @@ pub(crate) unsafe fn bls12_381_g1_add_c(
     let b_u64 = g1_bytes_be_to_u64_le_bls12_381(b_bytes);
 
     // Perform addition
-    let result = match add_complete_bls12_381(
-        &a_u64,
-        &b_u64,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let result = match add_complete_bls12_381(&a_u64, &b_u64) {
         Ok(r) => r,
         Err(code) => return code,
     };
@@ -759,12 +528,7 @@ pub(crate) unsafe fn bls12_381_g1_add_c(
 /// - [G1_MSM_ERR_NOT_ON_CURVE] = error (one of the input points is not on the curve)
 /// - [G1_MSM_ERR_NOT_IN_SUBGROUP] = error (one of the input points is not in the subgroup)
 #[inline]
-pub(crate) unsafe fn bls12_381_g1_msm_c(
-    ret: *mut u8,
-    pairs: *const u8,
-    num_pairs: usize,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bls12_381_g1_msm_c(ret: *mut u8, pairs: *const u8, num_pairs: usize) -> u8 {
     let ret_bytes: &mut [u8; 96] = &mut *(ret as *mut [u8; 96]);
 
     // Parse all pairs
@@ -784,12 +548,7 @@ pub(crate) unsafe fn bls12_381_g1_msm_c(
     }
 
     // Perform MSM with validation
-    let result = match msm_complete_bls12_381(
-        &points,
-        &scalars,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let result = match msm_complete_bls12_381(&points, &scalars) {
         Ok(r) => r,
         Err(code) => return code,
     };

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/cyclotomic.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/cyclotomic.rs
@@ -48,10 +48,7 @@ pub fn compress_cyclo_bls12_381(a: &[u64; 72]) -> [u64; 48] {
 /// **NOTE**: If the input is not of the form C(a), where a ∈ GΦ6(p²), then the compression-decompression
 ///           technique is not well defined. This means that D(C(a)) != a.
 #[inline]
-pub fn decompress_cyclo_bls12_381(
-    a: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn decompress_cyclo_bls12_381(a: &[u64; 48]) -> [u64; 72] {
     let a2: &[u64; 12] = &a[0..12].try_into().unwrap();
     let a3: &[u64; 12] = &a[12..24].try_into().unwrap();
     let a4: &[u64; 12] = &a[24..36].try_into().unwrap();
@@ -59,179 +56,39 @@ pub fn decompress_cyclo_bls12_381(
 
     let (a0, a1) = if eq(a2, &[0; 12]) {
         // a1 = (2·a4·a5)/a3
-        let a3_inv = inv_fp2_bls12_381(
-            a3,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let mut a1 = mul_fp2_bls12_381(
-            a4,
-            a5,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = dbl_fp2_bls12_381(
-            &a1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = mul_fp2_bls12_381(
-            &a1,
-            &a3_inv,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let a3_inv = inv_fp2_bls12_381(a3);
+        let mut a1 = mul_fp2_bls12_381(a4, a5);
+        a1 = dbl_fp2_bls12_381(&a1);
+        a1 = mul_fp2_bls12_381(&a1, &a3_inv);
 
         // a0 = (2·a1² - 3·a3·a4)(1+u) + 1
-        let a3a4 = mul_fp2_bls12_381(
-            a3,
-            a4,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let mut a0 = square_fp2_bls12_381(
-            &a1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = dbl_fp2_bls12_381(
-            &a0,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = sub_fp2_bls12_381(
-            &a0,
-            &scalar_mul_fp2_bls12_381(
-                &a3a4,
-                &[3, 0, 0, 0, 0, 0],
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = mul_fp2_bls12_381(
-            &a0,
-            &EXT_U,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = add_fp2_bls12_381(
-            &a0,
-            &[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let a3a4 = mul_fp2_bls12_381(a3, a4);
+        let mut a0 = square_fp2_bls12_381(&a1);
+        a0 = dbl_fp2_bls12_381(&a0);
+        a0 = sub_fp2_bls12_381(&a0, &scalar_mul_fp2_bls12_381(&a3a4, &[3, 0, 0, 0, 0, 0]));
+        a0 = mul_fp2_bls12_381(&a0, &EXT_U);
+        a0 = add_fp2_bls12_381(&a0, &[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
         (a0, a1)
     } else {
         // a1 = (a5²·(1+u) + 3·a4² - 2·a3)/(4·a2)
-        let a2_inv = inv_fp2_bls12_381(
-            &scalar_mul_fp2_bls12_381(
-                a2,
-                &[4, 0, 0, 0, 0, 0],
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let mut a4_sq = square_fp2_bls12_381(
-            a4,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a4_sq = scalar_mul_fp2_bls12_381(
-            &a4_sq,
-            &[3, 0, 0, 0, 0, 0],
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let mut a1 = square_fp2_bls12_381(
-            a5,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = mul_fp2_bls12_381(
-            &a1,
-            &EXT_U,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = add_fp2_bls12_381(
-            &a1,
-            &a4_sq,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = sub_fp2_bls12_381(
-            &a1,
-            &dbl_fp2_bls12_381(
-                a3,
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = mul_fp2_bls12_381(
-            &a1,
-            &a2_inv,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let a2_inv = inv_fp2_bls12_381(&scalar_mul_fp2_bls12_381(a2, &[4, 0, 0, 0, 0, 0]));
+        let mut a4_sq = square_fp2_bls12_381(a4);
+        a4_sq = scalar_mul_fp2_bls12_381(&a4_sq, &[3, 0, 0, 0, 0, 0]);
+        let mut a1 = square_fp2_bls12_381(a5);
+        a1 = mul_fp2_bls12_381(&a1, &EXT_U);
+        a1 = add_fp2_bls12_381(&a1, &a4_sq);
+        a1 = sub_fp2_bls12_381(&a1, &dbl_fp2_bls12_381(a3));
+        a1 = mul_fp2_bls12_381(&a1, &a2_inv);
         // a0 = (2·a1² + a2·a5 - 3·a3·a4)(1+u) + 1
-        let a3a4 = mul_fp2_bls12_381(
-            a3,
-            a4,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let a2a5 = mul_fp2_bls12_381(
-            a2,
-            a5,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let mut a0 = square_fp2_bls12_381(
-            &a1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = dbl_fp2_bls12_381(
-            &a0,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = add_fp2_bls12_381(
-            &a0,
-            &a2a5,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = sub_fp2_bls12_381(
-            &a0,
-            &scalar_mul_fp2_bls12_381(
-                &a3a4,
-                &[3, 0, 0, 0, 0, 0],
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = mul_fp2_bls12_381(
-            &a0,
-            &EXT_U,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = add_fp2_bls12_381(
-            &a0,
-            &[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let a3a4 = mul_fp2_bls12_381(a3, a4);
+        let a2a5 = mul_fp2_bls12_381(a2, a5);
+        let mut a0 = square_fp2_bls12_381(&a1);
+        a0 = dbl_fp2_bls12_381(&a0);
+        a0 = add_fp2_bls12_381(&a0, &a2a5);
+        a0 = sub_fp2_bls12_381(&a0, &scalar_mul_fp2_bls12_381(&a3a4, &[3, 0, 0, 0, 0, 0]));
+        a0 = mul_fp2_bls12_381(&a0, &EXT_U);
+        a0 = add_fp2_bls12_381(&a0, &[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
         (a0, a1)
     };
@@ -260,180 +117,46 @@ pub fn decompress_cyclo_bls12_381(
 //     - B45 = a4·a5
 //
 /// **NOTE**: The output is not guaranteed to be in GΦ6(p²), if the input isn't.
-pub fn square_cyclo_bls12_381(
-    a: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn square_cyclo_bls12_381(a: &[u64; 48]) -> [u64; 48] {
     let a2: &[u64; 12] = &a[0..12].try_into().unwrap();
     let a3: &[u64; 12] = &a[12..24].try_into().unwrap();
     let a4: &[u64; 12] = &a[24..36].try_into().unwrap();
     let a5: &[u64; 12] = &a[36..48].try_into().unwrap();
 
     // B23 = a2·a3, B45 = a4·a5
-    let b23 = mul_fp2_bls12_381(
-        a2,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let b45 = mul_fp2_bls12_381(
-        a4,
-        a5,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let b23 = mul_fp2_bls12_381(a2, a3);
+    let b45 = mul_fp2_bls12_381(a4, a5);
 
     // A23 = (a2 + a3)·(a2 + (1+u)·a3)
-    let a3xi = mul_fp2_bls12_381(
-        a3,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a23 = mul_fp2_bls12_381(
-        &add_fp2_bls12_381(
-            a2,
-            a3,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        &add_fp2_bls12_381(
-            a2,
-            &a3xi,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a3xi = mul_fp2_bls12_381(a3, &EXT_U);
+    let a23 = mul_fp2_bls12_381(&add_fp2_bls12_381(a2, a3), &add_fp2_bls12_381(a2, &a3xi));
 
     // A45 = (a4 + a5)·(a4 + (1+u)·a5)
-    let a5xi = mul_fp2_bls12_381(
-        a5,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a45 = mul_fp2_bls12_381(
-        &add_fp2_bls12_381(
-            a4,
-            a5,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        &add_fp2_bls12_381(
-            a4,
-            &a5xi,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a5xi = mul_fp2_bls12_381(a5, &EXT_U);
+    let a45 = mul_fp2_bls12_381(&add_fp2_bls12_381(a4, a5), &add_fp2_bls12_381(a4, &a5xi));
 
     // b2 = 2(a2 + 3·(1+u)·B45)
-    let mut b2 = mul_fp2_bls12_381(
-        &b45,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b2 = scalar_mul_fp2_bls12_381(
-        &b2,
-        &[3, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b2 = add_fp2_bls12_381(
-        a2,
-        &b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b2 = dbl_fp2_bls12_381(
-        &b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut b2 = mul_fp2_bls12_381(&b45, &EXT_U);
+    b2 = scalar_mul_fp2_bls12_381(&b2, &[3, 0, 0, 0, 0, 0]);
+    b2 = add_fp2_bls12_381(a2, &b2);
+    b2 = dbl_fp2_bls12_381(&b2);
 
     // b3 = 3·(A45 - (2+u)·B45) - 2·a3
-    let mut b3 = mul_fp2_bls12_381(
-        &b45,
-        &[2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b3 = sub_fp2_bls12_381(
-        &a45,
-        &b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b3 = scalar_mul_fp2_bls12_381(
-        &b3,
-        &[3, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b3 = sub_fp2_bls12_381(
-        &b3,
-        &dbl_fp2_bls12_381(
-            a3,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut b3 = mul_fp2_bls12_381(&b45, &[2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]);
+    b3 = sub_fp2_bls12_381(&a45, &b3);
+    b3 = scalar_mul_fp2_bls12_381(&b3, &[3, 0, 0, 0, 0, 0]);
+    b3 = sub_fp2_bls12_381(&b3, &dbl_fp2_bls12_381(a3));
 
     // b4 = 3·(A23 - (2+u)·B23) - 2·a4
-    let mut b4 = mul_fp2_bls12_381(
-        &b23,
-        &[2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b4 = sub_fp2_bls12_381(
-        &a23,
-        &b4,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b4 = scalar_mul_fp2_bls12_381(
-        &b4,
-        &[3, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b4 = sub_fp2_bls12_381(
-        &b4,
-        &dbl_fp2_bls12_381(
-            a4,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut b4 = mul_fp2_bls12_381(&b23, &[2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]);
+    b4 = sub_fp2_bls12_381(&a23, &b4);
+    b4 = scalar_mul_fp2_bls12_381(&b4, &[3, 0, 0, 0, 0, 0]);
+    b4 = sub_fp2_bls12_381(&b4, &dbl_fp2_bls12_381(a4));
 
     // b5 = 2·(a5 + 3·B23)
-    let mut b5 = scalar_mul_fp2_bls12_381(
-        &b23,
-        &[3, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b5 = add_fp2_bls12_381(
-        a5,
-        &b5,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b5 = dbl_fp2_bls12_381(
-        &b5,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut b5 = scalar_mul_fp2_bls12_381(&b23, &[3, 0, 0, 0, 0, 0]);
+    b5 = add_fp2_bls12_381(a5, &b5);
+    b5 = dbl_fp2_bls12_381(&b5);
 
     let mut result = [0u64; 48];
     result[0..12].copy_from_slice(&b2);
@@ -449,11 +172,7 @@ pub fn square_cyclo_bls12_381(
 // out: a^x = (a0 + a4·v + a3·v²) + (a2 + a1·v + a5·v²)·w ∈ ∈ GΦ6(p²)
 //
 /// **NOTE**: The output is not guaranteed to be in GΦ6(p²), if the input isn't.
-pub fn exp_cyclo_bls12_381(
-    a: &[u64; 72],
-    x: &[u8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn exp_cyclo_bls12_381(a: &[u64; 72], x: &[u8]) -> [u64; 72] {
     if eq(a, &[0; 72]) {
         return [0; 72];
     }
@@ -470,35 +189,19 @@ pub fn exp_cyclo_bls12_381(
     for &bit in x.iter() {
         if bit == 1 {
             // decompress and multiply
-            let decomp = decompress_cyclo_bls12_381(
-                &comp,
-                #[cfg(feature = "hints")]
-                hints,
-            );
-            result = mul_fp12_bls12_381(
-                &result,
-                &decomp,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let decomp = decompress_cyclo_bls12_381(&comp);
+            result = mul_fp12_bls12_381(&result, &decomp);
         }
 
         // We always square (in compressed form): C(c²)
-        comp = square_cyclo_bls12_381(
-            &comp,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        comp = square_cyclo_bls12_381(&comp);
     }
 
     result
 }
 
 /// Exponentiation in the cyclotomic subgroup GΦ6(p²) by x = 15132376222941642752
-pub fn exp_by_x_cyclo_bls12_381(
-    a: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn exp_by_x_cyclo_bls12_381(a: &[u64; 72]) -> [u64; 72] {
     /// Family parameter X
     const X_ABS_BIN_LE: [u8; 64] = [
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -506,19 +209,11 @@ pub fn exp_by_x_cyclo_bls12_381(
         1, 0, 1, 1,
     ];
 
-    exp_cyclo_bls12_381(
-        a,
-        &X_ABS_BIN_LE,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    exp_cyclo_bls12_381(a, &X_ABS_BIN_LE)
 }
 
 /// Exponentiation in the cyclotomic subgroup GΦ6(p²) by x+1 = 15132376222941642753
-pub fn exp_by_xone_cyclo_bls12_381(
-    a: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn exp_by_xone_cyclo_bls12_381(a: &[u64; 72]) -> [u64; 72] {
     /// Family parameter X+1
     const XONE_ABS_BIN_LE: [u8; 64] = [
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -526,19 +221,11 @@ pub fn exp_by_xone_cyclo_bls12_381(
         1, 0, 1, 1,
     ];
 
-    exp_cyclo_bls12_381(
-        a,
-        &XONE_ABS_BIN_LE,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    exp_cyclo_bls12_381(a, &XONE_ABS_BIN_LE)
 }
 
 /// Exponentiation in the cyclotomic subgroup GΦ6(p²) by (x+1)/3 = 5044125407647214251
-pub fn exp_by_xdiv3_cyclo_bls12_381(
-    a: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn exp_by_xdiv3_cyclo_bls12_381(a: &[u64; 72]) -> [u64; 72] {
     /// Family parameter (X+1)/3
     const XDIV3_ABS_BIN_LE: [u8; 63] = [
         1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
@@ -546,10 +233,5 @@ pub fn exp_by_xdiv3_cyclo_bls12_381(
         0, 0, 1,
     ];
 
-    exp_cyclo_bls12_381(
-        a,
-        &XDIV3_ABS_BIN_LE,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    exp_cyclo_bls12_381(a, &XDIV3_ABS_BIN_LE)
 }

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/final_exp.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/final_exp.rs
@@ -16,127 +16,46 @@ use super::{
 /// Given f ∈ Fp12*, computes f^((p¹²-1)/r) ∈ Fp12*
 ///
 /// Note: Unoptimized for the case f == 1
-pub fn final_exp_bls12_381(
-    f: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn final_exp_bls12_381(f: &[u64; 72]) -> [u64; 72] {
     //////////////////
     // The easy part: exp by (p^6-1)(p^2+1)
     //////////////////
 
     // f^(p^6-1) = f̅·f⁻¹
-    let f_conj = conjugate_fp12_bls12_381(
-        f,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let f_inv = inv_fp12_bls12_381(
-        f,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let easy1 = mul_fp12_bls12_381(
-        &f_conj,
-        &f_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let f_conj = conjugate_fp12_bls12_381(f);
+    let f_inv = inv_fp12_bls12_381(f);
+    let easy1 = mul_fp12_bls12_381(&f_conj, &f_inv);
 
     // easy1^(p²-1) = easy1^p²·easy1
-    let mut m = frobenius2_fp12_bls12_381(
-        &easy1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    m = mul_fp12_bls12_381(
-        &m,
-        &easy1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut m = frobenius2_fp12_bls12_381(&easy1);
+    m = mul_fp12_bls12_381(&m, &easy1);
 
     //////////////////
     // The hard part: exp by (p⁴-p²+1)/r
     //////////////////
 
     // f = m^{(x+1)/3}
-    let mut f = exp_by_xdiv3_cyclo_bls12_381(
-        &m,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut f = exp_by_xdiv3_cyclo_bls12_381(&m);
 
     // f = f^(x+1)
-    f = exp_by_xone_cyclo_bls12_381(
-        &f,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    f = exp_by_xone_cyclo_bls12_381(&f);
 
     // f1 = f^p, f2 = f̅^x
-    let f1 = frobenius1_fp12_bls12_381(
-        &f,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let f2 = exp_by_x_cyclo_bls12_381(
-        &conjugate_fp12_bls12_381(
-            &f,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let f1 = frobenius1_fp12_bls12_381(&f);
+    let f2 = exp_by_x_cyclo_bls12_381(&conjugate_fp12_bls12_381(&f));
 
     // f = f1*f2
-    let f = mul_fp12_bls12_381(
-        &f1,
-        &f2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let f = mul_fp12_bls12_381(&f1, &f2);
 
     // f1 = (f^x)^x, f2 = f^p², f3 = f̅
-    let f1 = exp_by_x_cyclo_bls12_381(
-        &exp_by_x_cyclo_bls12_381(
-            &f,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let f2 = frobenius2_fp12_bls12_381(
-        &f,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let f3 = conjugate_fp12_bls12_381(
-        &f,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let f1 = exp_by_x_cyclo_bls12_381(&exp_by_x_cyclo_bls12_381(&f));
+    let f2 = frobenius2_fp12_bls12_381(&f);
+    let f3 = conjugate_fp12_bls12_381(&f);
 
     // f = f1*f2*f3*m
-    let mut f = mul_fp12_bls12_381(
-        &f1,
-        &f2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    f = mul_fp12_bls12_381(
-        &f,
-        &f3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    f = mul_fp12_bls12_381(
-        &f,
-        &m,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut f = mul_fp12_bls12_381(&f1, &f2);
+    f = mul_fp12_bls12_381(&f, &f3);
+    f = mul_fp12_bls12_381(&f, &m);
 
     f
 }

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/fp.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/fp.rs
@@ -15,11 +15,7 @@ pub fn sgn0_fp_bls12_381(x: &[u64; 6]) -> u64 {
 
 /// Addition in Fp
 #[inline]
-pub fn add_fp_bls12_381(
-    x: &[u64; 6],
-    y: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 6] {
+pub fn add_fp_bls12_381(x: &[u64; 6], y: &[u64; 6]) -> [u64; 6] {
     // x·1 + y
     let mut params = SyscallArith384ModParams {
         a: x,
@@ -28,17 +24,13 @@ pub fn add_fp_bls12_381(
         module: &P,
         d: &mut [0, 0, 0, 0, 0, 0],
     };
-    syscall_arith384_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith384_mod(&mut params);
     *params.d
 }
 
 /// Doubling in Fp
 #[inline]
-pub fn dbl_fp_bls12_381(x: &[u64; 6], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 6] {
+pub fn dbl_fp_bls12_381(x: &[u64; 6]) -> [u64; 6] {
     // 2·x + 0 or x·1 + x
     let mut params = SyscallArith384ModParams {
         a: x,
@@ -47,21 +39,13 @@ pub fn dbl_fp_bls12_381(x: &[u64; 6], #[cfg(feature = "hints")] hints: &mut Vec<
         module: &P,
         d: &mut [0, 0, 0, 0, 0, 0],
     };
-    syscall_arith384_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith384_mod(&mut params);
     *params.d
 }
 
 /// Subtraction in Fp
 #[inline]
-pub fn sub_fp_bls12_381(
-    x: &[u64; 6],
-    y: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 6] {
+pub fn sub_fp_bls12_381(x: &[u64; 6], y: &[u64; 6]) -> [u64; 6] {
     // y·(-1) + x
     let mut params = SyscallArith384ModParams {
         a: y,
@@ -70,17 +54,13 @@ pub fn sub_fp_bls12_381(
         module: &P,
         d: &mut [0, 0, 0, 0, 0, 0],
     };
-    syscall_arith384_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith384_mod(&mut params);
     *params.d
 }
 
 /// Negation in Fp
 #[inline]
-pub fn neg_fp_bls12_381(x: &[u64; 6], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 6] {
+pub fn neg_fp_bls12_381(x: &[u64; 6]) -> [u64; 6] {
     // x·(-1) + 0
     let mut params = SyscallArith384ModParams {
         a: x,
@@ -89,21 +69,13 @@ pub fn neg_fp_bls12_381(x: &[u64; 6], #[cfg(feature = "hints")] hints: &mut Vec<
         module: &P,
         d: &mut [0, 0, 0, 0, 0, 0],
     };
-    syscall_arith384_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith384_mod(&mut params);
     *params.d
 }
 
 /// Multiplication in Fp
 #[inline]
-pub fn mul_fp_bls12_381(
-    x: &[u64; 6],
-    y: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 6] {
+pub fn mul_fp_bls12_381(x: &[u64; 6], y: &[u64; 6]) -> [u64; 6] {
     // x·y + 0
     let mut params = SyscallArith384ModParams {
         a: x,
@@ -112,20 +84,13 @@ pub fn mul_fp_bls12_381(
         module: &P,
         d: &mut [0, 0, 0, 0, 0, 0],
     };
-    syscall_arith384_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith384_mod(&mut params);
     *params.d
 }
 
 /// Squaring in Fp
 #[inline]
-pub fn square_fp_bls12_381(
-    x: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 6] {
+pub fn square_fp_bls12_381(x: &[u64; 6]) -> [u64; 6] {
     // x·x + 0
     let mut params = SyscallArith384ModParams {
         a: x,
@@ -134,26 +99,15 @@ pub fn square_fp_bls12_381(
         module: &P,
         d: &mut [0, 0, 0, 0, 0, 0],
     };
-    syscall_arith384_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith384_mod(&mut params);
     *params.d
 }
 
 /// Square root in Fp
 #[inline]
-pub fn sqrt_fp_bls12_381(
-    x: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> ([u64; 6], bool) {
+pub fn sqrt_fp_bls12_381(x: &[u64; 6]) -> ([u64; 6], bool) {
     // Hint the sqrt
-    let hint = fcall_bls12_381_fp_sqrt(
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let hint = fcall_bls12_381_fp_sqrt(x);
     let is_qr = hint[0] == 1;
     let sqrt = hint[1..7].try_into().unwrap();
 
@@ -165,11 +119,7 @@ pub fn sqrt_fp_bls12_381(
         module: &P,
         d: &mut [0, 0, 0, 0, 0, 0],
     };
-    syscall_arith384_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith384_mod(&mut params);
 
     if is_qr {
         // Check that sqrt * sqrt == x
@@ -177,12 +127,7 @@ pub fn sqrt_fp_bls12_381(
         (sqrt, true)
     } else {
         // Check that sqrt * sqrt == x * NQR
-        let nqr = mul_fp_bls12_381(
-            x,
-            &NQR_FP,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let nqr = mul_fp_bls12_381(x, &NQR_FP);
         assert_eq!(*params.d, nqr);
         (sqrt, false)
     }
@@ -190,7 +135,7 @@ pub fn sqrt_fp_bls12_381(
 
 /// Inversion of a non-zero element in Fp
 #[inline]
-pub fn inv_fp_bls12_381(x: &[u64; 6], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 6] {
+pub fn inv_fp_bls12_381(x: &[u64; 6]) -> [u64; 6] {
     // if x == 0, return 0
     if eq(x, &[0; 6]) {
         return *x;
@@ -200,11 +145,7 @@ pub fn inv_fp_bls12_381(x: &[u64; 6], #[cfg(feature = "hints")] hints: &mut Vec<
 
     // Remember that an element y ∈ Fp is the inverse of x ∈ Fp if and only if x·y = 1 in Fp
     // We will therefore hint the inverse y and check the product with x is 1
-    let inv = fcall_bls12_381_fp_inv(
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let inv = fcall_bls12_381_fp_inv(x);
 
     // x·y + 0
     let mut params = SyscallArith384ModParams {
@@ -214,11 +155,7 @@ pub fn inv_fp_bls12_381(x: &[u64; 6], #[cfg(feature = "hints")] hints: &mut Vec<
         module: &P,
         d: &mut [0, 0, 0, 0, 0, 0],
     };
-    syscall_arith384_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith384_mod(&mut params);
     assert_eq!(*params.d, [1, 0, 0, 0, 0, 0]);
 
     inv

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/fp12.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/fp12.rs
@@ -23,75 +23,26 @@ use super::{
 //       - c1 = a1·b1 + a2·b2·v
 //       - c2 = (a1+a2)·(b1+b2) - a1·b1 - a2·b2
 #[inline]
-pub fn mul_fp12_bls12_381(
-    a: &[u64; 72],
-    b: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn mul_fp12_bls12_381(a: &[u64; 72], b: &[u64; 72]) -> [u64; 72] {
     let a1 = &a[0..36].try_into().unwrap();
     let a2 = &a[36..72].try_into().unwrap();
     let b1 = &b[0..36].try_into().unwrap();
     let b2 = &b[36..72].try_into().unwrap();
 
     // a1·b1, a2·b2
-    let a1_b1 = mul_fp6_bls12_381(
-        a1,
-        b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2_b2 = mul_fp6_bls12_381(
-        a2,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_b1 = mul_fp6_bls12_381(a1, b1);
+    let a2_b2 = mul_fp6_bls12_381(a2, b2);
 
     // c1 = a1·b1 + a2·b2·v
-    let mut c1 = sparse_mula_fp6_bls12_381(
-        &a2_b2,
-        &EXT_V,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp6_bls12_381(
-        &c1,
-        &a1_b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = sparse_mula_fp6_bls12_381(&a2_b2, &EXT_V);
+    c1 = add_fp6_bls12_381(&c1, &a1_b1);
 
     // c2 = (a1+a2)·(b1+b2) - a1·b1 - a2·b2
-    let a1_plus_a2 = add_fp6_bls12_381(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let b1_plus_b2 = add_fp6_bls12_381(
-        b1,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut c2 = mul_fp6_bls12_381(
-        &a1_plus_a2,
-        &b1_plus_b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = sub_fp6_bls12_381(
-        &c2,
-        &a1_b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = sub_fp6_bls12_381(
-        &c2,
-        &a2_b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_plus_a2 = add_fp6_bls12_381(a1, a2);
+    let b1_plus_b2 = add_fp6_bls12_381(b1, b2);
+    let mut c2 = mul_fp6_bls12_381(&a1_plus_a2, &b1_plus_b2);
+    c2 = sub_fp6_bls12_381(&c2, &a1_b1);
+    c2 = sub_fp6_bls12_381(&c2, &a2_b2);
 
     let mut result = [0u64; 72];
     result[0..36].copy_from_slice(&c1);
@@ -106,55 +57,26 @@ pub fn mul_fp12_bls12_381(
 //       - c1 = a1 + a2·(b23·(1+u) + b22·v²)
 //       - c2 = a2 + a1·(b22·v + b23·v²)
 #[inline]
-pub fn sparse_mul_fp12_bls12_381(
-    a: &[u64; 72],
-    b: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn sparse_mul_fp12_bls12_381(a: &[u64; 72], b: &[u64; 24]) -> [u64; 72] {
     let a1 = &a[0..36].try_into().unwrap();
     let a2 = &a[36..72].try_into().unwrap();
     let b22: &[u64; 12] = &b[0..12].try_into().unwrap();
     let b23 = &b[12..24].try_into().unwrap();
 
     // c1 = a1 + a2·(b23·(1+u) + b22·v²)
-    let b23u = mul_fp2_bls12_381(
-        &EXT_U,
-        b23,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let b23u = mul_fp2_bls12_381(&EXT_U, b23);
     let mut sparse_c1 = [0u64; 24];
     sparse_c1[0..12].copy_from_slice(&b23u);
     sparse_c1[12..24].copy_from_slice(b22);
-    let mut c1 = sparse_mulc_fp6_bls12_381(
-        a2,
-        &sparse_c1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp6_bls12_381(
-        &c1,
-        a1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = sparse_mulc_fp6_bls12_381(a2, &sparse_c1);
+    c1 = add_fp6_bls12_381(&c1, a1);
 
     // c2 = a2 + a1·(b22·v + b23·v²)
     let mut sparse_c2 = [0u64; 24];
     sparse_c2[0..12].copy_from_slice(b22);
     sparse_c2[12..24].copy_from_slice(b23);
-    let mut c2 = sparse_mulb_fp6_bls12_381(
-        a1,
-        &sparse_c2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp6_bls12_381(
-        &c2,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = sparse_mulb_fp6_bls12_381(a1, &sparse_c2);
+    c2 = add_fp6_bls12_381(&c2, a2);
 
     let mut result = [0u64; 72];
     result[0..36].copy_from_slice(&c1);
@@ -169,71 +91,24 @@ pub fn sparse_mul_fp12_bls12_381(
 //       - c1 = (a1-a2)·(a1-a2·v) + a1·a2 + a1·a2·v
 //       - c2 = 2·a1·a2
 #[inline]
-pub fn square_fp12_bls12_381(
-    a: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn square_fp12_bls12_381(a: &[u64; 72]) -> [u64; 72] {
     let a1 = &a[0..36].try_into().unwrap();
     let a2 = &a[36..72].try_into().unwrap();
 
     // a1·a2, a2·v, a1·a2·v
-    let a1_a2 = mul_fp6_bls12_381(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2_v = sparse_mula_fp6_bls12_381(
-        a2,
-        &EXT_V,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1_a2_v = sparse_mula_fp6_bls12_381(
-        &a1_a2,
-        &EXT_V,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_a2 = mul_fp6_bls12_381(a1, a2);
+    let a2_v = sparse_mula_fp6_bls12_381(a2, &EXT_V);
+    let a1_a2_v = sparse_mula_fp6_bls12_381(&a1_a2, &EXT_V);
 
     // c2 = 2·a1·a2
-    let c2 = dbl_fp6_bls12_381(
-        &a1_a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c2 = dbl_fp6_bls12_381(&a1_a2);
 
     // c1 = (a1-a2)·(a1-a2·v) + a1·a2 + a1·a2·v
-    let a1_minus_a2 = sub_fp6_bls12_381(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1_minus_a2v = sub_fp6_bls12_381(
-        a1,
-        &a2_v,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut c1 = mul_fp6_bls12_381(
-        &a1_minus_a2,
-        &a1_minus_a2v,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp6_bls12_381(
-        &c1,
-        &a1_a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp6_bls12_381(
-        &c1,
-        &a1_a2_v,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_minus_a2 = sub_fp6_bls12_381(a1, a2);
+    let a1_minus_a2v = sub_fp6_bls12_381(a1, &a2_v);
+    let mut c1 = mul_fp6_bls12_381(&a1_minus_a2, &a1_minus_a2v);
+    c1 = add_fp6_bls12_381(&c1, &a1_a2);
+    c1 = add_fp6_bls12_381(&c1, &a1_a2_v);
 
     let mut result = [0u64; 72];
     result[0..36].copy_from_slice(&c1);
@@ -248,61 +123,22 @@ pub fn square_fp12_bls12_381(
 //       - c1 = a1·(a1² - a2²·v)⁻¹
 //       - c2 = -a2·(a1² - a2²·v)⁻¹
 #[inline]
-pub fn inv_fp12_bls12_381(
-    a: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn inv_fp12_bls12_381(a: &[u64; 72]) -> [u64; 72] {
     let a1 = &a[0..36].try_into().unwrap();
     let a2 = &a[36..72].try_into().unwrap();
 
     // a1², a2², a2²·v
-    let a1_square = square_fp6_bls12_381(
-        a1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2_square = square_fp6_bls12_381(
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2_square_v = sparse_mula_fp6_bls12_381(
-        &a2_square,
-        &EXT_V,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_square = square_fp6_bls12_381(a1);
+    let a2_square = square_fp6_bls12_381(a2);
+    let a2_square_v = sparse_mula_fp6_bls12_381(&a2_square, &EXT_V);
 
     // (a1² - a2²·v)⁻¹
-    let mut denom = sub_fp6_bls12_381(
-        &a1_square,
-        &a2_square_v,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    denom = inv_fp6_bls12_381(
-        &denom,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut denom = sub_fp6_bls12_381(&a1_square, &a2_square_v);
+    denom = inv_fp6_bls12_381(&denom);
 
     // c1 = a1·(a1² - a2²·v)⁻¹, c2 = -a2·(a1² - a2²·v)⁻¹
-    let c1 = mul_fp6_bls12_381(
-        a1,
-        &denom,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let c2 = neg_fp6_bls12_381(
-        &mul_fp6_bls12_381(
-            a2,
-            &denom,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c1 = mul_fp6_bls12_381(a1, &denom);
+    let c2 = neg_fp6_bls12_381(&mul_fp6_bls12_381(a2, &denom));
 
     let mut result = [0u64; 72];
     result[0..36].copy_from_slice(&c1);
@@ -312,17 +148,10 @@ pub fn inv_fp12_bls12_381(
 
 /// Conjugation in Fp12
 #[inline]
-pub fn conjugate_fp12_bls12_381(
-    a: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn conjugate_fp12_bls12_381(a: &[u64; 72]) -> [u64; 72] {
     let mut result = [0; 72];
     result[0..36].copy_from_slice(&a[0..36]);
-    result[36..72].copy_from_slice(&neg_fp6_bls12_381(
-        &a[36..72].try_into().unwrap(),
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    result[36..72].copy_from_slice(&neg_fp6_bls12_381(&a[36..72].try_into().unwrap()));
     result
 }
 
@@ -333,10 +162,7 @@ pub fn conjugate_fp12_bls12_381(
 //       - c1 = a̅11     + a̅12·γ12·v + a̅13·γ14·v²
 //       - c2 = a̅21·γ11 + a̅22·γ13·v + a̅23·γ15·v²
 #[inline]
-pub fn frobenius1_fp12_bls12_381(
-    a: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn frobenius1_fp12_bls12_381(a: &[u64; 72]) -> [u64; 72] {
     let a11 = &a[0..12].try_into().unwrap();
     let a12 = &a[12..24].try_into().unwrap();
     let a13 = &a[24..36].try_into().unwrap();
@@ -347,68 +173,19 @@ pub fn frobenius1_fp12_bls12_381(
     let mut result = [0; 72];
 
     // c1 = a̅11 + a̅12·γ12·v + a̅13·γ14·v²
-    result[0..12].copy_from_slice(&conjugate_fp2_bls12_381(
-        a11,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    let mut tmp = conjugate_fp2_bls12_381(
-        a12,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[12..24].copy_from_slice(&mul_fp2_bls12_381(
-        &tmp,
-        &FROBENIUS_GAMMA12,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    tmp = conjugate_fp2_bls12_381(
-        a13,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[24..36].copy_from_slice(&scalar_mul_fp2_bls12_381(
-        &tmp,
-        &FROBENIUS_GAMMA14,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    result[0..12].copy_from_slice(&conjugate_fp2_bls12_381(a11));
+    let mut tmp = conjugate_fp2_bls12_381(a12);
+    result[12..24].copy_from_slice(&mul_fp2_bls12_381(&tmp, &FROBENIUS_GAMMA12));
+    tmp = conjugate_fp2_bls12_381(a13);
+    result[24..36].copy_from_slice(&scalar_mul_fp2_bls12_381(&tmp, &FROBENIUS_GAMMA14));
 
     // c2 = a̅21·γ11 + a̅22·γ13·v + a̅23·γ15·v²
-    tmp = conjugate_fp2_bls12_381(
-        a21,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[36..48].copy_from_slice(&mul_fp2_bls12_381(
-        &tmp,
-        &FROBENIUS_GAMMA11,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    tmp = conjugate_fp2_bls12_381(
-        a22,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[48..60].copy_from_slice(&mul_fp2_bls12_381(
-        &tmp,
-        &FROBENIUS_GAMMA13,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    tmp = conjugate_fp2_bls12_381(
-        a23,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[60..72].copy_from_slice(&mul_fp2_bls12_381(
-        &tmp,
-        &FROBENIUS_GAMMA15,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    tmp = conjugate_fp2_bls12_381(a21);
+    result[36..48].copy_from_slice(&mul_fp2_bls12_381(&tmp, &FROBENIUS_GAMMA11));
+    tmp = conjugate_fp2_bls12_381(a22);
+    result[48..60].copy_from_slice(&mul_fp2_bls12_381(&tmp, &FROBENIUS_GAMMA13));
+    tmp = conjugate_fp2_bls12_381(a23);
+    result[60..72].copy_from_slice(&mul_fp2_bls12_381(&tmp, &FROBENIUS_GAMMA15));
 
     result
 }
@@ -420,10 +197,7 @@ pub fn frobenius1_fp12_bls12_381(
 //       - c1 = a11     + a12·γ22·v + a13·γ24·v²
 //       - c2 = a21·γ21 + a22·γ23·v + a23·γ25·v²
 #[inline]
-pub fn frobenius2_fp12_bls12_381(
-    a: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn frobenius2_fp12_bls12_381(a: &[u64; 72]) -> [u64; 72] {
     let a11: &[u64; 12] = &a[0..12].try_into().unwrap();
     let a12 = &a[12..24].try_into().unwrap();
     let a13 = &a[24..36].try_into().unwrap();
@@ -435,38 +209,13 @@ pub fn frobenius2_fp12_bls12_381(
 
     // c1 = a11 + a12·γ22·v + a13·γ24·v²
     result[0..12].copy_from_slice(a11);
-    result[12..24].copy_from_slice(&scalar_mul_fp2_bls12_381(
-        a12,
-        &FROBENIUS_GAMMA22,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    result[24..36].copy_from_slice(&scalar_mul_fp2_bls12_381(
-        a13,
-        &FROBENIUS_GAMMA24,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    result[12..24].copy_from_slice(&scalar_mul_fp2_bls12_381(a12, &FROBENIUS_GAMMA22));
+    result[24..36].copy_from_slice(&scalar_mul_fp2_bls12_381(a13, &FROBENIUS_GAMMA24));
 
     // c2 = a21·γ21 + a22·γ23·v + a23·γ25·v²
-    result[36..48].copy_from_slice(&scalar_mul_fp2_bls12_381(
-        a21,
-        &FROBENIUS_GAMMA21,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    result[48..60].copy_from_slice(&scalar_mul_fp2_bls12_381(
-        a22,
-        &FROBENIUS_GAMMA23,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    result[60..72].copy_from_slice(&scalar_mul_fp2_bls12_381(
-        a23,
-        &FROBENIUS_GAMMA25,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    result[36..48].copy_from_slice(&scalar_mul_fp2_bls12_381(a21, &FROBENIUS_GAMMA21));
+    result[48..60].copy_from_slice(&scalar_mul_fp2_bls12_381(a22, &FROBENIUS_GAMMA23));
+    result[60..72].copy_from_slice(&scalar_mul_fp2_bls12_381(a23, &FROBENIUS_GAMMA25));
 
     result
 }
@@ -476,11 +225,7 @@ pub fn frobenius2_fp12_bls12_381(
 // in: e, (a1 + a2·w) ∈ Fp12, where e ∈ [0,p¹²-2] ai ∈ Fp6
 // out: (c1 + c2·w) = (a1 + a2·w)^e ∈ Fp12
 #[inline]
-pub fn exp_fp12_bls12_381(
-    e: u64,
-    a: &[u64; 72],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn exp_fp12_bls12_381(e: u64, a: &[u64; 72]) -> [u64; 72] {
     let one = {
         let mut tmp = [0; 72];
         tmp[0] = 1;
@@ -499,12 +244,7 @@ pub fn exp_fp12_bls12_381(
         return *a;
     }
 
-    let (_, max_bit) = fcall_msb_pos_384(
-        &[e, 0, 0, 0, 0, 0],
-        &[0, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (_, max_bit) = fcall_msb_pos_384(&[e, 0, 0, 0, 0, 0], &[0, 0, 0, 0, 0, 0]);
 
     // Perform the loop, based on the binary representation of e
 
@@ -520,21 +260,12 @@ pub fn exp_fp12_bls12_381(
     let _max_bit = max_bit as usize;
     for i in (0.._max_bit).rev() {
         // Always square
-        result = square_fp12_bls12_381(
-            &result,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        result = square_fp12_bls12_381(&result);
 
         // Get the next bit b of e
         // If b == 1, we should multiply it by a, otherwise start the next iteration
         if ((e >> i) & 1) == 1 {
-            result = mul_fp12_bls12_381(
-                &result,
-                a,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            result = mul_fp12_bls12_381(&result, a);
 
             // Reconstruct e
             e_rec |= 1 << i;

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/fp2.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/fp2.rs
@@ -41,151 +41,86 @@ pub fn sgn0_fp2_bls12_381(x: &[u64; 12]) -> u64 {
 
 /// Addition in Fp2
 #[inline]
-pub fn add_fp2_bls12_381(
-    a: &[u64; 12],
-    b: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn add_fp2_bls12_381(a: &[u64; 12], b: &[u64; 12]) -> [u64; 12] {
     let mut f1 = to_syscall_complex(a);
     let f2 = to_syscall_complex(b);
     let mut params = SyscallBls12_381ComplexAddParams { f1: &mut f1, f2: &f2 };
-    syscall_bls12_381_complex_add(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_complex_add(&mut params);
     from_syscall_complex(&f1)
 }
 
 /// Doubling in Fp2
 #[inline]
-pub fn dbl_fp2_bls12_381(
-    a: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn dbl_fp2_bls12_381(a: &[u64; 12]) -> [u64; 12] {
     let mut f1 = to_syscall_complex(a);
     let f2 = to_syscall_complex(a);
     let mut params = SyscallBls12_381ComplexAddParams { f1: &mut f1, f2: &f2 };
-    syscall_bls12_381_complex_add(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_complex_add(&mut params);
     from_syscall_complex(&f1)
 }
 
 /// Negation in Fp2
 #[inline]
-pub fn neg_fp2_bls12_381(
-    a: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn neg_fp2_bls12_381(a: &[u64; 12]) -> [u64; 12] {
     let mut f1 = to_syscall_complex(a);
     let f2 = to_syscall_complex_x(&P_MINUS_ONE);
     let mut params = SyscallBls12_381ComplexMulParams { f1: &mut f1, f2: &f2 };
-    syscall_bls12_381_complex_mul(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_complex_mul(&mut params);
     from_syscall_complex(&f1)
 }
 
 /// Subtraction in Fp2
 #[inline]
-pub fn sub_fp2_bls12_381(
-    a: &[u64; 12],
-    b: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn sub_fp2_bls12_381(a: &[u64; 12], b: &[u64; 12]) -> [u64; 12] {
     let mut f1 = to_syscall_complex(a);
     let f2 = to_syscall_complex(b);
     let mut params = SyscallBls12_381ComplexSubParams { f1: &mut f1, f2: &f2 };
-    syscall_bls12_381_complex_sub(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_complex_sub(&mut params);
     from_syscall_complex(&f1)
 }
 
 /// Multiplication in Fp2
 #[inline]
-pub fn mul_fp2_bls12_381(
-    a: &[u64; 12],
-    b: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn mul_fp2_bls12_381(a: &[u64; 12], b: &[u64; 12]) -> [u64; 12] {
     let mut f1 = to_syscall_complex(a);
     let f2 = to_syscall_complex(b);
     let mut params = SyscallBls12_381ComplexMulParams { f1: &mut f1, f2: &f2 };
-    syscall_bls12_381_complex_mul(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_complex_mul(&mut params);
     from_syscall_complex(&f1)
 }
 
 /// Scalar multiplication in Fp2
 #[inline]
-pub fn scalar_mul_fp2_bls12_381(
-    a: &[u64; 12],
-    b: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn scalar_mul_fp2_bls12_381(a: &[u64; 12], b: &[u64; 6]) -> [u64; 12] {
     let mut f1 =
         SyscallComplex384 { x: a[0..6].try_into().unwrap(), y: a[6..12].try_into().unwrap() };
     let f2 = SyscallComplex384 { x: b[0..6].try_into().unwrap(), y: [0, 0, 0, 0, 0, 0] };
 
     let mut params = SyscallBls12_381ComplexMulParams { f1: &mut f1, f2: &f2 };
-    syscall_bls12_381_complex_mul(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_complex_mul(&mut params);
     from_syscall_complex(&f1)
 }
 
 /// Squaring in Fp2
 #[inline]
-pub fn square_fp2_bls12_381(
-    a: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn square_fp2_bls12_381(a: &[u64; 12]) -> [u64; 12] {
     let mut f1 = to_syscall_complex(a);
     let f2 = to_syscall_complex(a);
     let mut params = SyscallBls12_381ComplexMulParams { f1: &mut f1, f2: &f2 };
-    syscall_bls12_381_complex_mul(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_complex_mul(&mut params);
     from_syscall_complex(&f1)
 }
 
 /// Square root in Fp2
 #[inline]
-pub fn sqrt_fp2_bls12_381(
-    x: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> ([u64; 12], bool) {
+pub fn sqrt_fp2_bls12_381(x: &[u64; 12]) -> ([u64; 12], bool) {
     // Hint the sqrt
-    let hint = fcall_bls12_381_fp2_sqrt(
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let hint = fcall_bls12_381_fp2_sqrt(x);
     let is_qr = hint[0] == 1;
     let sqrt = hint[1..13].try_into().unwrap();
 
     // Compute sqrt * sqrt
-    let mul = mul_fp2_bls12_381(
-        &sqrt,
-        &sqrt,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mul = mul_fp2_bls12_381(&sqrt, &sqrt);
 
     if is_qr {
         // Check that sqrt * sqrt == x
@@ -193,12 +128,7 @@ pub fn sqrt_fp2_bls12_381(
         (sqrt, true)
     } else {
         // Check that sqrt * sqrt == x * NQR
-        let nqr = mul_fp2_bls12_381(
-            x,
-            &NQR_FP2,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let nqr = mul_fp2_bls12_381(x, &NQR_FP2);
         assert!(eq(&mul, &nqr));
         (sqrt, false)
     }
@@ -206,10 +136,7 @@ pub fn sqrt_fp2_bls12_381(
 
 /// Inversion in Fp2: returns a⁻¹
 #[inline]
-pub fn inv_fp2_bls12_381(
-    a: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn inv_fp2_bls12_381(a: &[u64; 12]) -> [u64; 12] {
     // if a == 0, return 0
     if eq(a, &[0; 12]) {
         return *a;
@@ -219,18 +146,9 @@ pub fn inv_fp2_bls12_381(
 
     // Remember that an element b ∈ Fp2 is the inverse of a ∈ Fp2 if and only if a·b = 1 in Fp2
     // We will therefore hint the inverse b and check the product with a is 1
-    let inv = fcall_bls12_381_fp2_inv(
-        a,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let inv = fcall_bls12_381_fp2_inv(a);
 
-    let product = mul_fp2_bls12_381(
-        a,
-        &inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let product = mul_fp2_bls12_381(a, &inv);
     assert_eq!(&product[0..6], &[1, 0, 0, 0, 0, 0]);
     assert_eq!(&product[6..12], &[0, 0, 0, 0, 0, 0]);
 
@@ -239,19 +157,12 @@ pub fn inv_fp2_bls12_381(
 
 /// Conjugation in Fp2
 #[inline]
-pub fn conjugate_fp2_bls12_381(
-    a: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+pub fn conjugate_fp2_bls12_381(a: &[u64; 12]) -> [u64; 12] {
     let mut f1 = SyscallComplex384 { x: a[0..6].try_into().unwrap(), y: [0, 0, 0, 0, 0, 0] };
     let f2 = SyscallComplex384 { x: [0, 0, 0, 0, 0, 0], y: a[6..12].try_into().unwrap() };
 
     let mut params = SyscallBls12_381ComplexSubParams { f1: &mut f1, f2: &f2 };
-    syscall_bls12_381_complex_sub(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bls12_381_complex_sub(&mut params);
     from_syscall_complex(&f1)
 }
 

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/fp6.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/fp6.rs
@@ -10,21 +10,12 @@ use super::{
 
 /// Addition in Fp6
 #[inline]
-pub fn add_fp6_bls12_381(
-    a: &[u64; 36],
-    b: &[u64; 36],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn add_fp6_bls12_381(a: &[u64; 36], b: &[u64; 36]) -> [u64; 36] {
     let mut result = [0; 36];
     for i in 0..3 {
         let a_i = &a[i * 12..(i + 1) * 12].try_into().unwrap();
         let b_i = &b[i * 12..(i + 1) * 12].try_into().unwrap();
-        let c_i = add_fp2_bls12_381(
-            a_i,
-            b_i,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let c_i = add_fp2_bls12_381(a_i, b_i);
         result[i * 12..(i + 1) * 12].copy_from_slice(&c_i);
     }
     result
@@ -32,18 +23,11 @@ pub fn add_fp6_bls12_381(
 
 /// Doubling in Fp6
 #[inline]
-pub fn dbl_fp6_bls12_381(
-    a: &[u64; 36],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn dbl_fp6_bls12_381(a: &[u64; 36]) -> [u64; 36] {
     let mut result = [0; 36];
     for i in 0..3 {
         let a_i = &a[i * 12..(i + 1) * 12].try_into().unwrap();
-        let c_i = dbl_fp2_bls12_381(
-            a_i,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let c_i = dbl_fp2_bls12_381(a_i);
         result[i * 12..(i + 1) * 12].copy_from_slice(&c_i);
     }
     result
@@ -51,18 +35,11 @@ pub fn dbl_fp6_bls12_381(
 
 /// Negation in Fp6
 #[inline]
-pub fn neg_fp6_bls12_381(
-    a: &[u64; 36],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn neg_fp6_bls12_381(a: &[u64; 36]) -> [u64; 36] {
     let mut result = [0; 36];
     for i in 0..3 {
         let a_i = &a[i * 12..(i + 1) * 12].try_into().unwrap();
-        let c_i = neg_fp2_bls12_381(
-            a_i,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let c_i = neg_fp2_bls12_381(a_i);
         result[i * 12..(i + 1) * 12].copy_from_slice(&c_i);
     }
     result
@@ -70,21 +47,12 @@ pub fn neg_fp6_bls12_381(
 
 /// Subtraction in Fp6
 #[inline]
-pub fn sub_fp6_bls12_381(
-    a: &[u64; 36],
-    b: &[u64; 36],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn sub_fp6_bls12_381(a: &[u64; 36], b: &[u64; 36]) -> [u64; 36] {
     let mut result = [0; 36];
     for i in 0..3 {
         let a_i = &a[i * 12..(i + 1) * 12].try_into().unwrap();
         let b_i = &b[i * 12..(i + 1) * 12].try_into().unwrap();
-        let c_i = sub_fp2_bls12_381(
-            a_i,
-            b_i,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let c_i = sub_fp2_bls12_381(a_i, b_i);
         result[i * 12..(i + 1) * 12].copy_from_slice(&c_i);
     }
     result
@@ -97,11 +65,7 @@ pub fn sub_fp6_bls12_381(
 //       - c2 = a1·b2 + a2·b1 + (a3·b3)·(1+u)
 //       - c3 = a1·b3 + a2·b2 + a3·b1
 #[inline]
-pub fn mul_fp6_bls12_381(
-    a: &[u64; 36],
-    b: &[u64; 36],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn mul_fp6_bls12_381(a: &[u64; 36], b: &[u64; 36]) -> [u64; 36] {
     let a1 = &a[0..12].try_into().unwrap();
     let a2 = &a[12..24].try_into().unwrap();
     let a3 = &a[24..36].try_into().unwrap();
@@ -110,106 +74,21 @@ pub fn mul_fp6_bls12_381(
     let b3 = &b[24..36].try_into().unwrap();
 
     // c1 = a1·b1 + [a2·b3 + a3·b2]·(1+u)
-    let mut c1 = mul_fp2_bls12_381(
-        a2,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp2_bls12_381(
-        &c1,
-        &mul_fp2_bls12_381(
-            a3,
-            b2,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = mul_fp2_bls12_381(
-        &c1,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp2_bls12_381(
-        &c1,
-        &mul_fp2_bls12_381(
-            a1,
-            b1,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bls12_381(a2, b3);
+    c1 = add_fp2_bls12_381(&c1, &mul_fp2_bls12_381(a3, b2));
+    c1 = mul_fp2_bls12_381(&c1, &EXT_U);
+    c1 = add_fp2_bls12_381(&c1, &mul_fp2_bls12_381(a1, b1));
 
     // c2 = a1·b2 + a2·b1 + (a3·b3)·(1+u)
-    let mut c2 = mul_fp2_bls12_381(
-        a3,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = mul_fp2_bls12_381(
-        &c2,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp2_bls12_381(
-        &c2,
-        &mul_fp2_bls12_381(
-            a1,
-            b2,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp2_bls12_381(
-        &c2,
-        &mul_fp2_bls12_381(
-            a2,
-            b1,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = mul_fp2_bls12_381(a3, b3);
+    c2 = mul_fp2_bls12_381(&c2, &EXT_U);
+    c2 = add_fp2_bls12_381(&c2, &mul_fp2_bls12_381(a1, b2));
+    c2 = add_fp2_bls12_381(&c2, &mul_fp2_bls12_381(a2, b1));
 
     // c3 = a1·b3 + a2·b2 + a3·b1
-    let mut c3 = mul_fp2_bls12_381(
-        a1,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bls12_381(
-        &c3,
-        &mul_fp2_bls12_381(
-            a2,
-            b2,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bls12_381(
-        &c3,
-        &mul_fp2_bls12_381(
-            a3,
-            b1,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c3 = mul_fp2_bls12_381(a1, b3);
+    c3 = add_fp2_bls12_381(&c3, &mul_fp2_bls12_381(a2, b2));
+    c3 = add_fp2_bls12_381(&c3, &mul_fp2_bls12_381(a3, b1));
 
     let mut result = [0u64; 36];
     result[0..12].copy_from_slice(&c1);
@@ -225,43 +104,19 @@ pub fn mul_fp6_bls12_381(
 //       - c2 = a1·b2
 //       - c3 = a2·b2
 #[inline]
-pub fn sparse_mula_fp6_bls12_381(
-    a: &[u64; 36],
-    b2: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn sparse_mula_fp6_bls12_381(a: &[u64; 36], b2: &[u64; 12]) -> [u64; 36] {
     let a1 = &a[0..12].try_into().unwrap();
     let a2 = &a[12..24].try_into().unwrap();
     let a3 = &a[24..36].try_into().unwrap();
 
     // c1 = a3·b2·(1+u)
-    let mut c1 = mul_fp2_bls12_381(
-        a3,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = mul_fp2_bls12_381(
-        &c1,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bls12_381(a3, b2);
+    c1 = mul_fp2_bls12_381(&c1, &EXT_U);
 
     // c2 = a1·b2
-    let c2 = mul_fp2_bls12_381(
-        a1,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c2 = mul_fp2_bls12_381(a1, b2);
     // c3 = a2·b2
-    let c3 = mul_fp2_bls12_381(
-        a2,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c3 = mul_fp2_bls12_381(a2, b2);
 
     let mut result = [0u64; 36];
     result[0..12].copy_from_slice(&c1);
@@ -278,11 +133,7 @@ pub fn sparse_mula_fp6_bls12_381(
 //       - c2 = a1·b2 + a3·b3·(1+u)
 //       - c3 = a1·b3 + a2·b2
 #[inline]
-pub fn sparse_mulb_fp6_bls12_381(
-    a: &[u64; 36],
-    b: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn sparse_mulb_fp6_bls12_381(a: &[u64; 36], b: &[u64; 24]) -> [u64; 36] {
     let a1 = &a[0..12].try_into().unwrap();
     let a2 = &a[12..24].try_into().unwrap();
     let a3 = &a[24..36].try_into().unwrap();
@@ -290,73 +141,18 @@ pub fn sparse_mulb_fp6_bls12_381(
     let b3 = &b[12..24].try_into().unwrap();
 
     // c1 = (a2·b3 + a3·b2)·(1+u)
-    let mut c1 = mul_fp2_bls12_381(
-        a2,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp2_bls12_381(
-        &c1,
-        &mul_fp2_bls12_381(
-            a3,
-            b2,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = mul_fp2_bls12_381(
-        &c1,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bls12_381(a2, b3);
+    c1 = add_fp2_bls12_381(&c1, &mul_fp2_bls12_381(a3, b2));
+    c1 = mul_fp2_bls12_381(&c1, &EXT_U);
 
     // c2 = a1·b2 + a3·b3·(1+u)
-    let mut c2 = mul_fp2_bls12_381(
-        a3,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = mul_fp2_bls12_381(
-        &c2,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp2_bls12_381(
-        &c2,
-        &mul_fp2_bls12_381(
-            a1,
-            b2,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = mul_fp2_bls12_381(a3, b3);
+    c2 = mul_fp2_bls12_381(&c2, &EXT_U);
+    c2 = add_fp2_bls12_381(&c2, &mul_fp2_bls12_381(a1, b2));
 
     // c3 = a1·b3 + a2·b2
-    let mut c3 = mul_fp2_bls12_381(
-        a1,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bls12_381(
-        &c3,
-        &mul_fp2_bls12_381(
-            a2,
-            b2,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c3 = mul_fp2_bls12_381(a1, b3);
+    c3 = add_fp2_bls12_381(&c3, &mul_fp2_bls12_381(a2, b2));
     let mut result = [0u64; 36];
     result[0..12].copy_from_slice(&c1);
     result[12..24].copy_from_slice(&c2);
@@ -372,11 +168,7 @@ pub fn sparse_mulb_fp6_bls12_381(
 //       - c2 = a2·b1 + a3·b3·(1+u)
 //       - c3 = a1·b3 + a3·b1
 #[inline]
-pub fn sparse_mulc_fp6_bls12_381(
-    a: &[u64; 36],
-    b: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn sparse_mulc_fp6_bls12_381(a: &[u64; 36], b: &[u64; 24]) -> [u64; 36] {
     let a1 = &a[0..12].try_into().unwrap();
     let a2 = &a[12..24].try_into().unwrap();
     let a3 = &a[24..36].try_into().unwrap();
@@ -384,73 +176,18 @@ pub fn sparse_mulc_fp6_bls12_381(
     let b3 = &b[12..24].try_into().unwrap();
 
     // c1 = a1·b1 + a2·b3·(1+u)
-    let mut c1 = mul_fp2_bls12_381(
-        a2,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = mul_fp2_bls12_381(
-        &c1,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp2_bls12_381(
-        &c1,
-        &mul_fp2_bls12_381(
-            a1,
-            b1,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bls12_381(a2, b3);
+    c1 = mul_fp2_bls12_381(&c1, &EXT_U);
+    c1 = add_fp2_bls12_381(&c1, &mul_fp2_bls12_381(a1, b1));
 
     // c2 = a2·b1 + a3·b3·(1+u)
-    let mut c2 = mul_fp2_bls12_381(
-        a3,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = mul_fp2_bls12_381(
-        &c2,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp2_bls12_381(
-        &c2,
-        &mul_fp2_bls12_381(
-            a2,
-            b1,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = mul_fp2_bls12_381(a3, b3);
+    c2 = mul_fp2_bls12_381(&c2, &EXT_U);
+    c2 = add_fp2_bls12_381(&c2, &mul_fp2_bls12_381(a2, b1));
 
     // c3 = a1·b3 + a3·b1
-    let mut c3 = mul_fp2_bls12_381(
-        a1,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bls12_381(
-        &c3,
-        &mul_fp2_bls12_381(
-            a3,
-            b1,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c3 = mul_fp2_bls12_381(a1, b3);
+    c3 = add_fp2_bls12_381(&c3, &mul_fp2_bls12_381(a3, b1));
     let mut result = [0u64; 36];
     result[0..12].copy_from_slice(&c1);
     result[12..24].copy_from_slice(&c2);
@@ -466,92 +203,25 @@ pub fn sparse_mulc_fp6_bls12_381(
 //       - c2 = a3²·(1+u) + 2·a1·a2
 //       - c3 = a2² + 2·a1·a3
 #[inline]
-pub fn square_fp6_bls12_381(
-    a: &[u64; 36],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn square_fp6_bls12_381(a: &[u64; 36]) -> [u64; 36] {
     let a1 = &a[0..12].try_into().unwrap();
     let a2 = &a[12..24].try_into().unwrap();
     let a3 = &a[24..36].try_into().unwrap();
 
     // c1 = a1² + 2·a2·a3·(1+u)
-    let mut c1 = mul_fp2_bls12_381(
-        a2,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = dbl_fp2_bls12_381(
-        &c1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = mul_fp2_bls12_381(
-        &c1,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp2_bls12_381(
-        &c1,
-        &square_fp2_bls12_381(
-            a1,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bls12_381(a2, a3);
+    c1 = dbl_fp2_bls12_381(&c1);
+    c1 = mul_fp2_bls12_381(&c1, &EXT_U);
+    c1 = add_fp2_bls12_381(&c1, &square_fp2_bls12_381(a1));
 
     // c2 = a3²·(1+u) + 2·a1·a2
-    let mut c2 = square_fp2_bls12_381(
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = mul_fp2_bls12_381(
-        &c2,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp2_bls12_381(
-        &c2,
-        &dbl_fp2_bls12_381(
-            &mul_fp2_bls12_381(
-                a1,
-                a2,
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = square_fp2_bls12_381(a3);
+    c2 = mul_fp2_bls12_381(&c2, &EXT_U);
+    c2 = add_fp2_bls12_381(&c2, &dbl_fp2_bls12_381(&mul_fp2_bls12_381(a1, a2)));
 
     // c3 = a2² + 2·a1·a3
-    let mut c3 = square_fp2_bls12_381(
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bls12_381(
-        &c3,
-        &dbl_fp2_bls12_381(
-            &mul_fp2_bls12_381(
-                a1,
-                a3,
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c3 = square_fp2_bls12_381(a2);
+    c3 = add_fp2_bls12_381(&c3, &dbl_fp2_bls12_381(&mul_fp2_bls12_381(a1, a3)));
 
     let mut result = [0u64; 36];
     result[0..12].copy_from_slice(&c1);
@@ -572,146 +242,42 @@ pub fn square_fp6_bls12_381(
 //       * c2mid = (1 + u)·a3² - (a1·a2)
 //       * c3mid = a2² - (a1·a3)
 #[inline]
-pub fn inv_fp6_bls12_381(
-    a: &[u64; 36],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 36] {
+pub fn inv_fp6_bls12_381(a: &[u64; 36]) -> [u64; 36] {
     let a1 = &a[0..12].try_into().unwrap();
     let a2 = &a[12..24].try_into().unwrap();
     let a3 = &a[24..36].try_into().unwrap();
 
     // a1², a2², a3²
-    let a1_squared = square_fp2_bls12_381(
-        a1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2_squared = square_fp2_bls12_381(
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a3_squared = square_fp2_bls12_381(
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_squared = square_fp2_bls12_381(a1);
+    let a2_squared = square_fp2_bls12_381(a2);
+    let a3_squared = square_fp2_bls12_381(a3);
 
     // a1·a2, a1·a3, a2·a3
-    let a1_a2 = mul_fp2_bls12_381(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1_a3 = mul_fp2_bls12_381(
-        a1,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2_a3 = mul_fp2_bls12_381(
-        a2,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_a2 = mul_fp2_bls12_381(a1, a2);
+    let a1_a3 = mul_fp2_bls12_381(a1, a3);
+    let a2_a3 = mul_fp2_bls12_381(a2, a3);
 
     // c1mid = a1² - (1 + u)·(a2·a3)
-    let mut c1mid = mul_fp2_bls12_381(
-        &a2_a3,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1mid = sub_fp2_bls12_381(
-        &a1_squared,
-        &c1mid,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1mid = mul_fp2_bls12_381(&a2_a3, &EXT_U);
+    c1mid = sub_fp2_bls12_381(&a1_squared, &c1mid);
 
     // c2mid = (1 + u)·a3² - (a1·a2)
-    let mut c2mid = mul_fp2_bls12_381(
-        &a3_squared,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2mid = sub_fp2_bls12_381(
-        &c2mid,
-        &a1_a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2mid = mul_fp2_bls12_381(&a3_squared, &EXT_U);
+    c2mid = sub_fp2_bls12_381(&c2mid, &a1_a2);
     // c3mid = a2² - (a1·a3)
-    let c3mid = sub_fp2_bls12_381(
-        &a2_squared,
-        &a1_a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c3mid = sub_fp2_bls12_381(&a2_squared, &a1_a3);
 
     // (a1·c1mid + (1 + u)·(a3·c2mid + a2·c3mid))⁻¹
-    let mut last = mul_fp2_bls12_381(
-        a3,
-        &c2mid,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    last = add_fp2_bls12_381(
-        &last,
-        &mul_fp2_bls12_381(
-            a2,
-            &c3mid,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    last = mul_fp2_bls12_381(
-        &last,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    last = add_fp2_bls12_381(
-        &last,
-        &mul_fp2_bls12_381(
-            a1,
-            &c1mid,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let last_inv = inv_fp2_bls12_381(
-        &last,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut last = mul_fp2_bls12_381(a3, &c2mid);
+    last = add_fp2_bls12_381(&last, &mul_fp2_bls12_381(a2, &c3mid));
+    last = mul_fp2_bls12_381(&last, &EXT_U);
+    last = add_fp2_bls12_381(&last, &mul_fp2_bls12_381(a1, &c1mid));
+    let last_inv = inv_fp2_bls12_381(&last);
 
     // c1 = c1mid·last_inv, c2 = c2mid·last_inv, c3 = c3mid·last_inv
-    let c1 = mul_fp2_bls12_381(
-        &c1mid,
-        &last_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let c2 = mul_fp2_bls12_381(
-        &c2mid,
-        &last_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let c3 = mul_fp2_bls12_381(
-        &c3mid,
-        &last_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c1 = mul_fp2_bls12_381(&c1mid, &last_inv);
+    let c2 = mul_fp2_bls12_381(&c2mid, &last_inv);
+    let c3 = mul_fp2_bls12_381(&c3mid, &last_inv);
 
     let mut result = [0u64; 36];
     result[0..12].copy_from_slice(&c1);

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/fr.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/fr.rs
@@ -7,10 +7,7 @@ use crate::{
 
 use super::constants::{R, R_MINUS_ONE};
 
-pub fn reduce_fr_bls12_381(
-    x: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn reduce_fr_bls12_381(x: &[u64; 4]) -> [u64; 4] {
     if lt(x, &R) {
         return *x;
     }
@@ -23,36 +20,24 @@ pub fn reduce_fr_bls12_381(
         module: &R,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     *params.d
 }
 
 /// Addition in Fr
 #[inline]
-pub fn add_fr_bls12_381(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn add_fr_bls12_381(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·1 + y
     let mut params =
         SyscallArith256ModParams { a: x, b: &[1, 0, 0, 0], c: y, module: &R, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
 /// Doubling in Fr
 #[inline]
-pub fn dbl_fr_bls12_381(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 4] {
+pub fn dbl_fr_bls12_381(x: &[u64; 4]) -> [u64; 4] {
     // 2·x + 0 or x·1 + x
     let mut params = SyscallArith256ModParams {
         a: x,
@@ -61,35 +46,23 @@ pub fn dbl_fr_bls12_381(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<
         module: &R,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
 /// Subtraction in Fr
 #[inline]
-pub fn sub_fr_bls12_381(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn sub_fr_bls12_381(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // y·(-1) + x
     let mut params =
         SyscallArith256ModParams { a: y, b: &R_MINUS_ONE, c: x, module: &R, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
 /// Negation in Fr
 #[inline]
-pub fn neg_fr_bls12_381(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 4] {
+pub fn neg_fr_bls12_381(x: &[u64; 4]) -> [u64; 4] {
     // x·(-1) + 0
     let mut params = SyscallArith256ModParams {
         a: x,
@@ -98,46 +71,27 @@ pub fn neg_fr_bls12_381(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<
         module: &R,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
 /// Multiplication in Fr
 #[inline]
-pub fn mul_fr_bls12_381(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn mul_fr_bls12_381(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·y + 0
     let mut params =
         SyscallArith256ModParams { a: x, b: y, c: &[0, 0, 0, 0], module: &R, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
 /// Squaring in Fr
 #[inline]
-pub fn square_fr_bls12_381(
-    x: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn square_fr_bls12_381(x: &[u64; 4]) -> [u64; 4] {
     // x·x + 0
     let mut params =
         SyscallArith256ModParams { a: x, b: x, c: &[0, 0, 0, 0], module: &R, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/kzg.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/kzg.rs
@@ -19,43 +19,22 @@ pub fn verify_kzg_proof(
     y_bytes: &[u8; 32],
     commitment_bytes: &[u8; 48],
     proof_bytes: &[u8; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> bool {
     // Parse the commitment
-    let commitment = match decompress_bls12_381(
-        commitment_bytes,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let commitment = match decompress_bls12_381(commitment_bytes) {
         Ok(result) => result,
         Err(_) => return false,
     };
-    if !eq(&commitment, &G1_IDENTITY)
-        && !is_on_subgroup_bls12_381(
-            &commitment,
-            #[cfg(feature = "hints")]
-            hints,
-        )
-    {
+    if !eq(&commitment, &G1_IDENTITY) && !is_on_subgroup_bls12_381(&commitment) {
         return false;
     }
 
     // Parse the proof
-    let proof = match decompress_bls12_381(
-        proof_bytes,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let proof = match decompress_bls12_381(proof_bytes) {
         Ok(result) => result,
         Err(_) => return false,
     };
-    if !eq(&proof, &G1_IDENTITY)
-        && !is_on_subgroup_bls12_381(
-            &proof,
-            #[cfg(feature = "hints")]
-            hints,
-        )
-    {
+    if !eq(&proof, &G1_IDENTITY) && !is_on_subgroup_bls12_381(&proof) {
         return false;
     }
 
@@ -81,32 +60,12 @@ pub fn verify_kzg_proof(
     let g2 = G2_GENERATOR;
 
     // Compute c_minus_y = C - [y]G₁
-    let y_g1 = scalar_mul_bls12_381(
-        &g1,
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let c_minus_y = sub_complete_bls12_381(
-        &commitment,
-        &y_g1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y_g1 = scalar_mul_bls12_381(&g1, &y);
+    let c_minus_y = sub_complete_bls12_381(&commitment, &y_g1);
 
     // Compute t_minus_z = [τ]₂ - [z]G₂
-    let z_g2 = scalar_mul_twist_bls12_381(
-        &g2,
-        &z,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let t_minus_z = sub_complete_twist_bls12_381(
-        &tau_g2,
-        &z_g2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let z_g2 = scalar_mul_twist_bls12_381(&g2, &z);
+    let t_minus_z = sub_complete_twist_bls12_381(&tau_g2, &z_g2);
 
     // LHS: e(C - [y]G₁, G₂) - G₂ is never infinity
     // RHS: e(π, [τ]₂ - [z]G₂)
@@ -132,23 +91,14 @@ pub fn verify_kzg_proof(
     // General case: no infinities, proceed with pairing check
     // The check is equivalent to:
     // e(C - [y]G₁, -G₂) · e(π, [τ]₂ - [z]G₂) = 1
-    let neg_g2 = neg_twist_bls12_381(
-        &g2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let neg_g2 = neg_twist_bls12_381(&g2);
 
     // Batch pairing check
     let g1_points = [c_minus_y, proof];
     let g2_points = [neg_g2, t_minus_z];
 
     // Check if the pairing result equals 1
-    is_one(&pairing_batch_bls12_381(
-        &g1_points,
-        &g2_points,
-        #[cfg(feature = "hints")]
-        hints,
-    ))
+    is_one(&pairing_batch_bls12_381(&g1_points, &g2_points))
 }
 
 /// Verify KZG proof using BLS12-381 implementation.
@@ -172,21 +122,13 @@ pub(crate) unsafe fn verify_kzg_proof_c(
     y: *const u8,
     commitment: *const u8,
     proof: *const u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> bool {
     let z_bytes: &[u8; 32] = &*(z as *const [u8; 32]);
     let y_bytes: &[u8; 32] = &*(y as *const [u8; 32]);
     let commitment_bytes: &[u8; 48] = &*(commitment as *const [u8; 48]);
     let proof_bytes: &[u8; 48] = &*(proof as *const [u8; 48]);
 
-    verify_kzg_proof(
-        z_bytes,
-        y_bytes,
-        commitment_bytes,
-        proof_bytes,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    verify_kzg_proof(z_bytes, y_bytes, commitment_bytes, proof_bytes)
 }
 
 /// Convert 32-byte big-endian scalar to [u64; 4] little-endian, checking canonicity

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/map_to_curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/map_to_curve.rs
@@ -29,43 +29,24 @@ const G2_MAP_TO_CURVE_SUCCESS: u8 = 0;
 const G2_MAP_TO_CURVE_ERR_NOT_IN_FIELD: u8 = 1;
 
 /// Maps a field element to a point on the BLS12-381 G1 curve
-pub fn map_to_curve_g1_bls12_381(
-    u: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 12], u8> {
+pub fn map_to_curve_g1_bls12_381(u: &[u64; 6]) -> Result<[u64; 12], u8> {
     // Verify input is in field
     if !lt(u, &P) {
         return Err(G1_MAP_TO_CURVE_ERR_NOT_IN_FIELD);
     }
 
     // Step 1: Map to isogenous curve E' using simplified SWU
-    let p_prime = map_to_curve_simple_swu_g1_bls12_381(
-        u,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let p_prime = map_to_curve_simple_swu_g1_bls12_381(u);
 
     // Step 2: Apply isogeny map from E' to E
-    let p = isogeny_map_g1_bls12_381(
-        &p_prime,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let p = isogeny_map_g1_bls12_381(&p_prime);
 
     // Step 3: Clear cofactor
-    Ok(scalar_mul_bls12_381(
-        &p,
-        &COFACTOR_G1,
-        #[cfg(feature = "hints")]
-        hints,
-    ))
+    Ok(scalar_mul_bls12_381(&p, &COFACTOR_G1))
 }
 
 /// Maps a field element in Fp2 to a point on the BLS12-381 G2 curve
-pub fn map_to_curve_g2_bls12_381(
-    u: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 24], u8> {
+pub fn map_to_curve_g2_bls12_381(u: &[u64; 12]) -> Result<[u64; 24], u8> {
     // Verify input is in field
     let u_0: [u64; 6] = u[0..6].try_into().unwrap();
     let u_1: [u64; 6] = u[6..12].try_into().unwrap();
@@ -74,166 +55,62 @@ pub fn map_to_curve_g2_bls12_381(
     }
 
     // Step 1: Map to isogenous curve E' using simplified SWU
-    let p_prime = map_to_curve_simple_swu_g2_bls12_381(
-        u,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let p_prime = map_to_curve_simple_swu_g2_bls12_381(u);
 
     // Step 2: Apply isogeny map from E' to E
-    let p = isogeny_map_g2_bls12_381(
-        &p_prime,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let p = isogeny_map_g2_bls12_381(&p_prime);
 
     // Step 3: Clear cofactor
-    Ok(clear_cofactor_twist_bls12_381(
-        &p,
-        #[cfg(feature = "hints")]
-        hints,
-    ))
+    Ok(clear_cofactor_twist_bls12_381(&p))
 }
 
 /// Maps a field element u ∈ Fp to a point on the isogenous curve E'
 /// using the simplified Shallue-van de Woestijne-Ulas (SWU) method for AB != 0
-fn map_to_curve_simple_swu_g1_bls12_381(
-    u: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+fn map_to_curve_simple_swu_g1_bls12_381(u: &[u64; 6]) -> [u64; 12] {
     // 1. tv1 = inv0(Z^2 * u^4 + Z * u^2)
-    let u2 = square_fp_bls12_381(
-        u,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let u4 = square_fp_bls12_381(
-        &u2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let z_u2 = mul_fp_bls12_381(
-        &SWU_Z_G1,
-        &u2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let z2_u4 = mul_fp_bls12_381(
-        &SWU_Z2_G1,
-        &u4,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let tv1_denom = add_fp_bls12_381(
-        &z2_u4,
-        &z_u2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let tv1 = inv_fp_bls12_381(
-        &tv1_denom,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let u2 = square_fp_bls12_381(u);
+    let u4 = square_fp_bls12_381(&u2);
+    let z_u2 = mul_fp_bls12_381(&SWU_Z_G1, &u2);
+    let z2_u4 = mul_fp_bls12_381(&SWU_Z2_G1, &u4);
+    let tv1_denom = add_fp_bls12_381(&z2_u4, &z_u2);
+    let tv1 = inv_fp_bls12_381(&tv1_denom);
 
     // 2. x1 = (-B / A) * (1 + tv1)
-    let neg_b = neg_fp_bls12_381(
-        &ISO_B_G1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a_inv = inv_fp_bls12_381(
-        &ISO_A_G1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let neg_b_over_a = mul_fp_bls12_381(
-        &neg_b,
-        &a_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let neg_b = neg_fp_bls12_381(&ISO_B_G1);
+    let a_inv = inv_fp_bls12_381(&ISO_A_G1);
+    let neg_b_over_a = mul_fp_bls12_381(&neg_b, &a_inv);
     let one = [1u64, 0, 0, 0, 0, 0];
-    let one_plus_tv1 = add_fp_bls12_381(
-        &one,
-        &tv1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut x1 = mul_fp_bls12_381(
-        &neg_b_over_a,
-        &one_plus_tv1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let one_plus_tv1 = add_fp_bls12_381(&one, &tv1);
+    let mut x1 = mul_fp_bls12_381(&neg_b_over_a, &one_plus_tv1);
 
     // 3. If tv1 == 0, set x1 = B / (Z * A)
     if is_zero(&tv1) {
-        let z_a = mul_fp_bls12_381(
-            &SWU_Z_G1,
-            &ISO_A_G1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let z_a_inv = inv_fp_bls12_381(
-            &z_a,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        x1 = mul_fp_bls12_381(
-            &ISO_B_G1,
-            &z_a_inv,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let z_a = mul_fp_bls12_381(&SWU_Z_G1, &ISO_A_G1);
+        let z_a_inv = inv_fp_bls12_381(&z_a);
+        x1 = mul_fp_bls12_381(&ISO_B_G1, &z_a_inv);
     }
 
     // 4. gx1 = x1^3 + A * x1 + B
-    let gx1 = compute_y2_iso_g1_bls12_381(
-        &x1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let gx1 = compute_y2_iso_g1_bls12_381(&x1);
 
     // 5. x2 = Z * u^2 * x1 (computed lazily below if needed)
 
     // 6. gx2 = x2^3 + A * x2 + B  (computed lazily below if needed)
 
     // 7-8. Select x and y based on whether gx1 is square
-    let (y1, gx1_is_qr) = sqrt_fp_bls12_381(
-        &gx1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (y1, gx1_is_qr) = sqrt_fp_bls12_381(&gx1);
     let (x, mut y) = if gx1_is_qr {
         (x1, y1)
     } else {
-        let x2 = mul_fp_bls12_381(
-            &z_u2,
-            &x1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let gx2 = compute_y2_iso_g1_bls12_381(
-            &x2,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let (y2, _) = sqrt_fp_bls12_381(
-            &gx2,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let x2 = mul_fp_bls12_381(&z_u2, &x1);
+        let gx2 = compute_y2_iso_g1_bls12_381(&x2);
+        let (y2, _) = sqrt_fp_bls12_381(&gx2);
         (x2, y2)
     };
 
     // 9. If sgn0(u) != sgn0(y), set y = -y
     if sgn0_fp_bls12_381(u) != sgn0_fp_bls12_381(&y) {
-        y = neg_fp_bls12_381(
-            &y,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        y = neg_fp_bls12_381(&y);
     }
 
     // Return point (x, y) on E'
@@ -245,146 +122,50 @@ fn map_to_curve_simple_swu_g1_bls12_381(
 
 /// Maps a field element u ∈ Fp2 to a point on the isogenous curve E'
 /// using the simplified Shallue-van de Woestijne-Ulas (SWU) method for AB != 0
-fn map_to_curve_simple_swu_g2_bls12_381(
-    u: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+fn map_to_curve_simple_swu_g2_bls12_381(u: &[u64; 12]) -> [u64; 24] {
     // 1. tv1 = inv0(Z^2 * u^4 + Z * u^2)
-    let u2 = square_fp2_bls12_381(
-        u,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let u4 = square_fp2_bls12_381(
-        &u2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let z_u2 = mul_fp2_bls12_381(
-        &SWU_Z_G2,
-        &u2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let z2 = square_fp2_bls12_381(
-        &SWU_Z_G2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let z2_u4 = mul_fp2_bls12_381(
-        &z2,
-        &u4,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let tv1_denom = add_fp2_bls12_381(
-        &z2_u4,
-        &z_u2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let tv1 = inv_fp2_bls12_381(
-        &tv1_denom,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let u2 = square_fp2_bls12_381(u);
+    let u4 = square_fp2_bls12_381(&u2);
+    let z_u2 = mul_fp2_bls12_381(&SWU_Z_G2, &u2);
+    let z2 = square_fp2_bls12_381(&SWU_Z_G2);
+    let z2_u4 = mul_fp2_bls12_381(&z2, &u4);
+    let tv1_denom = add_fp2_bls12_381(&z2_u4, &z_u2);
+    let tv1 = inv_fp2_bls12_381(&tv1_denom);
 
     // 2. x1 = (-B / A) * (1 + tv1)
-    let neg_b = neg_fp2_bls12_381(
-        &ISO_B_G2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a_inv = inv_fp2_bls12_381(
-        &ISO_A_G2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let neg_b_over_a = mul_fp2_bls12_381(
-        &neg_b,
-        &a_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let neg_b = neg_fp2_bls12_381(&ISO_B_G2);
+    let a_inv = inv_fp2_bls12_381(&ISO_A_G2);
+    let neg_b_over_a = mul_fp2_bls12_381(&neg_b, &a_inv);
     let one: [u64; 12] = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-    let one_plus_tv1 = add_fp2_bls12_381(
-        &one,
-        &tv1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut x1 = mul_fp2_bls12_381(
-        &neg_b_over_a,
-        &one_plus_tv1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let one_plus_tv1 = add_fp2_bls12_381(&one, &tv1);
+    let mut x1 = mul_fp2_bls12_381(&neg_b_over_a, &one_plus_tv1);
 
     // 3. If tv1 == 0, set x1 = B / (Z * A)
     if is_zero(&tv1) {
-        let z_a = mul_fp2_bls12_381(
-            &SWU_Z_G2,
-            &ISO_A_G2,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let z_a_inv = inv_fp2_bls12_381(
-            &z_a,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        x1 = mul_fp2_bls12_381(
-            &ISO_B_G2,
-            &z_a_inv,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let z_a = mul_fp2_bls12_381(&SWU_Z_G2, &ISO_A_G2);
+        let z_a_inv = inv_fp2_bls12_381(&z_a);
+        x1 = mul_fp2_bls12_381(&ISO_B_G2, &z_a_inv);
     }
 
     // 4. gx1 = x1^3 + A * x1 + B
-    let gx1 = compute_y2_iso_g2_bls12_381(
-        &x1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let gx1 = compute_y2_iso_g2_bls12_381(&x1);
 
     // 7-8. Select x and y based on whether gx1 is square
-    let (y1, gx1_is_qr) = sqrt_fp2_bls12_381(
-        &gx1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (y1, gx1_is_qr) = sqrt_fp2_bls12_381(&gx1);
     let (x, mut y) = if gx1_is_qr {
         (x1, y1)
     } else {
         // 5. x2 = Z * u^2 * x1
-        let x2 = mul_fp2_bls12_381(
-            &z_u2,
-            &x1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let x2 = mul_fp2_bls12_381(&z_u2, &x1);
         // 6. gx2 = x2^3 + A * x2 + B
-        let gx2 = compute_y2_iso_g2_bls12_381(
-            &x2,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let (y2, _) = sqrt_fp2_bls12_381(
-            &gx2,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let gx2 = compute_y2_iso_g2_bls12_381(&x2);
+        let (y2, _) = sqrt_fp2_bls12_381(&gx2);
         (x2, y2)
     };
 
     // 9. If sgn0(u) != sgn0(y), set y = -y
     if sgn0_fp2_bls12_381(u) != sgn0_fp2_bls12_381(&y) {
-        y = neg_fp2_bls12_381(
-            &y,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        y = neg_fp2_bls12_381(&y);
     }
 
     // Return point (x, y) on E'
@@ -395,140 +176,40 @@ fn map_to_curve_simple_swu_g2_bls12_381(
 }
 
 /// Compute y² = x³ + A'x + B' for the isogenous curve E' (G1)
-fn compute_y2_iso_g1_bls12_381(
-    x: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 6] {
-    let x2 = square_fp_bls12_381(
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x3 = mul_fp_bls12_381(
-        &x2,
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let ax = mul_fp_bls12_381(
-        &ISO_A_G1,
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x3_ax = add_fp_bls12_381(
-        &x3,
-        &ax,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    add_fp_bls12_381(
-        &x3_ax,
-        &ISO_B_G1,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+fn compute_y2_iso_g1_bls12_381(x: &[u64; 6]) -> [u64; 6] {
+    let x2 = square_fp_bls12_381(x);
+    let x3 = mul_fp_bls12_381(&x2, x);
+    let ax = mul_fp_bls12_381(&ISO_A_G1, x);
+    let x3_ax = add_fp_bls12_381(&x3, &ax);
+    add_fp_bls12_381(&x3_ax, &ISO_B_G1)
 }
 
 /// Compute y² = x³ + A'x + B' for the isogenous curve E' (G2)
-fn compute_y2_iso_g2_bls12_381(
-    x: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
-    let x2 = square_fp2_bls12_381(
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x3 = mul_fp2_bls12_381(
-        &x2,
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let ax = mul_fp2_bls12_381(
-        &ISO_A_G2,
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x3_ax = add_fp2_bls12_381(
-        &x3,
-        &ax,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    add_fp2_bls12_381(
-        &x3_ax,
-        &ISO_B_G2,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+fn compute_y2_iso_g2_bls12_381(x: &[u64; 12]) -> [u64; 12] {
+    let x2 = square_fp2_bls12_381(x);
+    let x3 = mul_fp2_bls12_381(&x2, x);
+    let ax = mul_fp2_bls12_381(&ISO_A_G2, x);
+    let x3_ax = add_fp2_bls12_381(&x3, &ax);
+    add_fp2_bls12_381(&x3_ax, &ISO_B_G2)
 }
 
 /// Apply the 11-isogeny map from E' to E for G1
-fn isogeny_map_g1_bls12_381(
-    p: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+fn isogeny_map_g1_bls12_381(p: &[u64; 12]) -> [u64; 12] {
     let x: [u64; 6] = p[0..6].try_into().unwrap();
     let y: [u64; 6] = p[6..12].try_into().unwrap();
 
     // Compute x-coordinate: x_num / x_den
-    let x_num = eval_poly_fp(
-        &ISO_X_NUM_G1,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_den = eval_poly_fp(
-        &ISO_X_DEN_G1,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_den_inv = inv_fp_bls12_381(
-        &x_den,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_out = mul_fp_bls12_381(
-        &x_num,
-        &x_den_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let x_num = eval_poly_fp(&ISO_X_NUM_G1, &x);
+    let x_den = eval_poly_fp(&ISO_X_DEN_G1, &x);
+    let x_den_inv = inv_fp_bls12_381(&x_den);
+    let x_out = mul_fp_bls12_381(&x_num, &x_den_inv);
 
     // Compute y-coordinate: y' * y_num / y_den
-    let y_num = eval_poly_fp(
-        &ISO_Y_NUM_G1,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_den = eval_poly_fp(
-        &ISO_Y_DEN_G1,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_den_inv = inv_fp_bls12_381(
-        &y_den,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_frac = mul_fp_bls12_381(
-        &y_num,
-        &y_den_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_out = mul_fp_bls12_381(
-        &y,
-        &y_frac,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y_num = eval_poly_fp(&ISO_Y_NUM_G1, &x);
+    let y_den = eval_poly_fp(&ISO_Y_DEN_G1, &x);
+    let y_den_inv = inv_fp_bls12_381(&y_den);
+    let y_frac = mul_fp_bls12_381(&y_num, &y_den_inv);
+    let y_out = mul_fp_bls12_381(&y, &y_frac);
 
     let mut result = [0u64; 12];
     result[0..6].copy_from_slice(&x_out);
@@ -537,68 +218,22 @@ fn isogeny_map_g1_bls12_381(
 }
 
 /// Apply the 3-isogeny map from E' to E for G2
-fn isogeny_map_g2_bls12_381(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+fn isogeny_map_g2_bls12_381(p: &[u64; 24]) -> [u64; 24] {
     let x: [u64; 12] = p[0..12].try_into().unwrap();
     let y: [u64; 12] = p[12..24].try_into().unwrap();
 
     // Compute x-coordinate: x_num / x_den
-    let x_num = eval_poly_fp2(
-        &ISO_X_NUM_G2,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_den = eval_poly_fp2(
-        &ISO_X_DEN_G2,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_den_inv = inv_fp2_bls12_381(
-        &x_den,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_out = mul_fp2_bls12_381(
-        &x_num,
-        &x_den_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let x_num = eval_poly_fp2(&ISO_X_NUM_G2, &x);
+    let x_den = eval_poly_fp2(&ISO_X_DEN_G2, &x);
+    let x_den_inv = inv_fp2_bls12_381(&x_den);
+    let x_out = mul_fp2_bls12_381(&x_num, &x_den_inv);
 
     // Compute y-coordinate: y' * y_num / y_den
-    let y_num = eval_poly_fp2(
-        &ISO_Y_NUM_G2,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_den = eval_poly_fp2(
-        &ISO_Y_DEN_G2,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_den_inv = inv_fp2_bls12_381(
-        &y_den,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_frac = mul_fp2_bls12_381(
-        &y_num,
-        &y_den_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_out = mul_fp2_bls12_381(
-        &y,
-        &y_frac,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y_num = eval_poly_fp2(&ISO_Y_NUM_G2, &x);
+    let y_den = eval_poly_fp2(&ISO_Y_DEN_G2, &x);
+    let y_den_inv = inv_fp2_bls12_381(&y_den);
+    let y_frac = mul_fp2_bls12_381(&y_num, &y_den_inv);
+    let y_out = mul_fp2_bls12_381(&y, &y_frac);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&x_out);
@@ -607,51 +242,23 @@ fn isogeny_map_g2_bls12_381(
 }
 
 /// Evaluate a polynomial at x
-fn eval_poly_fp<const N: usize>(
-    coeffs: &[[u64; 6]; N],
-    x: &[u64; 6],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 6] {
+fn eval_poly_fp<const N: usize>(coeffs: &[[u64; 6]; N], x: &[u64; 6]) -> [u64; 6] {
     // Use Horner's method
     let mut result = coeffs[N - 1];
     for i in (0..N - 1).rev() {
-        result = mul_fp_bls12_381(
-            &result,
-            x,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        result = add_fp_bls12_381(
-            &result,
-            &coeffs[i],
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        result = mul_fp_bls12_381(&result, x);
+        result = add_fp_bls12_381(&result, &coeffs[i]);
     }
     result
 }
 
 /// Evaluate a polynomial at x over Fp2
-fn eval_poly_fp2<const N: usize>(
-    coeffs: &[[u64; 12]; N],
-    x: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 12] {
+fn eval_poly_fp2<const N: usize>(coeffs: &[[u64; 12]; N], x: &[u64; 12]) -> [u64; 12] {
     // Use Horner's method
     let mut result = coeffs[N - 1];
     for i in (0..N - 1).rev() {
-        result = mul_fp2_bls12_381(
-            &result,
-            x,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        result = add_fp2_bls12_381(
-            &result,
-            &coeffs[i],
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        result = mul_fp2_bls12_381(&result, x);
+        result = add_fp2_bls12_381(&result, &coeffs[i]);
     }
     result
 }
@@ -673,11 +280,7 @@ pub(crate) const FP2_TO_G2_SUCCESS: u8 = 0;
 /// - 0 = success
 /// - 1 = error (input not in field)
 #[inline]
-pub(crate) unsafe fn bls12_381_fp_to_g1_c(
-    ret: *mut u8,
-    fp: *const u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bls12_381_fp_to_g1_c(ret: *mut u8, fp: *const u8) -> u8 {
     let fp_bytes: &[u8; 48] = &*(fp as *const [u8; 48]);
     let ret_bytes: &mut [u8; 96] = &mut *(ret as *mut [u8; 96]);
 
@@ -685,11 +288,7 @@ pub(crate) unsafe fn bls12_381_fp_to_g1_c(
     let u = bytes_be_to_u64_le_fp_bls12_381(fp_bytes);
 
     // Map to curve
-    let result = match map_to_curve_g1_bls12_381(
-        &u,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let result = match map_to_curve_g1_bls12_381(&u) {
         Ok(p) => p,
         Err(code) => return code,
     };
@@ -712,11 +311,7 @@ pub(crate) unsafe fn bls12_381_fp_to_g1_c(
 /// - 0 = success
 /// - 1 = error (input not in field)
 #[inline]
-pub(crate) unsafe fn bls12_381_fp2_to_g2_c(
-    ret: *mut u8,
-    fp2: *const u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bls12_381_fp2_to_g2_c(ret: *mut u8, fp2: *const u8) -> u8 {
     let fp2_bytes: &[u8; 96] = &*(fp2 as *const [u8; 96]);
     let ret_bytes: &mut [u8; 192] = &mut *(ret as *mut [u8; 192]);
 
@@ -724,11 +319,7 @@ pub(crate) unsafe fn bls12_381_fp2_to_g2_c(
     let u = bytes_be_to_u64_le_fp2_bls12_381(fp2_bytes);
 
     // Map to curve
-    let result = match map_to_curve_g2_bls12_381(
-        &u,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let result = match map_to_curve_g2_bls12_381(&u) {
         Ok(p) => p,
         Err(code) => return code,
     };

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/miller_loop.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/miller_loop.rs
@@ -17,43 +17,16 @@ use super::{
 /// Computes the Miller loop of a non-zero point `p` in G1 and a non-zero point `q` in G2
 ///
 /// Note: It is not optimized for the case where either `p` or `q` is the point at infinity.
-pub fn miller_loop_bls12_381(
-    p: &[u64; 12],
-    q: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn miller_loop_bls12_381(p: &[u64; 12], q: &[u64; 24]) -> [u64; 72] {
     // Before the loop starts, compute xp' = (-xp/yp)·1/(1+u) and yp' = (1/yp)·1/(1+u)
     let mut xp: [u64; 6] = p[0..6].try_into().unwrap();
     let mut yp: [u64; 6] = p[6..12].try_into().unwrap();
-    yp = inv_fp_bls12_381(
-        &yp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    xp = neg_fp_bls12_381(
-        &xp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    xp = mul_fp_bls12_381(
-        &xp,
-        &yp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    yp = inv_fp_bls12_381(&yp);
+    xp = neg_fp_bls12_381(&xp);
+    xp = mul_fp_bls12_381(&xp, &yp);
 
-    let xp_prime: [u64; 12] = scalar_mul_fp2_bls12_381(
-        &EXT_U_INV,
-        &xp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let yp_prime: [u64; 12] = scalar_mul_fp2_bls12_381(
-        &EXT_U_INV,
-        &yp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let xp_prime: [u64; 12] = scalar_mul_fp2_bls12_381(&EXT_U_INV, &xp);
+    let yp_prime: [u64; 12] = scalar_mul_fp2_bls12_381(&EXT_U_INV, &yp);
 
     // Initialize the Miller loop with r = q and f = 1
     let mut r: [u64; 24] = q[0..24].try_into().unwrap();
@@ -64,112 +37,41 @@ pub fn miller_loop_bls12_381(
     };
     for &bit in X_ABS_BIN_BE.iter().skip(1) {
         // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(r)}
-        let (lambda, mu) = fcall_bls12_381_twist_dbl_line_coeffs(
-            &r,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let (lambda, mu) = fcall_bls12_381_twist_dbl_line_coeffs(&r);
 
         // Check that the line is correct
-        assert!(is_tangent_twist_bls12_381(
-            &r,
-            &lambda,
-            &mu,
-            #[cfg(feature = "hints")]
-            hints,
-        ));
+        assert!(is_tangent_twist_bls12_381(&r, &lambda, &mu,));
 
         // Compute f = f² · line_{twist(r),twist(r)}(p)
-        f = square_fp12_bls12_381(
-            &f,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let l = line_eval_twist_bls12_381(
-            &lambda,
-            &mu,
-            &xp_prime,
-            &yp_prime,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        f = sparse_mul_fp12_bls12_381(
-            &f,
-            &l,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        f = square_fp12_bls12_381(&f);
+        let l = line_eval_twist_bls12_381(&lambda, &mu, &xp_prime, &yp_prime);
+        f = sparse_mul_fp12_bls12_381(&f, &l);
 
         // Double r
-        r = dbl_twist_with_hints_bls12_381(
-            &r,
-            &lambda,
-            &mu,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        r = dbl_twist_with_hints_bls12_381(&r, &lambda, &mu);
 
         if bit == 1 {
             // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(q)}
-            let (lambda, mu) = fcall_bls12_381_twist_add_line_coeffs(
-                &r,
-                q,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let (lambda, mu) = fcall_bls12_381_twist_add_line_coeffs(&r, q);
 
             // Check that the line is correct
-            assert!(is_line_twist_bls12_381(
-                &r,
-                q,
-                &lambda,
-                &mu,
-                #[cfg(feature = "hints")]
-                hints,
-            ));
+            assert!(is_line_twist_bls12_381(&r, q, &lambda, &mu,));
 
             // Compute f = f · line_{twist(r),twist(q)}
-            let l = line_eval_twist_bls12_381(
-                &lambda,
-                &mu,
-                &xp_prime,
-                &yp_prime,
-                #[cfg(feature = "hints")]
-                hints,
-            );
-            f = sparse_mul_fp12_bls12_381(
-                &f,
-                &l,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let l = line_eval_twist_bls12_381(&lambda, &mu, &xp_prime, &yp_prime);
+            f = sparse_mul_fp12_bls12_381(&f, &l);
 
             // Add r and q
-            r = add_twist_with_hints_bls12_381(
-                &r,
-                q,
-                &lambda,
-                &mu,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            r = add_twist_with_hints_bls12_381(&r, q, &lambda, &mu);
         }
     }
 
     // Finally, compute f̅
-    conjugate_fp12_bls12_381(
-        &f,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    conjugate_fp12_bls12_381(&f)
 }
 
 /// Computes the Miller loop for the BN254 curve for a batch of non-zero points `p_i` in G1 and non-zero points `q_i` in G2
-pub fn miller_loop_batch_bls12_381(
-    g1_points: &[[u64; 12]],
-    g2_points: &[[u64; 24]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn miller_loop_batch_bls12_381(g1_points: &[[u64; 12]], g2_points: &[[u64; 24]]) -> [u64; 72] {
     // Before the loop starts, compute xp' = (-xp/yp)·1/(1+u) and yp' = (1/yp)·1/(1+u)
     let n = g1_points.len();
     let mut xp_primes: Vec<[u64; 12]> = Vec::with_capacity(n);
@@ -177,35 +79,12 @@ pub fn miller_loop_batch_bls12_381(
     for p in g1_points.iter() {
         let mut xp: [u64; 6] = p[0..6].try_into().unwrap();
         let mut yp: [u64; 6] = p[6..12].try_into().unwrap();
-        yp = inv_fp_bls12_381(
-            &yp,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        xp = neg_fp_bls12_381(
-            &xp,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        xp = mul_fp_bls12_381(
-            &xp,
-            &yp,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        yp = inv_fp_bls12_381(&yp);
+        xp = neg_fp_bls12_381(&xp);
+        xp = mul_fp_bls12_381(&xp, &yp);
 
-        let xp_prime: [u64; 12] = scalar_mul_fp2_bls12_381(
-            &EXT_U_INV,
-            &xp,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let yp_prime: [u64; 12] = scalar_mul_fp2_bls12_381(
-            &EXT_U_INV,
-            &yp,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let xp_prime: [u64; 12] = scalar_mul_fp2_bls12_381(&EXT_U_INV, &xp);
+        let yp_prime: [u64; 12] = scalar_mul_fp2_bls12_381(&EXT_U_INV, &yp);
         xp_primes.push(xp_prime);
         yp_primes.push(yp_prime);
     }
@@ -216,113 +95,46 @@ pub fn miller_loop_batch_bls12_381(
     f[0] = 1;
     for &bit in X_ABS_BIN_BE.iter().skip(1) {
         // Compute f = f² · line_{twist(r),twist(r)}(p)
-        f = square_fp12_bls12_381(
-            &f,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        f = square_fp12_bls12_381(&f);
 
         for i in 0..n {
             let r = &mut r[i];
 
             // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(r)}
-            let (lambda, mu) = fcall_bls12_381_twist_dbl_line_coeffs(
-                r,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let (lambda, mu) = fcall_bls12_381_twist_dbl_line_coeffs(r);
 
             // Check that the line is correct
-            assert!(is_tangent_twist_bls12_381(
-                r,
-                &lambda,
-                &mu,
-                #[cfg(feature = "hints")]
-                hints,
-            ));
+            assert!(is_tangent_twist_bls12_381(r, &lambda, &mu,));
 
             let xp_prime = &xp_primes[i];
             let yp_prime = &yp_primes[i];
-            let l = line_eval_twist_bls12_381(
-                &lambda,
-                &mu,
-                xp_prime,
-                yp_prime,
-                #[cfg(feature = "hints")]
-                hints,
-            );
-            f = sparse_mul_fp12_bls12_381(
-                &f,
-                &l,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let l = line_eval_twist_bls12_381(&lambda, &mu, xp_prime, yp_prime);
+            f = sparse_mul_fp12_bls12_381(&f, &l);
 
             // Double r
-            *r = dbl_twist_with_hints_bls12_381(
-                r,
-                &lambda,
-                &mu,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            *r = dbl_twist_with_hints_bls12_381(r, &lambda, &mu);
 
             if bit == 1 {
                 let q = &g2_points[i];
 
                 // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(q')}
-                let (lambda, mu) = fcall_bls12_381_twist_add_line_coeffs(
-                    r,
-                    q,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                let (lambda, mu) = fcall_bls12_381_twist_add_line_coeffs(r, q);
 
                 // Check that the line is correct
-                assert!(is_line_twist_bls12_381(
-                    r,
-                    q,
-                    &lambda,
-                    &mu,
-                    #[cfg(feature = "hints")]
-                    hints,
-                ));
+                assert!(is_line_twist_bls12_381(r, q, &lambda, &mu,));
 
                 // Compute f = f · line_{twist(r),twist(q')}
-                let l = line_eval_twist_bls12_381(
-                    &lambda,
-                    &mu,
-                    xp_prime,
-                    yp_prime,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
-                f = sparse_mul_fp12_bls12_381(
-                    &f,
-                    &l,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                let l = line_eval_twist_bls12_381(&lambda, &mu, xp_prime, yp_prime);
+                f = sparse_mul_fp12_bls12_381(&f, &l);
 
                 // Add r and q
-                *r = add_twist_with_hints_bls12_381(
-                    r,
-                    q,
-                    &lambda,
-                    &mu,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                *r = add_twist_with_hints_bls12_381(r, q, &lambda, &mu);
             }
         }
     }
 
     // Finally, compute f̅
-    conjugate_fp12_bls12_381(
-        &f,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    conjugate_fp12_bls12_381(&f)
 }
 
 // We follow https://eprint.iacr.org/2024/640.pdf for the line computations.
@@ -342,66 +154,24 @@ fn is_line_twist_bls12_381(
     q2: &[u64; 24],
     lambda: &[u64; 12],
     mu: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> bool {
-    line_check_twist_bls12_381(
-        q1,
-        lambda,
-        mu,
-        #[cfg(feature = "hints")]
-        hints,
-    ) && line_check_twist_bls12_381(
-        q2,
-        lambda,
-        mu,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    line_check_twist_bls12_381(q1, lambda, mu) && line_check_twist_bls12_381(q2, lambda, mu)
 }
 
 /// Checks if the line defined by (𝜆,𝜇) is tangent to the curve at non-zero point `q` in G2
 #[inline]
-fn is_tangent_twist_bls12_381(
-    q: &[u64; 24],
-    lambda: &[u64; 12],
-    mu: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+fn is_tangent_twist_bls12_381(q: &[u64; 24], lambda: &[u64; 12], mu: &[u64; 12]) -> bool {
     // Check the line passes through q
-    let curve_check = line_check_twist_bls12_381(
-        q,
-        lambda,
-        mu,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let curve_check = line_check_twist_bls12_381(q, lambda, mu);
 
     // Check the line is tangent at q by checking that 2𝜆y = 3x²
     let x: &[u64; 12] = q[0..12].try_into().unwrap();
     let y: &[u64; 12] = q[12..24].try_into().unwrap();
-    let mut lhs = mul_fp2_bls12_381(
-        lambda,
-        y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lhs = dbl_fp2_bls12_381(
-        &lhs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut lhs = mul_fp2_bls12_381(lambda, y);
+    lhs = dbl_fp2_bls12_381(&lhs);
 
-    let mut rhs = square_fp2_bls12_381(
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = scalar_mul_fp2_bls12_381(
-        &rhs,
-        &[3, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut rhs = square_fp2_bls12_381(x);
+    rhs = scalar_mul_fp2_bls12_381(&rhs, &[3, 0, 0, 0, 0, 0]);
     let tangent_check = eq(&lhs, &rhs);
 
     curve_check && tangent_check
@@ -409,28 +179,13 @@ fn is_tangent_twist_bls12_381(
 
 /// Check if the line defined by (𝜆,𝜇) passes through non-zero point `q` in G2
 #[inline]
-fn line_check_twist_bls12_381(
-    q: &[u64; 24],
-    lambda: &[u64; 12],
-    mu: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+fn line_check_twist_bls12_381(q: &[u64; 24], lambda: &[u64; 12], mu: &[u64; 12]) -> bool {
     let x: &[u64; 12] = q[0..12].try_into().unwrap();
     let y: &[u64; 12] = q[12..24].try_into().unwrap();
 
     // Check if y = λx + μ
-    let mut rhs = mul_fp2_bls12_381(
-        lambda,
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = add_fp2_bls12_381(
-        &rhs,
-        mu,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut rhs = mul_fp2_bls12_381(lambda, x);
+    rhs = add_fp2_bls12_381(&rhs, mu);
     eq(&rhs, y)
 }
 
@@ -441,24 +196,9 @@ fn line_eval_twist_bls12_381(
     mu: &[u64; 12],
     x: &[u64; 12],
     y: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 24] {
-    let coeff1 = mul_fp2_bls12_381(
-        mu,
-        &neg_fp2_bls12_381(
-            y,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let coeff2 = mul_fp2_bls12_381(
-        lambda,
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let coeff1 = mul_fp2_bls12_381(mu, &neg_fp2_bls12_381(y));
+    let coeff2 = mul_fp2_bls12_381(lambda, x);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&coeff1);
@@ -474,48 +214,19 @@ fn add_twist_with_hints_bls12_381(
     q2: &[u64; 24],
     lambda: &[u64; 12],
     mu: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 24] {
     let x1: &[u64; 12] = q1[0..12].try_into().unwrap();
     let x2: &[u64; 12] = q2[0..12].try_into().unwrap();
 
     // Compute x3 = λ² - x1 - x2
-    let mut x3 = square_fp2_bls12_381(
-        lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bls12_381(
-        &x3,
-        x1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bls12_381(
-        &x3,
-        x2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut x3 = square_fp2_bls12_381(lambda);
+    x3 = sub_fp2_bls12_381(&x3, x1);
+    x3 = sub_fp2_bls12_381(&x3, x2);
 
     // Compute y3 = -λx3 - μ
-    let mut y3 = mul_fp2_bls12_381(
-        lambda,
-        &x3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = add_fp2_bls12_381(
-        mu,
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = neg_fp2_bls12_381(
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y3 = mul_fp2_bls12_381(lambda, &x3);
+    y3 = add_fp2_bls12_381(mu, &y3);
+    y3 = neg_fp2_bls12_381(&y3);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&x3);
@@ -525,49 +236,17 @@ fn add_twist_with_hints_bls12_381(
 
 /// Doubling of a non-zero point `q` in G2 with hinted line coefficients (𝜆,𝜇)
 #[inline]
-fn dbl_twist_with_hints_bls12_381(
-    q: &[u64; 24],
-    lambda: &[u64; 12],
-    mu: &[u64; 12],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+fn dbl_twist_with_hints_bls12_381(q: &[u64; 24], lambda: &[u64; 12], mu: &[u64; 12]) -> [u64; 24] {
     let x: &[u64; 12] = q[0..12].try_into().unwrap();
 
     // Compute x3 = λ² - 2x
-    let mut x3 = square_fp2_bls12_381(
-        lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bls12_381(
-        &x3,
-        &dbl_fp2_bls12_381(
-            x,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut x3 = square_fp2_bls12_381(lambda);
+    x3 = sub_fp2_bls12_381(&x3, &dbl_fp2_bls12_381(x));
 
     // Compute y3 = -λx3 - μ
-    let mut y3 = mul_fp2_bls12_381(
-        lambda,
-        &x3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = add_fp2_bls12_381(
-        mu,
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = neg_fp2_bls12_381(
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y3 = mul_fp2_bls12_381(lambda, &x3);
+    y3 = add_fp2_bls12_381(mu, &y3);
+    y3 = neg_fp2_bls12_381(&y3);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&x3);

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/pairing.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/pairing.rs
@@ -32,11 +32,7 @@ const PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP: u8 = 7;
 ///  pairingBLS12-381:
 ///          input: P ∈ G1 and Q ∈ G2
 ///          output: e(P,Q) ∈ GT
-pub fn pairing_bls12_381(
-    p: &[u64; 12],
-    q: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn pairing_bls12_381(p: &[u64; 12], q: &[u64; 24]) -> [u64; 72] {
     // e(P, 𝒪) = e(𝒪, Q) = 1;
     if *p == G1_IDENTITY || *q == G2_IDENTITY {
         let mut one = [0; 72];
@@ -45,19 +41,10 @@ pub fn pairing_bls12_381(
     }
 
     // Miller loop
-    let miller_loop = miller_loop_bls12_381(
-        p,
-        q,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let miller_loop = miller_loop_bls12_381(p, q);
 
     // Final exponentiation
-    final_exp_bls12_381(
-        &miller_loop,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    final_exp_bls12_381(&miller_loop)
 }
 
 /// Computes the optimal Ate pairing for a batch of G1 and G2 points over the BLS12-381 curve
@@ -65,11 +52,7 @@ pub fn pairing_bls12_381(
 ///     e(P₁, Q₁) · e(P₂, Q₂) · ... · e(Pₙ, Qₙ) ∈ GT
 ///
 /// Assumes all points are non-infinity and already validated (on curve and in subgroup).
-pub fn pairing_batch_bls12_381(
-    g1_points: &[[u64; 12]],
-    g2_points: &[[u64; 24]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 72] {
+pub fn pairing_batch_bls12_381(g1_points: &[[u64; 12]], g2_points: &[[u64; 24]]) -> [u64; 72] {
     // Since each e(Pi, Qi) := FinalExp(MillerLoop(Pi, Qi))
     // We have:
     //  e(P₁, Q₁) · e(P₂, Q₂) · ... · e(Pₙ, Qₙ) = FinalExp(MillerLoop(P₁, Q₁) · MillerLoop(P₂, Q₂) · ... · MillerLoop(Pₙ, Qₙ))
@@ -86,25 +69,15 @@ pub fn pairing_batch_bls12_381(
         return one;
     }
 
-    let miller_loop = miller_loop_batch_bls12_381(
-        g1_points,
-        g2_points,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let miller_loop = miller_loop_batch_bls12_381(g1_points, g2_points);
 
-    final_exp_bls12_381(
-        &miller_loop,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    final_exp_bls12_381(&miller_loop)
 }
 
 /// Pairing check with validation
 pub fn pairing_check_bls12_381(
     g1_points: &[[u64; 12]],
     g2_points: &[[u64; 24]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> Result<bool, u8> {
     assert_eq!(g1_points.len(), g2_points.len(), "Number of G1 and G2 points must be equal");
 
@@ -128,18 +101,10 @@ pub fn pairing_check_bls12_381(
             if !lt(&x1, &P) || !lt(&y1, &P) {
                 return Err(PAIRING_CHECK_ERR_G1_NOT_IN_FIELD);
             }
-            if !is_on_curve_bls12_381(
-                g1,
-                #[cfg(feature = "hints")]
-                hints,
-            ) {
+            if !is_on_curve_bls12_381(g1) {
                 return Err(PAIRING_CHECK_ERR_G1_NOT_ON_CURVE);
             }
-            if !is_on_subgroup_bls12_381(
-                g1,
-                #[cfg(feature = "hints")]
-                hints,
-            ) {
+            if !is_on_subgroup_bls12_381(g1) {
                 return Err(PAIRING_CHECK_ERR_G1_NOT_IN_SUBGROUP);
             }
             continue;
@@ -155,18 +120,10 @@ pub fn pairing_check_bls12_381(
             if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
                 return Err(PAIRING_CHECK_ERR_G2_NOT_IN_FIELD);
             }
-            if !is_on_curve_twist_bls12_381(
-                g2,
-                #[cfg(feature = "hints")]
-                hints,
-            ) {
+            if !is_on_curve_twist_bls12_381(g2) {
                 return Err(PAIRING_CHECK_ERR_G2_NOT_ON_CURVE);
             }
-            if !is_on_subgroup_twist_bls12_381(
-                g2,
-                #[cfg(feature = "hints")]
-                hints,
-            ) {
+            if !is_on_subgroup_twist_bls12_381(g2) {
                 return Err(PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP);
             }
             continue;
@@ -178,18 +135,10 @@ pub fn pairing_check_bls12_381(
         if !lt(&x1, &P) || !lt(&y1, &P) {
             return Err(PAIRING_CHECK_ERR_G1_NOT_IN_FIELD);
         }
-        if !is_on_curve_bls12_381(
-            g1,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_bls12_381(g1) {
             return Err(PAIRING_CHECK_ERR_G1_NOT_ON_CURVE);
         }
-        if !is_on_subgroup_bls12_381(
-            g1,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_subgroup_bls12_381(g1) {
             return Err(PAIRING_CHECK_ERR_G1_NOT_IN_SUBGROUP);
         }
 
@@ -200,18 +149,10 @@ pub fn pairing_check_bls12_381(
         if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
             return Err(PAIRING_CHECK_ERR_G2_NOT_IN_FIELD);
         }
-        if !is_on_curve_twist_bls12_381(
-            g2,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_twist_bls12_381(g2) {
             return Err(PAIRING_CHECK_ERR_G2_NOT_ON_CURVE);
         }
-        if !is_on_subgroup_twist_bls12_381(
-            g2,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_subgroup_twist_bls12_381(g2) {
             return Err(PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP);
         }
 
@@ -225,12 +166,7 @@ pub fn pairing_check_bls12_381(
     }
 
     // Compute batch pairing and check if result is 1
-    Ok(is_one(&pairing_batch_bls12_381(
-        &valid_g1,
-        &valid_g2,
-        #[cfg(feature = "hints")]
-        hints,
-    )))
+    Ok(is_one(&pairing_batch_bls12_381(&valid_g1, &valid_g2)))
 }
 
 /// BLS12-381 pairing check for big-endian byte format.
@@ -253,11 +189,7 @@ pub fn pairing_check_bls12_381(
 /// - [PAIRING_CHECK_ERR_G2_NOT_ON_CURVE] = error (at least one G2 point not on curve)
 /// - [PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP] = error (at least one G2 point not in subgroup)
 #[inline]
-pub(crate) unsafe fn bls12_381_pairing_check_c(
-    pairs: *const u8,
-    num_pairs: usize,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bls12_381_pairing_check_c(pairs: *const u8, num_pairs: usize) -> u8 {
     // Parse all pairs
     let mut g1_points: Vec<[u64; 12]> = Vec::with_capacity(num_pairs);
     let mut g2_points: Vec<[u64; 24]> = Vec::with_capacity(num_pairs);
@@ -271,12 +203,7 @@ pub(crate) unsafe fn bls12_381_pairing_check_c(
         g2_points.push(g2_bytes_be_to_u64_le_bls12_381(g2_bytes));
     }
 
-    match pairing_check_bls12_381(
-        &g1_points,
-        &g2_points,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    match pairing_check_bls12_381(&g1_points, &g2_points) {
         Ok(true) => PAIRING_CHECK_SUCCESS,
         Ok(false) => PAIRING_CHECK_FAILED,
         Err(code) => code,

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
@@ -34,10 +34,7 @@ pub const G2_MSM_ERR_NOT_IN_SUBGROUP: u8 = 4;
 /// - Bit 7 (0x80): Compression flag (must be 1 for compressed)
 /// - Bit 6 (0x40): Infinity flag (1 = point at infinity)
 /// - Bit 5 (0x20): Sign flag (1 = y is lexicographically largest)
-pub fn decompress_twist_bls12_381(
-    input: &[u8; 96],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<([u64; 24], bool), &'static str> {
+pub fn decompress_twist_bls12_381(input: &[u8; 96]) -> Result<([u64; 24], bool), &'static str> {
     let flags = input[0];
 
     // Check compression bit
@@ -99,30 +96,12 @@ pub fn decompress_twist_bls12_381(
     x[6..12].copy_from_slice(&x_i);
 
     // Calculate y² = x³ + 4(1+u)
-    let x_sq = square_fp2_bls12_381(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_cb = mul_fp2_bls12_381(
-        &x_sq,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_sq = add_fp2_bls12_381(
-        &x_cb,
-        &ETWISTED_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let x_sq = square_fp2_bls12_381(&x);
+    let x_cb = mul_fp2_bls12_381(&x_sq, &x);
+    let y_sq = add_fp2_bls12_381(&x_cb, &ETWISTED_B);
 
     // Compute sqrt
-    let (y, has_sqrt) = sqrt_fp2_bls12_381(
-        &y_sq,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (y, has_sqrt) = sqrt_fp2_bls12_381(&y_sq);
     if !has_sqrt {
         return Err("No square root exists - point not on curve");
     }
@@ -131,11 +110,7 @@ pub fn decompress_twist_bls12_381(
     // y = y_r + y_i * u is "larger" if:
     //   - y_i > -y_i, OR
     //   - y_i == -y_i (i.e., y_i == 0) AND y_r > -y_r
-    let y_neg = neg_fp2_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y_neg = neg_fp2_bls12_381(&y);
     let y_r: [u64; 6] = y[0..6].try_into().unwrap();
     let y_i: [u64; 6] = y[6..12].try_into().unwrap();
     let y_neg_r: [u64; 6] = y_neg[0..6].try_into().unwrap();
@@ -160,112 +135,45 @@ pub fn decompress_twist_bls12_381(
 }
 
 /// Check if a non-zero point `p` is on the BLS12-381 twist
-pub fn is_on_curve_twist_bls12_381(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+pub fn is_on_curve_twist_bls12_381(p: &[u64; 24]) -> bool {
     // q in E' iff y² == x³ + 4·(1+u)
     let x: [u64; 12] = p[0..12].try_into().unwrap();
     let y: [u64; 12] = p[12..24].try_into().unwrap();
-    let x_sq = square_fp2_bls12_381(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_cubed = mul_fp2_bls12_381(
-        &x_sq,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_cubed_plus_b = add_fp2_bls12_381(
-        &x_cubed,
-        &ETWISTED_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_sq = square_fp2_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let x_sq = square_fp2_bls12_381(&x);
+    let x_cubed = mul_fp2_bls12_381(&x_sq, &x);
+    let x_cubed_plus_b = add_fp2_bls12_381(&x_cubed, &ETWISTED_B);
+    let y_sq = square_fp2_bls12_381(&y);
     eq(&x_cubed_plus_b, &y_sq)
 }
 
 /// Check if a non-zero point `p` is on the BLS12-381 twist subgroup
-pub fn is_on_subgroup_twist_bls12_381(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+pub fn is_on_subgroup_twist_bls12_381(p: &[u64; 24]) -> bool {
     // p in subgroup iff:
     //          x·𝜓³(P) + P == 𝜓²(P)
     // where ψ := 𝜑⁻¹𝜋ₚ𝜑 is the untwist-Frobenius-twist endomorphism
 
     // Compute ψ²(P), ψ³(P)
-    let utf1 = utf_endomorphism_twist_bls12_381(
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let rhs = utf_endomorphism_twist_bls12_381(
-        &utf1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let utf3 = utf_endomorphism_twist_bls12_381(
-        &rhs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let utf1 = utf_endomorphism_twist_bls12_381(p);
+    let rhs = utf_endomorphism_twist_bls12_381(&utf1);
+    let utf3 = utf_endomorphism_twist_bls12_381(&rhs);
 
     // Compute [x]ψ³(P) + P (since x is negative, we compute -[|x|]ψ³(P))
-    let xutf3: [u64; 24] = scalar_mul_by_abs_x_twist_bls12_381(
-        &utf3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut lhs = neg_twist_bls12_381(
-        &xutf3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lhs = add_twist_bls12_381(
-        &lhs,
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let xutf3: [u64; 24] = scalar_mul_by_abs_x_twist_bls12_381(&utf3);
+    let mut lhs = neg_twist_bls12_381(&xutf3);
+    lhs = add_twist_bls12_381(&lhs, p);
 
     eq(&lhs, &rhs)
 }
 
-fn psi_twist_bls12_381(p: &[u64; 24], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 24] {
+fn psi_twist_bls12_381(p: &[u64; 24]) -> [u64; 24] {
     let x: [u64; 12] = p[0..12].try_into().unwrap();
     let y: [u64; 12] = p[12..24].try_into().unwrap();
 
-    let mut frobx = conjugate_fp2_bls12_381(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    frobx = mul_fp2_bls12_381(
-        &frobx,
-        &PSI_C1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut frobx = conjugate_fp2_bls12_381(&x);
+    frobx = mul_fp2_bls12_381(&frobx, &PSI_C1);
 
-    let mut froby = conjugate_fp2_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    froby = mul_fp2_bls12_381(
-        &froby,
-        &PSI_C2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut froby = conjugate_fp2_bls12_381(&y);
+    froby = mul_fp2_bls12_381(&froby, &PSI_C2);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&frobx);
@@ -273,24 +181,12 @@ fn psi_twist_bls12_381(p: &[u64; 24], #[cfg(feature = "hints")] hints: &mut Vec<
     result
 }
 
-fn psi2_twist_bls12_381(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+fn psi2_twist_bls12_381(p: &[u64; 24]) -> [u64; 24] {
     let x: [u64; 12] = p[0..12].try_into().unwrap();
     let y: [u64; 12] = p[12..24].try_into().unwrap();
 
-    let xa = mul_fp2_bls12_381(
-        &x,
-        &PSI2_C1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let ya = neg_fp2_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let xa = mul_fp2_bls12_381(&x, &PSI2_C1);
+    let ya = neg_fp2_bls12_381(&y);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&xa);
@@ -300,83 +196,23 @@ fn psi2_twist_bls12_381(
 
 /// Efficient cofactor clearing for G2 using endomorphisms
 /// Implements: h_eff * P where h_eff is the effective cofactor
-pub fn clear_cofactor_twist_bls12_381(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
-    let mut t1 = scalar_mul_by_abs_x_twist_bls12_381(
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t1 = neg_twist_bls12_381(
-        &t1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut t2 = psi_twist_bls12_381(
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut t3 = dbl_twist_bls12_381(
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t3 = psi2_twist_bls12_381(
-        &t3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t3 = sub_twist_bls12_381(
-        &t3,
-        &t2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t2 = add_twist_bls12_381(
-        &t1,
-        &t2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t2 = scalar_mul_by_abs_x_twist_bls12_381(
-        &t2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t2 = neg_twist_bls12_381(
-        &t2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t3 = add_twist_bls12_381(
-        &t3,
-        &t2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t3 = sub_twist_bls12_381(
-        &t3,
-        &t1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    sub_twist_bls12_381(
-        &t3,
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+pub fn clear_cofactor_twist_bls12_381(p: &[u64; 24]) -> [u64; 24] {
+    let mut t1 = scalar_mul_by_abs_x_twist_bls12_381(p);
+    t1 = neg_twist_bls12_381(&t1);
+    let mut t2 = psi_twist_bls12_381(p);
+    let mut t3 = dbl_twist_bls12_381(p);
+    t3 = psi2_twist_bls12_381(&t3);
+    t3 = sub_twist_bls12_381(&t3, &t2);
+    t2 = add_twist_bls12_381(&t1, &t2);
+    t2 = scalar_mul_by_abs_x_twist_bls12_381(&t2);
+    t2 = neg_twist_bls12_381(&t2);
+    t3 = add_twist_bls12_381(&t3, &t2);
+    t3 = sub_twist_bls12_381(&t3, &t1);
+    sub_twist_bls12_381(&t3, p)
 }
 
 /// Addition of two non-zero points
-pub fn add_twist_bls12_381(
-    p1: &[u64; 24],
-    p2: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn add_twist_bls12_381(p1: &[u64; 24], p2: &[u64; 24]) -> [u64; 24] {
     let x1: [u64; 12] = p1[0..12].try_into().unwrap();
     let y1: [u64; 12] = p1[12..24].try_into().unwrap();
     let x2: [u64; 12] = p2[0..12].try_into().unwrap();
@@ -387,11 +223,7 @@ pub fn add_twist_bls12_381(
         // Is y1 == y2?
         if eq(&y1, &y2) {
             // Compute the doubling
-            return dbl_twist_bls12_381(
-                p1,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            return dbl_twist_bls12_381(p1);
         } else {
             // Points are the inverse of each other, return the point at infinity
             return G2_IDENTITY;
@@ -399,65 +231,17 @@ pub fn add_twist_bls12_381(
     }
 
     // Compute the addition
-    let mut den = sub_fp2_bls12_381(
-        &x2,
-        &x1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    den = inv_fp2_bls12_381(
-        &den,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut lambda = sub_fp2_bls12_381(
-        &y2,
-        &y1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = mul_fp2_bls12_381(
-        &lambda,
-        &den,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut den = sub_fp2_bls12_381(&x2, &x1);
+    den = inv_fp2_bls12_381(&den);
+    let mut lambda = sub_fp2_bls12_381(&y2, &y1);
+    lambda = mul_fp2_bls12_381(&lambda, &den);
 
-    let mut x3 = square_fp2_bls12_381(
-        &lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bls12_381(
-        &x3,
-        &x1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bls12_381(
-        &x3,
-        &x2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut y3 = sub_fp2_bls12_381(
-        &x1,
-        &x3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = mul_fp2_bls12_381(
-        &lambda,
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = sub_fp2_bls12_381(
-        &y3,
-        &y1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut x3 = square_fp2_bls12_381(&lambda);
+    x3 = sub_fp2_bls12_381(&x3, &x1);
+    x3 = sub_fp2_bls12_381(&x3, &x2);
+    let mut y3 = sub_fp2_bls12_381(&x1, &x3);
+    y3 = mul_fp2_bls12_381(&lambda, &y3);
+    y3 = sub_fp2_bls12_381(&y3, &y1);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&x3);
@@ -466,11 +250,7 @@ pub fn add_twist_bls12_381(
 }
 
 /// Addition of two points
-pub fn add_complete_twist_bls12_381(
-    p1: &[u64; 24],
-    p2: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 24], u8> {
+pub fn add_complete_twist_bls12_381(p1: &[u64; 24], p2: &[u64; 24]) -> Result<[u64; 24], u8> {
     let p1_is_inf = eq(p1, &G2_IDENTITY);
     let p2_is_inf = eq(p2, &G2_IDENTITY);
 
@@ -488,11 +268,7 @@ pub fn add_complete_twist_bls12_381(
         if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
             return Err(G2_ADD_ERR_NOT_IN_FIELD);
         }
-        if !is_on_curve_twist_bls12_381(
-            p2,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_twist_bls12_381(p2) {
             return Err(G2_ADD_ERR_NOT_ON_CURVE);
         }
         return Ok(*p2);
@@ -507,11 +283,7 @@ pub fn add_complete_twist_bls12_381(
         if !lt(&x1_0, &P) || !lt(&x1_1, &P) || !lt(&y1_0, &P) || !lt(&y1_1, &P) {
             return Err(G2_ADD_ERR_NOT_IN_FIELD);
         }
-        if !is_on_curve_twist_bls12_381(
-            p1,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_twist_bls12_381(p1) {
             return Err(G2_ADD_ERR_NOT_ON_CURVE);
         }
         return Ok(*p1);
@@ -525,11 +297,7 @@ pub fn add_complete_twist_bls12_381(
     if !lt(&x1_0, &P) || !lt(&x1_1, &P) || !lt(&y1_0, &P) || !lt(&y1_1, &P) {
         return Err(G2_ADD_ERR_NOT_IN_FIELD);
     }
-    if !is_on_curve_twist_bls12_381(
-        p1,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !is_on_curve_twist_bls12_381(p1) {
         return Err(G2_ADD_ERR_NOT_ON_CURVE);
     }
 
@@ -540,97 +308,33 @@ pub fn add_complete_twist_bls12_381(
     if !lt(&x2_0, &P) || !lt(&x2_1, &P) || !lt(&y2_0, &P) || !lt(&y2_1, &P) {
         return Err(G2_ADD_ERR_NOT_IN_FIELD);
     }
-    if !is_on_curve_twist_bls12_381(
-        p2,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !is_on_curve_twist_bls12_381(p2) {
         return Err(G2_ADD_ERR_NOT_ON_CURVE);
     }
 
     // Perform addition
-    Ok(add_twist_bls12_381(
-        p1,
-        p2,
-        #[cfg(feature = "hints")]
-        hints,
-    ))
+    Ok(add_twist_bls12_381(p1, p2))
 }
 
 /// Doubling of a non-zero point
-pub fn dbl_twist_bls12_381(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn dbl_twist_bls12_381(p: &[u64; 24]) -> [u64; 24] {
     let x: [u64; 12] = p[0..12].try_into().unwrap();
     let y: [u64; 12] = p[12..24].try_into().unwrap();
 
     // Compute the doubling
-    let mut lambda = dbl_fp2_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = inv_fp2_bls12_381(
-        &lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = scalar_mul_fp2_bls12_381(
-        &lambda,
-        &[0x3, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = mul_fp2_bls12_381(
-        &lambda,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = mul_fp2_bls12_381(
-        &lambda,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut lambda = dbl_fp2_bls12_381(&y);
+    lambda = inv_fp2_bls12_381(&lambda);
+    lambda = scalar_mul_fp2_bls12_381(&lambda, &[0x3, 0, 0, 0, 0, 0]);
+    lambda = mul_fp2_bls12_381(&lambda, &x);
+    lambda = mul_fp2_bls12_381(&lambda, &x);
 
-    let mut x3 = square_fp2_bls12_381(
-        &lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bls12_381(
-        &x3,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bls12_381(
-        &x3,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut x3 = square_fp2_bls12_381(&lambda);
+    x3 = sub_fp2_bls12_381(&x3, &x);
+    x3 = sub_fp2_bls12_381(&x3, &x);
 
-    let mut y3 = sub_fp2_bls12_381(
-        &x,
-        &x3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = mul_fp2_bls12_381(
-        &lambda,
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = sub_fp2_bls12_381(
-        &y3,
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y3 = sub_fp2_bls12_381(&x, &x3);
+    y3 = mul_fp2_bls12_381(&lambda, &y3);
+    y3 = sub_fp2_bls12_381(&y3, &y);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&x3);
@@ -639,39 +343,22 @@ pub fn dbl_twist_bls12_381(
 }
 
 /// Subtraction of two non-zero points `p1` and `p2` on the BLS12-381 curve
-pub fn sub_twist_bls12_381(
-    p1: &[u64; 24],
-    p2: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn sub_twist_bls12_381(p1: &[u64; 24], p2: &[u64; 24]) -> [u64; 24] {
     let x2: [u64; 12] = p2[0..12].try_into().unwrap();
     let y2: [u64; 12] = p2[12..24].try_into().unwrap();
 
     // P1 - P2 = P1 + (-P2)
-    let y2_neg = neg_fp2_bls12_381(
-        &y2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y2_neg = neg_fp2_bls12_381(&y2);
 
     let mut p2_neg = [0u64; 24];
     p2_neg[0..12].copy_from_slice(&x2);
     p2_neg[12..24].copy_from_slice(&y2_neg);
 
-    add_twist_bls12_381(
-        p1,
-        &p2_neg,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    add_twist_bls12_381(p1, &p2_neg)
 }
 
 /// Subtraction of two points `p1` and `p2` on the BLS12-381 curve
-pub fn sub_complete_twist_bls12_381(
-    p1: &[u64; 24],
-    p2: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn sub_complete_twist_bls12_381(p1: &[u64; 24], p2: &[u64; 24]) -> [u64; 24] {
     let p1_is_inf = *p1 == G2_IDENTITY;
     let p2_is_inf = *p2 == G2_IDENTITY;
 
@@ -681,39 +368,23 @@ pub fn sub_complete_twist_bls12_381(
         return G2_IDENTITY;
     } else if p1_is_inf {
         // O - P2 = -P2
-        return neg_twist_bls12_381(
-            p2,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        return neg_twist_bls12_381(p2);
     } else if p2_is_inf {
         // P1 - O = P1
         return *p1;
     }
 
     // Perform regular subtraction: P1 - P2 = P1 + (-P2)
-    sub_twist_bls12_381(
-        p1,
-        p2,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    sub_twist_bls12_381(p1, p2)
 }
 
 /// Negation of a point
-pub fn neg_twist_bls12_381(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn neg_twist_bls12_381(p: &[u64; 24]) -> [u64; 24] {
     let x: [u64; 12] = p[0..12].try_into().unwrap();
     let y: [u64; 12] = p[12..24].try_into().unwrap();
 
     // Compute the negation
-    let y_neg = neg_fp2_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y_neg = neg_fp2_bls12_381(&y);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&x);
@@ -722,11 +393,7 @@ pub fn neg_twist_bls12_381(
 }
 
 /// Multiplies a non-zero point `p` on the BLS12-381 curve by a scalar `k` on the BLS12-381 scalar field
-pub fn scalar_mul_twist_bls12_381(
-    p: &[u64; 24],
-    k: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn scalar_mul_twist_bls12_381(p: &[u64; 24], k: &[u64; 4]) -> [u64; 24] {
     // Direct cases: k = 0, k = 1, k = 2
     match k {
         [0, 0, 0, 0] => {
@@ -739,11 +406,7 @@ pub fn scalar_mul_twist_bls12_381(
         }
         [2, 0, 0, 0] => {
             // Return 2p
-            return dbl_twist_bls12_381(
-                p,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            return dbl_twist_bls12_381(p);
         }
         _ => {}
     }
@@ -752,12 +415,7 @@ pub fn scalar_mul_twist_bls12_381(
     // Hint the length the binary representations of k
     // We will verify the output by recomposing k
     // Moreover, we should check that the first received bit is 1
-    let (max_limb, max_bit) = fcall_msb_pos_256(
-        k,
-        &[0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (max_limb, max_bit) = fcall_msb_pos_256(k, &[0, 0, 0, 0]);
 
     // Perform the loop, based on the binary representation of k
 
@@ -787,21 +445,12 @@ pub fn scalar_mul_twist_bls12_381(
     for i in (0..=limb).rev() {
         for j in (0..=bit).rev() {
             // Always double
-            q = dbl_twist_bls12_381(
-                &q,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            q = dbl_twist_bls12_381(&q);
 
             // Get the next bit b of k.
             // If b == 1, we should add P to Q, otherwise start the next iteration
             if ((k[i] >> j) & 1) == 1 {
-                q = add_twist_bls12_381(
-                    &q,
-                    p,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                q = add_twist_bls12_381(&q, p);
 
                 // Reconstruct k
                 k_rec[i] |= 1 << j;
@@ -818,41 +467,20 @@ pub fn scalar_mul_twist_bls12_381(
 }
 
 /// Scalar multiplication of a non-zero point `p` by a binary scalar `k`
-pub fn scalar_mul_bin_twist_bls12_381(
-    p: &[u64; 24],
-    k: &[u8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn scalar_mul_bin_twist_bls12_381(p: &[u64; 24], k: &[u8]) -> [u64; 24] {
     let mut r = *p;
     for &bit in k.iter().skip(1) {
-        r = dbl_twist_bls12_381(
-            &r,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        r = dbl_twist_bls12_381(&r);
         if bit == 1 {
-            r = add_twist_bls12_381(
-                &r,
-                p,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            r = add_twist_bls12_381(&r, p);
         }
     }
     r
 }
 
 /// Scalar multiplication of a non-zero point by x
-pub fn scalar_mul_by_abs_x_twist_bls12_381(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
-    scalar_mul_bin_twist_bls12_381(
-        p,
-        &X_ABS_BIN_BE,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+pub fn scalar_mul_by_abs_x_twist_bls12_381(p: &[u64; 24]) -> [u64; 24] {
+    scalar_mul_bin_twist_bls12_381(p, &X_ABS_BIN_BE)
 }
 
 /// Multi-Scalar Multiplication (MSM) for BLS12-381 G2 points
@@ -861,7 +489,6 @@ pub fn scalar_mul_by_abs_x_twist_bls12_381(
 pub fn msm_complete_twist_bls12_381(
     points: &[[u64; 24]],
     scalars: &[[u64; 4]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> Result<[u64; 24], u8> {
     debug_assert_eq!(points.len(), scalars.len());
 
@@ -875,11 +502,7 @@ pub fn msm_complete_twist_bls12_381(
         }
 
         // Reduce the scalar modulo the group order, and skip if the result is zero
-        let scalar = reduce_fr_bls12_381(
-            scalar,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let scalar = reduce_fr_bls12_381(scalar);
         if is_zero(&scalar) {
             continue;
         }
@@ -894,30 +517,17 @@ pub fn msm_complete_twist_bls12_381(
         }
 
         // Verify point is on curve
-        if !is_on_curve_twist_bls12_381(
-            point,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_twist_bls12_381(point) {
             return Err(G2_MSM_ERR_NOT_ON_CURVE);
         }
 
         // Verify point is in subgroup (required for MSM per EIP-2537)
-        if !is_on_subgroup_twist_bls12_381(
-            point,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_subgroup_twist_bls12_381(point) {
             return Err(G2_MSM_ERR_NOT_IN_SUBGROUP);
         }
 
         // Compute P * k
-        let product = scalar_mul_twist_bls12_381(
-            point,
-            &scalar,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let product = scalar_mul_twist_bls12_381(point, &scalar);
 
         // Skip if product is infinity
         if product == G2_IDENTITY {
@@ -929,12 +539,7 @@ pub fn msm_complete_twist_bls12_381(
             acc = product;
             acc_is_inf = false;
         } else {
-            acc = add_twist_bls12_381(
-                &acc,
-                &product,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            acc = add_twist_bls12_381(&acc, &product);
             acc_is_inf = acc == G2_IDENTITY;
         }
     }
@@ -946,67 +551,26 @@ pub fn msm_complete_twist_bls12_381(
 ///     𝜑 : E'(Fp2) -> E(Fp12) defined by 𝜑(x,y) = (x/ω²,y/ω³) is the untwist map
 ///     𝜋ₚ : E(Fp12) -> E(Fp12) defined by 𝜋ₚ(x,y) = (xᵖ,yᵖ) is the Frobenius map
 ///     𝜑⁻¹ : E(Fp12) -> E'(Fp2) defined by 𝜑⁻¹(x,y) = (x·ω²,y·ω³) is the twist map
-pub fn utf_endomorphism_twist_bls12_381(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn utf_endomorphism_twist_bls12_381(p: &[u64; 24]) -> [u64; 24] {
     let mut x: [u64; 12] = p[0..12].try_into().unwrap();
     let mut y: [u64; 12] = p[12..24].try_into().unwrap();
 
     // 1] Compute 𝜑(x,y) = (x/ω²,y/ω³) = (x·(%W_INV_X + %W_INV_Y·u)·ω⁴,y·(%W_INV_X + %W_INV_Y·u)·ω³) ∈ E(Fp12)
-    x = mul_fp2_bls12_381(
-        &x,
-        &EXT_U_INV,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y = mul_fp2_bls12_381(
-        &y,
-        &EXT_U_INV,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    x = mul_fp2_bls12_381(&x, &EXT_U_INV);
+    y = mul_fp2_bls12_381(&y, &EXT_U_INV);
 
     // 2] Compute 𝜋ₚ(a,b) = (aᵖ,bᵖ), i.e., apply the frobenius operator
     //    Since the previous result has only one non-zero coefficient, we can apply a specialized frobenius directly
     //    (a·ω⁴)ᵖ = a̅·γ14·ω⁴, (b·ω³)ᵖ = b̅·γ13·ω³
-    x = conjugate_fp2_bls12_381(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x = scalar_mul_fp2_bls12_381(
-        &x,
-        &FROBENIUS_GAMMA14,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y = conjugate_fp2_bls12_381(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y = mul_fp2_bls12_381(
-        &y,
-        &FROBENIUS_GAMMA13,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    x = conjugate_fp2_bls12_381(&x);
+    x = scalar_mul_fp2_bls12_381(&x, &FROBENIUS_GAMMA14);
+    y = conjugate_fp2_bls12_381(&y);
+    y = mul_fp2_bls12_381(&y, &FROBENIUS_GAMMA13);
 
     // 3] Compute 𝜑⁻¹(a,b) = (a·ω²,b·ω³) ∈ E'(Fp2). In our particular case, we have:
     //         𝜑⁻¹((a̅·γ14·ω⁴)·ω²,(b̅·γ13·ω³)·ω³) = (a̅·γ14·(1+u), b̅·γ13·(1+u))
-    x = mul_fp2_bls12_381(
-        &x,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y = mul_fp2_bls12_381(
-        &y,
-        &EXT_U,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    x = mul_fp2_bls12_381(&x, &EXT_U);
+    y = mul_fp2_bls12_381(&y, &EXT_U);
 
     let mut result = [0u64; 24];
     result[0..12].copy_from_slice(&x);
@@ -1031,12 +595,7 @@ pub fn utf_endomorphism_twist_bls12_381(
 /// - [G2_ADD_ERR_NOT_IN_FIELD] = error (at least one point coordinate not in field)
 /// - [G2_ADD_ERR_NOT_ON_CURVE] = error (at least one point not on curve)
 #[inline]
-pub(crate) unsafe fn bls12_381_g2_add_c(
-    ret: *mut u8,
-    a: *const u8,
-    b: *const u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bls12_381_g2_add_c(ret: *mut u8, a: *const u8, b: *const u8) -> u8 {
     let a_bytes: &[u8; 192] = &*(a as *const [u8; 192]);
     let b_bytes: &[u8; 192] = &*(b as *const [u8; 192]);
     let ret_bytes: &mut [u8; 192] = &mut *(ret as *mut [u8; 192]);
@@ -1046,12 +605,7 @@ pub(crate) unsafe fn bls12_381_g2_add_c(
     let b_u64 = g2_bytes_be_to_u64_le_bls12_381(b_bytes);
 
     // Perform addition
-    let result = match add_complete_twist_bls12_381(
-        &a_u64,
-        &b_u64,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let result = match add_complete_twist_bls12_381(&a_u64, &b_u64) {
         Ok(r) => r,
         Err(code) => return code,
     };
@@ -1081,12 +635,7 @@ pub(crate) unsafe fn bls12_381_g2_add_c(
 /// - [G2_MSM_ERR_NOT_ON_CURVE] = error (at least one point not on curve)
 /// - [G2_MSM_ERR_NOT_IN_SUBGROUP] = error (at least one point not in subgroup)
 #[inline]
-pub(crate) unsafe fn bls12_381_g2_msm_c(
-    ret: *mut u8,
-    pairs: *const u8,
-    num_pairs: usize,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bls12_381_g2_msm_c(ret: *mut u8, pairs: *const u8, num_pairs: usize) -> u8 {
     let ret_bytes: &mut [u8; 192] = &mut *(ret as *mut [u8; 192]);
 
     // Parse all pairs
@@ -1106,12 +655,7 @@ pub(crate) unsafe fn bls12_381_g2_msm_c(
     }
 
     // Perform MSM with validation
-    let result = match msm_complete_twist_bls12_381(
-        &points,
-        &scalars,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let result = match msm_complete_twist_bls12_381(&points, &scalars) {
         Ok(r) => r,
         Err(code) => return code,
     };

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/curve.rs
@@ -29,42 +29,20 @@ const G1_MUL_ERR_NOT_IN_FIELD: u8 = 2;
 const G1_MUL_ERR_NOT_ON_CURVE: u8 = 3;
 
 /// Check if a non-zero point `p` is on the BN254 curve
-pub fn is_on_curve_bn254(p: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> bool {
+pub fn is_on_curve_bn254(p: &[u64; 8]) -> bool {
     let x: [u64; 4] = p[0..4].try_into().unwrap();
     let y: [u64; 4] = p[4..8].try_into().unwrap();
 
     // p in E iff y² == x³ + 3
-    let lhs = square_fp_bn254(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut rhs = square_fp_bn254(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = mul_fp_bn254(
-        &rhs,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = add_fp_bn254(
-        &rhs,
-        &E_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let lhs = square_fp_bn254(&y);
+    let mut rhs = square_fp_bn254(&x);
+    rhs = mul_fp_bn254(&rhs, &x);
+    rhs = add_fp_bn254(&rhs, &E_B);
     eq(&lhs, &rhs)
 }
 
 /// Adds two non-zero points `p1` and `p2` on the BN254 curve
-pub fn add_bn254(
-    p1: &[u64; 8],
-    p2: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 8] {
+pub fn add_bn254(p1: &[u64; 8], p2: &[u64; 8]) -> [u64; 8] {
     let x1: [u64; 4] = p1[0..4].try_into().unwrap();
     let y1: [u64; 4] = p1[4..8].try_into().unwrap();
     let x2: [u64; 4] = p2[0..4].try_into().unwrap();
@@ -75,11 +53,7 @@ pub fn add_bn254(
         // Is y1 == y2?
         if eq(&y1, &y2) {
             // Compute the doubling
-            return dbl_bn254(
-                p1,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            return dbl_bn254(p1);
         } else {
             // Return 𝒪
             return G1_IDENTITY;
@@ -94,11 +68,7 @@ pub fn add_bn254(
 
     // Call the syscall to add the two points
     let mut params = SyscallBn254CurveAddParams { p1: &mut p1, p2: &p2 };
-    syscall_bn254_curve_add(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_curve_add(&mut params);
 
     // Convert the result back to a single array
     let x3 = params.p1.x;
@@ -107,11 +77,7 @@ pub fn add_bn254(
 }
 
 /// Addition of two points with validation and identity handling
-pub fn add_complete_bn254(
-    p1: &[u64; 8],
-    p2: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 8], u8> {
+pub fn add_complete_bn254(p1: &[u64; 8], p2: &[u64; 8]) -> Result<[u64; 8], u8> {
     let p1_is_inf = eq(p1, &G1_IDENTITY);
     let p2_is_inf = eq(p2, &G1_IDENTITY);
 
@@ -127,11 +93,7 @@ pub fn add_complete_bn254(
         if !lt(&x2, &P) || !lt(&y2, &P) {
             return Err(G1_ADD_ERR_NOT_IN_FIELD);
         }
-        if !is_on_curve_bn254(
-            p2,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_bn254(p2) {
             return Err(G1_ADD_ERR_NOT_ON_CURVE);
         }
         return Ok(*p2);
@@ -144,11 +106,7 @@ pub fn add_complete_bn254(
         if !lt(&x1, &P) || !lt(&y1, &P) {
             return Err(G1_ADD_ERR_NOT_IN_FIELD);
         }
-        if !is_on_curve_bn254(
-            p1,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_bn254(p1) {
             return Err(G1_ADD_ERR_NOT_ON_CURVE);
         }
         return Ok(*p1);
@@ -160,11 +118,7 @@ pub fn add_complete_bn254(
     if !lt(&x1, &P) || !lt(&y1, &P) {
         return Err(G1_ADD_ERR_NOT_IN_FIELD);
     }
-    if !is_on_curve_bn254(
-        p1,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !is_on_curve_bn254(p1) {
         return Err(G1_ADD_ERR_NOT_ON_CURVE);
     }
 
@@ -173,54 +127,33 @@ pub fn add_complete_bn254(
     if !lt(&x2, &P) || !lt(&y2, &P) {
         return Err(G1_ADD_ERR_NOT_IN_FIELD);
     }
-    if !is_on_curve_bn254(
-        p2,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !is_on_curve_bn254(p2) {
         return Err(G1_ADD_ERR_NOT_ON_CURVE);
     }
 
     // Perform addition
-    Ok(add_bn254(
-        p1,
-        p2,
-        #[cfg(feature = "hints")]
-        hints,
-    ))
+    Ok(add_bn254(p1, p2))
 }
 
 /// Doubles a non-zero point `p` on the BN254 curve
-pub fn dbl_bn254(p: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 8] {
+pub fn dbl_bn254(p: &[u64; 8]) -> [u64; 8] {
     let mut p1 = SyscallPoint256 { x: p[0..4].try_into().unwrap(), y: p[4..8].try_into().unwrap() };
-    syscall_bn254_curve_dbl(
-        &mut p1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_curve_dbl(&mut p1);
     [p1.x[0], p1.x[1], p1.x[2], p1.x[3], p1.y[0], p1.y[1], p1.y[2], p1.y[3]]
 }
 
 /// Negation of a point
-pub fn neg_bn254(p: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 8] {
+pub fn neg_bn254(p: &[u64; 8]) -> [u64; 8] {
     let x: [u64; 4] = p[0..4].try_into().unwrap();
     let y: [u64; 4] = p[4..8].try_into().unwrap();
 
     // Compute the negation
-    let y_neg = neg_fp_bn254(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y_neg = neg_fp_bn254(&y);
     [x[0], x[1], x[2], x[3], y_neg[0], y_neg[1], y_neg[2], y_neg[3]]
 }
 
 /// Multiplies a non-zero point `p` on the BN254 curve by a scalar `k` on the BN254 scalar field
-pub fn scalar_mul_bn254(
-    p: &[u64; 8],
-    k: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 8] {
+pub fn scalar_mul_bn254(p: &[u64; 8], k: &[u64; 4]) -> [u64; 8] {
     // Direct cases: k = 0, k = 1, k = 2
     match k {
         [0, 0, 0, 0] => {
@@ -233,11 +166,7 @@ pub fn scalar_mul_bn254(
         }
         [2, 0, 0, 0] => {
             // Return 2p
-            return dbl_bn254(
-                p,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            return dbl_bn254(p);
         }
         _ => {}
     }
@@ -246,12 +175,7 @@ pub fn scalar_mul_bn254(
     // Hint the length the binary representations of k
     // We will verify the output by recomposing k
     // Moreover, we should check that the first received bit is 1
-    let (max_limb, max_bit) = fcall_msb_pos_256(
-        k,
-        &[0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (max_limb, max_bit) = fcall_msb_pos_256(k, &[0, 0, 0, 0]);
 
     // Perform the loop, based on the binary representation of k
 
@@ -284,21 +208,13 @@ pub fn scalar_mul_bn254(
     for i in (0..=limb).rev() {
         for j in (0..=bit).rev() {
             // Always double
-            syscall_bn254_curve_dbl(
-                &mut q,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            syscall_bn254_curve_dbl(&mut q);
 
             // Get the next bit b of k.
             // If b == 1, we should add P to Q, otherwise start the next iteration
             if ((k[i] >> j) & 1) == 1 {
                 let mut params = SyscallBn254CurveAddParams { p1: &mut q, p2: &p };
-                syscall_bn254_curve_add(
-                    &mut params,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                syscall_bn254_curve_add(&mut params);
 
                 // Reconstruct k
                 k_rec[i] |= 1 << j;
@@ -317,11 +233,7 @@ pub fn scalar_mul_bn254(
 }
 
 /// Scalar multiplication with validation and identity handling
-pub fn mul_complete_bn254(
-    p: &[u64; 8],
-    k: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 8], u8> {
+pub fn mul_complete_bn254(p: &[u64; 8], k: &[u64; 4]) -> Result<[u64; 8], u8> {
     // If point is infinity, result is infinity
     if eq(p, &G1_IDENTITY) {
         return Ok(G1_IDENTITY);
@@ -335,28 +247,15 @@ pub fn mul_complete_bn254(
         return Err(G1_MUL_ERR_NOT_IN_FIELD);
     }
 
-    if !is_on_curve_bn254(
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !is_on_curve_bn254(p) {
         return Err(G1_MUL_ERR_NOT_ON_CURVE);
     }
 
     // Reduce the scalar
-    let k = reduce_fr_bn254(
-        k,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let k = reduce_fr_bn254(k);
 
     // Perform scalar multiplication
-    Ok(scalar_mul_bn254(
-        p,
-        &k,
-        #[cfg(feature = "hints")]
-        hints,
-    ))
+    Ok(scalar_mul_bn254(p, &k))
 }
 
 /// BN254 G1 point addition with big-endian byte format
@@ -371,12 +270,7 @@ pub fn mul_complete_bn254(
 /// - 1 if p1 is invalid (not on curve or invalid field element)
 /// - 2 if p2 is invalid (not on curve or invalid field element)
 #[inline]
-pub(crate) unsafe fn bn254_g1_add_c(
-    p1: *const u8,
-    p2: *const u8,
-    ret: *mut u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bn254_g1_add_c(p1: *const u8, p2: *const u8, ret: *mut u8) -> u8 {
     let p1_bytes: &[u8; 64] = &*(p1 as *const [u8; 64]);
     let p2_bytes: &[u8; 64] = &*(p2 as *const [u8; 64]);
     let ret_bytes: &mut [u8; 64] = &mut *(ret as *mut [u8; 64]);
@@ -386,12 +280,7 @@ pub(crate) unsafe fn bn254_g1_add_c(
     let p2_u64 = g1_bytes_be_to_u64_le_bn254(p2_bytes);
 
     // Perform addition with validation
-    let result = match add_complete_bn254(
-        &p1_u64,
-        &p2_u64,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let result = match add_complete_bn254(&p1_u64, &p2_u64) {
         Ok(r) => r,
         Err(code) => return code,
     };
@@ -416,12 +305,7 @@ pub(crate) unsafe fn bn254_g1_add_c(
 /// - 0 if the operation succeeded
 /// - 1 if point is invalid (not on curve or invalid field element)
 #[inline]
-pub(crate) unsafe fn bn254_g1_mul_c(
-    point: *const u8,
-    scalar: *const u8,
-    ret: *mut u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bn254_g1_mul_c(point: *const u8, scalar: *const u8, ret: *mut u8) -> u8 {
     let point_bytes: &[u8; 64] = &*(point as *const [u8; 64]);
     let scalar_bytes: &[u8; 32] = &*(scalar as *const [u8; 32]);
     let ret_bytes: &mut [u8; 64] = &mut *(ret as *mut [u8; 64]);
@@ -431,12 +315,7 @@ pub(crate) unsafe fn bn254_g1_mul_c(
     let scalar_u64 = scalar_bytes_be_to_u64_le_bn254(scalar_bytes);
 
     // Perform scalar multiplication with validation
-    let product = match mul_complete_bn254(
-        &point_u64,
-        &scalar_u64,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let product = match mul_complete_bn254(&point_u64, &scalar_u64) {
         Ok(r) => r,
         Err(code) => return code,
     };

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/cyclotomic.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/cyclotomic.rs
@@ -47,10 +47,7 @@ pub fn compress_cyclo_bn254(a: &[u64; 48]) -> [u64; 32] {
 /// **NOTE**: If the input is not of the form C(a), where a ∈ GΦ6(p²), then the compression-decompression
 ///           technique is not well defined. This means that D(C(a)) != a.
 #[inline]
-pub fn decompress_cyclo_bn254(
-    a: &[u64; 32],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn decompress_cyclo_bn254(a: &[u64; 32]) -> [u64; 48] {
     let a2: &[u64; 8] = &a[0..8].try_into().unwrap();
     let a3: &[u64; 8] = &a[8..16].try_into().unwrap();
     let a4: &[u64; 8] = &a[16..24].try_into().unwrap();
@@ -58,179 +55,39 @@ pub fn decompress_cyclo_bn254(
 
     let (a0, a1) = if eq(a2, &[0, 0, 0, 0, 0, 0, 0, 0]) {
         // a1 = (2·a4·a5)/a3
-        let a3_inv = inv_fp2_bn254(
-            a3,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let mut a1 = mul_fp2_bn254(
-            a4,
-            a5,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = dbl_fp2_bn254(
-            &a1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = mul_fp2_bn254(
-            &a1,
-            &a3_inv,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let a3_inv = inv_fp2_bn254(a3);
+        let mut a1 = mul_fp2_bn254(a4, a5);
+        a1 = dbl_fp2_bn254(&a1);
+        a1 = mul_fp2_bn254(&a1, &a3_inv);
 
         // a0 = (2·a1² - 3·a3·a4)(9+u) + 1
-        let a3a4 = mul_fp2_bn254(
-            a3,
-            a4,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let mut a0 = square_fp2_bn254(
-            &a1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = dbl_fp2_bn254(
-            &a0,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = sub_fp2_bn254(
-            &a0,
-            &scalar_mul_fp2_bn254(
-                &a3a4,
-                &[3, 0, 0, 0],
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = mul_fp2_bn254(
-            &a0,
-            &[9, 0, 0, 0, 1, 0, 0, 0],
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = add_fp2_bn254(
-            &a0,
-            &[1, 0, 0, 0, 0, 0, 0, 0],
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let a3a4 = mul_fp2_bn254(a3, a4);
+        let mut a0 = square_fp2_bn254(&a1);
+        a0 = dbl_fp2_bn254(&a0);
+        a0 = sub_fp2_bn254(&a0, &scalar_mul_fp2_bn254(&a3a4, &[3, 0, 0, 0]));
+        a0 = mul_fp2_bn254(&a0, &[9, 0, 0, 0, 1, 0, 0, 0]);
+        a0 = add_fp2_bn254(&a0, &[1, 0, 0, 0, 0, 0, 0, 0]);
 
         (a0, a1)
     } else {
         // a1 = (a5²·(9+u) + 3·a4² - 2·a3)/(4·a2)
-        let a2_inv = inv_fp2_bn254(
-            &scalar_mul_fp2_bn254(
-                a2,
-                &[4, 0, 0, 0],
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let a4_sq = square_fp2_bn254(
-            a4,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let mut a1 = square_fp2_bn254(
-            a5,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = mul_fp2_bn254(
-            &a1,
-            &[9, 0, 0, 0, 1, 0, 0, 0],
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = add_fp2_bn254(
-            &a1,
-            &scalar_mul_fp2_bn254(
-                &a4_sq,
-                &[3, 0, 0, 0],
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = sub_fp2_bn254(
-            &a1,
-            &dbl_fp2_bn254(
-                a3,
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a1 = mul_fp2_bn254(
-            &a1,
-            &a2_inv,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let a2_inv = inv_fp2_bn254(&scalar_mul_fp2_bn254(a2, &[4, 0, 0, 0]));
+        let a4_sq = square_fp2_bn254(a4);
+        let mut a1 = square_fp2_bn254(a5);
+        a1 = mul_fp2_bn254(&a1, &[9, 0, 0, 0, 1, 0, 0, 0]);
+        a1 = add_fp2_bn254(&a1, &scalar_mul_fp2_bn254(&a4_sq, &[3, 0, 0, 0]));
+        a1 = sub_fp2_bn254(&a1, &dbl_fp2_bn254(a3));
+        a1 = mul_fp2_bn254(&a1, &a2_inv);
 
         // a0 = (2·a1² + a2·a5 - 3·a3·a4)(9+u) + 1
-        let a3a4 = mul_fp2_bn254(
-            a3,
-            a4,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let a2a5 = mul_fp2_bn254(
-            a2,
-            a5,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let mut a0 = square_fp2_bn254(
-            &a1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = dbl_fp2_bn254(
-            &a0,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = add_fp2_bn254(
-            &a0,
-            &a2a5,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = sub_fp2_bn254(
-            &a0,
-            &scalar_mul_fp2_bn254(
-                &a3a4,
-                &[3, 0, 0, 0],
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = mul_fp2_bn254(
-            &a0,
-            &[9, 0, 0, 0, 1, 0, 0, 0],
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        a0 = add_fp2_bn254(
-            &a0,
-            &[1, 0, 0, 0, 0, 0, 0, 0],
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let a3a4 = mul_fp2_bn254(a3, a4);
+        let a2a5 = mul_fp2_bn254(a2, a5);
+        let mut a0 = square_fp2_bn254(&a1);
+        a0 = dbl_fp2_bn254(&a0);
+        a0 = add_fp2_bn254(&a0, &a2a5);
+        a0 = sub_fp2_bn254(&a0, &scalar_mul_fp2_bn254(&a3a4, &[3, 0, 0, 0]));
+        a0 = mul_fp2_bn254(&a0, &[9, 0, 0, 0, 1, 0, 0, 0]);
+        a0 = add_fp2_bn254(&a0, &[1, 0, 0, 0, 0, 0, 0, 0]);
 
         (a0, a1)
     };
@@ -260,180 +117,46 @@ pub fn decompress_cyclo_bn254(
 //     - B45 = a4·a5
 //
 /// **NOTE**: The output is not guaranteed to be in GΦ6(p²), if the input isn't.
-pub fn square_cyclo_bn254(
-    a: &[u64; 32],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 32] {
+pub fn square_cyclo_bn254(a: &[u64; 32]) -> [u64; 32] {
     let a2: &[u64; 8] = &a[0..8].try_into().unwrap();
     let a3: &[u64; 8] = &a[8..16].try_into().unwrap();
     let a4: &[u64; 8] = &a[16..24].try_into().unwrap();
     let a5: &[u64; 8] = &a[24..32].try_into().unwrap();
 
     // B23 = a2·a3, B45 = a4·a5
-    let b23 = mul_fp2_bn254(
-        a2,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let b45 = mul_fp2_bn254(
-        a4,
-        a5,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let b23 = mul_fp2_bn254(a2, a3);
+    let b45 = mul_fp2_bn254(a4, a5);
 
     // A23 = (a2 + a3)·(a2 + (9+u)·a3)
-    let a3xi = mul_fp2_bn254(
-        a3,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a23 = mul_fp2_bn254(
-        &add_fp2_bn254(
-            a2,
-            a3,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        &add_fp2_bn254(
-            a2,
-            &a3xi,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a3xi = mul_fp2_bn254(a3, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    let a23 = mul_fp2_bn254(&add_fp2_bn254(a2, a3), &add_fp2_bn254(a2, &a3xi));
 
     // A45 = (a4 + a5)·(a4 + (9+u)·a5)
-    let a5xi = mul_fp2_bn254(
-        a5,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a45 = mul_fp2_bn254(
-        &add_fp2_bn254(
-            a4,
-            a5,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        &add_fp2_bn254(
-            a4,
-            &a5xi,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a5xi = mul_fp2_bn254(a5, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    let a45 = mul_fp2_bn254(&add_fp2_bn254(a4, a5), &add_fp2_bn254(a4, &a5xi));
 
     // b2 = 2(a2 + 3·(9+u)·B45)
-    let mut b2 = mul_fp2_bn254(
-        &b45,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b2 = scalar_mul_fp2_bn254(
-        &b2,
-        &[3, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b2 = add_fp2_bn254(
-        a2,
-        &b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b2 = dbl_fp2_bn254(
-        &b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut b2 = mul_fp2_bn254(&b45, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    b2 = scalar_mul_fp2_bn254(&b2, &[3, 0, 0, 0]);
+    b2 = add_fp2_bn254(a2, &b2);
+    b2 = dbl_fp2_bn254(&b2);
 
     // b3 = 3·(A45 - (10+u)·B45) - 2·a3
-    let mut b3 = mul_fp2_bn254(
-        &b45,
-        &[10, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b3 = sub_fp2_bn254(
-        &a45,
-        &b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b3 = scalar_mul_fp2_bn254(
-        &b3,
-        &[3, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b3 = sub_fp2_bn254(
-        &b3,
-        &dbl_fp2_bn254(
-            a3,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut b3 = mul_fp2_bn254(&b45, &[10, 0, 0, 0, 1, 0, 0, 0]);
+    b3 = sub_fp2_bn254(&a45, &b3);
+    b3 = scalar_mul_fp2_bn254(&b3, &[3, 0, 0, 0]);
+    b3 = sub_fp2_bn254(&b3, &dbl_fp2_bn254(a3));
 
     // b4 = 3·(A23 - (10+u)·B23) - 2·a4
-    let mut b4 = mul_fp2_bn254(
-        &b23,
-        &[10, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b4 = sub_fp2_bn254(
-        &a23,
-        &b4,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b4 = scalar_mul_fp2_bn254(
-        &b4,
-        &[3, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b4 = sub_fp2_bn254(
-        &b4,
-        &dbl_fp2_bn254(
-            a4,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut b4 = mul_fp2_bn254(&b23, &[10, 0, 0, 0, 1, 0, 0, 0]);
+    b4 = sub_fp2_bn254(&a23, &b4);
+    b4 = scalar_mul_fp2_bn254(&b4, &[3, 0, 0, 0]);
+    b4 = sub_fp2_bn254(&b4, &dbl_fp2_bn254(a4));
 
     // b5 = 2·(a5 + 3·B23)
-    let mut b5 = scalar_mul_fp2_bn254(
-        &b23,
-        &[3, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b5 = add_fp2_bn254(
-        a5,
-        &b5,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    b5 = dbl_fp2_bn254(
-        &b5,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut b5 = scalar_mul_fp2_bn254(&b23, &[3, 0, 0, 0]);
+    b5 = add_fp2_bn254(a5, &b5);
+    b5 = dbl_fp2_bn254(&b5);
 
     let mut result = [0; 32];
     result[0..8].copy_from_slice(&b2);
@@ -450,10 +173,7 @@ pub fn square_cyclo_bn254(
 // out: a^x = (a0 + a4·v + a3·v²) + (a2 + a1·v + a5·v²)·w ∈ ∈ GΦ6(p²)
 //
 /// **NOTE**: The output is not guaranteed to be in GΦ6(p²), if the input isn't.
-pub fn exp_by_x_cyclo_bn254(
-    a: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn exp_by_x_cyclo_bn254(a: &[u64; 48]) -> [u64; 48] {
     // Binary representation of the exponent x = 4965661367192848881 in big-endian format
     const X_BIN_LE: [u8; 63] = [
         1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0,
@@ -468,25 +188,12 @@ pub fn exp_by_x_cyclo_bn254(
     let mut comp = compress_cyclo_bn254(a);
     for &bit in X_BIN_LE.iter().skip(1) {
         // We always square (in compressed form): C(c²)
-        comp = square_cyclo_bn254(
-            &comp,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        comp = square_cyclo_bn254(&comp);
 
         if bit == 1 {
             // decompress and multiply
-            let decomp = decompress_cyclo_bn254(
-                &comp,
-                #[cfg(feature = "hints")]
-                hints,
-            );
-            result = mul_fp12_bn254(
-                &result,
-                &decomp,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let decomp = decompress_cyclo_bn254(&comp);
+            result = mul_fp12_bn254(&result, &decomp);
         }
     }
 

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/final_exp.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/final_exp.rs
@@ -12,249 +12,86 @@ use super::{
 // However, I dont think its a good idea in general to optimize verification "at all costs".
 
 /// Given f ∈ Fp12*, computes f^((p¹²-1)/r) ∈ Fp12*
-pub fn final_exp_bn254(f: &[u64; 48], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 48] {
+pub fn final_exp_bn254(f: &[u64; 48]) -> [u64; 48] {
     //////////////////
     // The easy part: exp by (p^6-1)(p^2+1)
     //////////////////
 
     // f^(p^6-1) = f̅·f⁻¹
-    let f_conj = conjugate_fp12_bn254(
-        f,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let f_inv = inv_fp12_bn254(
-        f,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let easy1 = mul_fp12_bn254(
-        &f_conj,
-        &f_inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let f_conj = conjugate_fp12_bn254(f);
+    let f_inv = inv_fp12_bn254(f);
+    let easy1 = mul_fp12_bn254(&f_conj, &f_inv);
 
     // easy1^(p²-1) = easy1^p²·easy1
-    let mut m = frobenius2_fp12_bn254(
-        &easy1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    m = mul_fp12_bn254(
-        &m,
-        &easy1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut m = frobenius2_fp12_bn254(&easy1);
+    m = mul_fp12_bn254(&m, &easy1);
 
     //////////////////
     // The hard part: exp by (p⁴-p²+1)/r
     //////////////////
 
     // m^x, (m^x)^x, (m^{x²})^x
-    let mx = exp_by_x_cyclo_bn254(
-        &m,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mxx = exp_by_x_cyclo_bn254(
-        &mx,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mxxx = exp_by_x_cyclo_bn254(
-        &mxx,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mx = exp_by_x_cyclo_bn254(&m);
+    let mxx = exp_by_x_cyclo_bn254(&mx);
+    let mxxx = exp_by_x_cyclo_bn254(&mxx);
 
     // m^p, m^p², m^p³, (m^x)^p, (m^x²)^p, (m^x³)^p, (m^x²)^p²
-    let mp = frobenius1_fp12_bn254(
-        &m,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mpp = frobenius2_fp12_bn254(
-        &m,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mppp = frobenius3_fp12_bn254(
-        &m,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mxp = frobenius1_fp12_bn254(
-        &mx,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mxxp = frobenius1_fp12_bn254(
-        &mxx,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mxxxp = frobenius1_fp12_bn254(
-        &mxxx,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mxxpp = frobenius2_fp12_bn254(
-        &mxx,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mp = frobenius1_fp12_bn254(&m);
+    let mpp = frobenius2_fp12_bn254(&m);
+    let mppp = frobenius3_fp12_bn254(&m);
+    let mxp = frobenius1_fp12_bn254(&mx);
+    let mxxp = frobenius1_fp12_bn254(&mxx);
+    let mxxxp = frobenius1_fp12_bn254(&mxxx);
+    let mxxpp = frobenius2_fp12_bn254(&mxx);
 
     // y1 = m^p·m^p²·m^p³
-    let mut y1 = mul_fp12_bn254(
-        &mp,
-        &mpp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y1 = mul_fp12_bn254(
-        &y1,
-        &mppp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y1 = mul_fp12_bn254(&mp, &mpp);
+    y1 = mul_fp12_bn254(&y1, &mppp);
 
     // y2 = m̅
-    let y2 = conjugate_fp12_bn254(
-        &m,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y2 = conjugate_fp12_bn254(&m);
 
     // y3 = (m^x²)^p² (already done)
 
     // y4 = \bar{(m^x)^p}
-    let y4 = conjugate_fp12_bn254(
-        &mxp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y4 = conjugate_fp12_bn254(&mxp);
 
     // y5 = \bar{m^x·(m^x²)^p}
-    let mut y5 = mul_fp12_bn254(
-        &mx,
-        &mxxp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y5 = conjugate_fp12_bn254(
-        &y5,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y5 = mul_fp12_bn254(&mx, &mxxp);
+    y5 = conjugate_fp12_bn254(&y5);
     // y6 = \bar{m^x²}
-    let y6 = conjugate_fp12_bn254(
-        &mxx,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y6 = conjugate_fp12_bn254(&mxx);
 
     // y7 = \bar{m^x³·(m^x³)^p}
-    let mut y7 = mul_fp12_bn254(
-        &mxxx,
-        &mxxxp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y7 = conjugate_fp12_bn254(
-        &y7,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y7 = mul_fp12_bn254(&mxxx, &mxxxp);
+    y7 = conjugate_fp12_bn254(&y7);
     // Compute y1·y2²·y3⁶·y4¹²·y5¹⁸·y6³⁰·y7³⁶ as follows
     // T11 = y7²·y5·y6
-    let mut t11 = square_fp12_bn254(
-        &y7,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t11 = mul_fp12_bn254(
-        &t11,
-        &y5,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t11 = mul_fp12_bn254(
-        &t11,
-        &y6,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut t11 = square_fp12_bn254(&y7);
+    t11 = mul_fp12_bn254(&t11, &y5);
+    t11 = mul_fp12_bn254(&t11, &y6);
 
     // T21 = T11·y4·y6
-    let mut t21 = mul_fp12_bn254(
-        &t11,
-        &y4,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t21 = mul_fp12_bn254(
-        &t21,
-        &y6,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut t21 = mul_fp12_bn254(&t11, &y4);
+    t21 = mul_fp12_bn254(&t21, &y6);
 
     // T12 = T11·y3
-    let t12 = mul_fp12_bn254(
-        &t11,
-        &mxxpp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let t12 = mul_fp12_bn254(&t11, &mxxpp);
     // T22 = T21²·T12
-    let mut t22 = square_fp12_bn254(
-        &t21,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t22 = mul_fp12_bn254(
-        &t22,
-        &t12,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut t22 = square_fp12_bn254(&t21);
+    t22 = mul_fp12_bn254(&t22, &t12);
 
     // T23 = T22²
-    let t23 = square_fp12_bn254(
-        &t22,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let t23 = square_fp12_bn254(&t22);
 
     // T24 = T23·y1
-    let t24 = mul_fp12_bn254(
-        &t23,
-        &y1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let t24 = mul_fp12_bn254(&t23, &y1);
 
     // T13 = T23·y2
-    let t13 = mul_fp12_bn254(
-        &t23,
-        &y2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let t13 = mul_fp12_bn254(&t23, &y2);
 
     // T14 = T13²·T24
-    let mut t14 = square_fp12_bn254(
-        &t13,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    t14 = mul_fp12_bn254(
-        &t14,
-        &t24,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut t14 = square_fp12_bn254(&t13);
+    t14 = mul_fp12_bn254(&t14, &t24);
     t14
 }

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/fp.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/fp.rs
@@ -9,25 +9,17 @@ use super::constants::{P, P_MINUS_ONE};
 
 /// Addition in the base field of the BN254 curve
 #[inline]
-pub fn add_fp_bn254(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn add_fp_bn254(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·1 + y
     let mut params =
         SyscallArith256ModParams { a: x, b: &[1, 0, 0, 0], c: y, module: &P, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
 /// Negation in the base field of the BN254 curve
 #[inline]
-pub fn neg_fp_bn254(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 4] {
+pub fn neg_fp_bn254(x: &[u64; 4]) -> [u64; 4] {
     // x·(-1) + 0
     let mut params = SyscallArith256ModParams {
         a: x,
@@ -36,49 +28,33 @@ pub fn neg_fp_bn254(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>
         module: &P,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
 /// Multiplication in the base field of the BN254 curve
 #[inline]
-pub fn mul_fp_bn254(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn mul_fp_bn254(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·y + 0
     let mut params =
         SyscallArith256ModParams { a: x, b: y, c: &[0, 0, 0, 0], module: &P, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
 /// Squaring in the base field of the BN254 curve
 #[inline]
-pub fn square_fp_bn254(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 4] {
+pub fn square_fp_bn254(x: &[u64; 4]) -> [u64; 4] {
     // x·x + 0
     let mut params =
         SyscallArith256ModParams { a: x, b: x, c: &[0, 0, 0, 0], module: &P, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
 /// Inversion in the base field of the BN254 curve
 #[inline]
-pub fn inv_fp_bn254(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 4] {
+pub fn inv_fp_bn254(x: &[u64; 4]) -> [u64; 4] {
     // if x == 0, return 0
     if eq(x, &[0, 0, 0, 0]) {
         return [0, 0, 0, 0];
@@ -88,11 +64,7 @@ pub fn inv_fp_bn254(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>
 
     // Remember that an element y ∈ Fp is the inverse of x ∈ Fp if and only if x·y = 1 in Fp
     // We will therefore hint the inverse y and check the product with x is 1
-    let inv = fcall_bn254_fp_inv(
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let inv = fcall_bn254_fp_inv(x);
 
     // x·y + 0
     let mut params = SyscallArith256ModParams {
@@ -102,11 +74,7 @@ pub fn inv_fp_bn254(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>
         module: &P,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     assert_eq!(*params.d, [1, 0, 0, 0]);
 
     inv

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/fp12.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/fp12.rs
@@ -24,71 +24,22 @@ use super::{
 //      - c1 = a1·b1 + a2·b2·v
 //      - c2 = (a1+a2)·(b1+b2) - a1·b1 - a2·b2
 #[inline]
-pub fn mul_fp12_bn254(
-    a: &[u64; 48],
-    b: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn mul_fp12_bn254(a: &[u64; 48], b: &[u64; 48]) -> [u64; 48] {
     let a1 = &a[0..24].try_into().unwrap();
     let a2 = &a[24..48].try_into().unwrap();
     let b1 = &b[0..24].try_into().unwrap();
     let b2 = &b[24..48].try_into().unwrap();
 
-    let a1b1 = mul_fp6_bn254(
-        a1,
-        b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2b2 = mul_fp6_bn254(
-        a2,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1b1 = mul_fp6_bn254(a1, b1);
+    let a2b2 = mul_fp6_bn254(a2, b2);
 
-    let a2b2v = sparse_mula_fp6_bn254(
-        &a2b2,
-        &[1, 0, 0, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let c1 = add_fp6_bn254(
-        &a1b1,
-        &a2b2v,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1_plus_a2 = add_fp6_bn254(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let b1_plus_b2 = add_fp6_bn254(
-        b1,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut c2 = mul_fp6_bn254(
-        &a1_plus_a2,
-        &b1_plus_b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = sub_fp6_bn254(
-        &c2,
-        &a1b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = sub_fp6_bn254(
-        &c2,
-        &a2b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a2b2v = sparse_mula_fp6_bn254(&a2b2, &[1, 0, 0, 0, 0, 0, 0, 0]);
+    let c1 = add_fp6_bn254(&a1b1, &a2b2v);
+    let a1_plus_a2 = add_fp6_bn254(a1, a2);
+    let b1_plus_b2 = add_fp6_bn254(b1, b2);
+    let mut c2 = mul_fp6_bn254(&a1_plus_a2, &b1_plus_b2);
+    c2 = sub_fp6_bn254(&c2, &a1b1);
+    c2 = sub_fp6_bn254(&c2, &a2b2);
 
     let mut result = [0; 48];
     result[0..24].copy_from_slice(&c1);
@@ -103,39 +54,15 @@ pub fn mul_fp12_bn254(
 //      - c1 = a1 + a2·(b21·v + b22·v²)
 //      - c2 = a2 + a1·(b21 + b22·v)
 #[inline]
-pub fn sparse_mul_fp12_bn254(
-    a: &[u64; 48],
-    b: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn sparse_mul_fp12_bn254(a: &[u64; 48], b: &[u64; 16]) -> [u64; 48] {
     let a1 = &a[0..24].try_into().unwrap();
     let a2 = &a[24..48].try_into().unwrap();
 
-    let mut c1 = sparse_mulc_fp6_bn254(
-        a2,
-        b,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp6_bn254(
-        &c1,
-        a1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = sparse_mulc_fp6_bn254(a2, b);
+    c1 = add_fp6_bn254(&c1, a1);
 
-    let mut c2 = sparse_mulb_fp6_bn254(
-        a1,
-        b,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp6_bn254(
-        &c2,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = sparse_mulb_fp6_bn254(a1, b);
+    c2 = add_fp6_bn254(&c2, a2);
 
     let mut result = [0; 48];
     result[0..24].copy_from_slice(&c1);
@@ -150,70 +77,23 @@ pub fn sparse_mul_fp12_bn254(
 //      - c1 = (a1-a2)·(a1-a2·v) + a1·a2 + a1·a2·v
 //      - c2 = 2·a1·a2
 #[inline]
-pub fn square_fp12_bn254(
-    a: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn square_fp12_bn254(a: &[u64; 48]) -> [u64; 48] {
     let a1 = &a[0..24].try_into().unwrap();
     let a2 = &a[24..48].try_into().unwrap();
 
     // a1·a2, a2·v, a1·a2·v
-    let a1a2 = mul_fp6_bn254(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2v = sparse_mula_fp6_bn254(
-        a2,
-        &[1, 0, 0, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1a2v = sparse_mula_fp6_bn254(
-        &a1a2,
-        &[1, 0, 0, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1a2 = mul_fp6_bn254(a1, a2);
+    let a2v = sparse_mula_fp6_bn254(a2, &[1, 0, 0, 0, 0, 0, 0, 0]);
+    let a1a2v = sparse_mula_fp6_bn254(&a1a2, &[1, 0, 0, 0, 0, 0, 0, 0]);
 
     // c1
-    let a1_minus_a2 = sub_fp6_bn254(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1_minus_a2v = sub_fp6_bn254(
-        a1,
-        &a2v,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut c1 = mul_fp6_bn254(
-        &a1_minus_a2,
-        &a1_minus_a2v,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp6_bn254(
-        &c1,
-        &a1a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp6_bn254(
-        &c1,
-        &a1a2v,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_minus_a2 = sub_fp6_bn254(a1, a2);
+    let a1_minus_a2v = sub_fp6_bn254(a1, &a2v);
+    let mut c1 = mul_fp6_bn254(&a1_minus_a2, &a1_minus_a2v);
+    c1 = add_fp6_bn254(&c1, &a1a2);
+    c1 = add_fp6_bn254(&c1, &a1a2v);
     // c2
-    let c2 = dbl_fp6_bn254(
-        &a1a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c2 = dbl_fp6_bn254(&a1a2);
 
     let mut result = [0; 48];
     result[0..24].copy_from_slice(&c1);
@@ -228,55 +108,19 @@ pub fn square_fp12_bn254(
 //      - c1 = a1·(a1² - a2²·v)⁻¹
 //      - c2 = -a2·(a1² - a2²·v)⁻¹
 #[inline]
-pub fn inv_fp12_bn254(a: &[u64; 48], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 48] {
+pub fn inv_fp12_bn254(a: &[u64; 48]) -> [u64; 48] {
     let a1 = &a[0..24].try_into().unwrap();
     let a2 = &a[24..48].try_into().unwrap();
 
-    let a1_sq = square_fp6_bn254(
-        a1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2_sq = square_fp6_bn254(
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_sq = square_fp6_bn254(a1);
+    let a2_sq = square_fp6_bn254(a2);
 
-    let a2_sqv = sparse_mula_fp6_bn254(
-        &a2_sq,
-        &[1, 0, 0, 0, 0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1_sq_minus_a2_sqv = sub_fp6_bn254(
-        &a1_sq,
-        &a2_sqv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let inv = inv_fp6_bn254(
-        &a1_sq_minus_a2_sqv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a2_sqv = sparse_mula_fp6_bn254(&a2_sq, &[1, 0, 0, 0, 0, 0, 0, 0]);
+    let a1_sq_minus_a2_sqv = sub_fp6_bn254(&a1_sq, &a2_sqv);
+    let inv = inv_fp6_bn254(&a1_sq_minus_a2_sqv);
 
-    let c1 = mul_fp6_bn254(
-        a1,
-        &inv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let c2 = neg_fp6_bn254(
-        &mul_fp6_bn254(
-            a2,
-            &inv,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c1 = mul_fp6_bn254(a1, &inv);
+    let c2 = neg_fp6_bn254(&mul_fp6_bn254(a2, &inv));
 
     let mut result = [0; 48];
     result[0..24].copy_from_slice(&c1);
@@ -286,17 +130,10 @@ pub fn inv_fp12_bn254(a: &[u64; 48], #[cfg(feature = "hints")] hints: &mut Vec<u
 
 /// Conjugation in the degree 12 extension of the BN254 curve
 #[inline]
-pub fn conjugate_fp12_bn254(
-    a: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn conjugate_fp12_bn254(a: &[u64; 48]) -> [u64; 48] {
     let mut result = [0; 48];
     result[0..24].copy_from_slice(&a[0..24]);
-    result[24..48].copy_from_slice(&neg_fp6_bn254(
-        &a[24..48].try_into().unwrap(),
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    result[24..48].copy_from_slice(&neg_fp6_bn254(&a[24..48].try_into().unwrap()));
     result
 }
 
@@ -307,10 +144,7 @@ pub fn conjugate_fp12_bn254(
 //      - c1 = a̅11     + a̅12·γ12·v + a̅13·γ14·v²
 //      - c2 = a̅21·γ11 + a̅22·γ13·v + a̅23·γ15·v²
 #[inline]
-pub fn frobenius1_fp12_bn254(
-    a: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn frobenius1_fp12_bn254(a: &[u64; 48]) -> [u64; 48] {
     let a11 = &a[0..8].try_into().unwrap();
     let a12 = &a[8..16].try_into().unwrap();
     let a13 = &a[16..24].try_into().unwrap();
@@ -321,68 +155,19 @@ pub fn frobenius1_fp12_bn254(
     let mut result = [0; 48];
 
     // c1 = a̅11 + a̅12·γ12·v + a̅13·γ14·v²
-    result[0..8].copy_from_slice(&conjugate_fp2_bn254(
-        a11,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    let mut tmp = conjugate_fp2_bn254(
-        a12,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[8..16].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA12,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    tmp = conjugate_fp2_bn254(
-        a13,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[16..24].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA14,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    result[0..8].copy_from_slice(&conjugate_fp2_bn254(a11));
+    let mut tmp = conjugate_fp2_bn254(a12);
+    result[8..16].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA12));
+    tmp = conjugate_fp2_bn254(a13);
+    result[16..24].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA14));
 
     // c2 = a̅21·γ11 + a̅22·γ13·v + a̅23·γ15·v²
-    tmp = conjugate_fp2_bn254(
-        a21,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[24..32].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA11,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    tmp = conjugate_fp2_bn254(
-        a22,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[32..40].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA13,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    tmp = conjugate_fp2_bn254(
-        a23,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[40..48].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA15,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    tmp = conjugate_fp2_bn254(a21);
+    result[24..32].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA11));
+    tmp = conjugate_fp2_bn254(a22);
+    result[32..40].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA13));
+    tmp = conjugate_fp2_bn254(a23);
+    result[40..48].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA15));
 
     result
 }
@@ -394,10 +179,7 @@ pub fn frobenius1_fp12_bn254(
 //      - c1 = a11     + a12·γ22·v + a13·γ24·v²
 //      - c2 = a21·γ21 + a22·γ23·v + a23·γ25·v²
 #[inline]
-pub fn frobenius2_fp12_bn254(
-    a: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn frobenius2_fp12_bn254(a: &[u64; 48]) -> [u64; 48] {
     let a11: &[u64; 8] = &a[0..8].try_into().unwrap();
     let a12 = &a[8..16].try_into().unwrap();
     let a13 = &a[16..24].try_into().unwrap();
@@ -409,38 +191,13 @@ pub fn frobenius2_fp12_bn254(
 
     // c1 = a11 + a12·γ22·v + a13·γ24·v²
     result[0..8].copy_from_slice(a11);
-    result[8..16].copy_from_slice(&scalar_mul_fp2_bn254(
-        a12,
-        &FROBENIUS_GAMMA22,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    result[16..24].copy_from_slice(&scalar_mul_fp2_bn254(
-        a13,
-        &FROBENIUS_GAMMA24,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    result[8..16].copy_from_slice(&scalar_mul_fp2_bn254(a12, &FROBENIUS_GAMMA22));
+    result[16..24].copy_from_slice(&scalar_mul_fp2_bn254(a13, &FROBENIUS_GAMMA24));
 
     // c2 = a21·γ21 + a22·γ23·v + a23·γ25·v²
-    result[24..32].copy_from_slice(&scalar_mul_fp2_bn254(
-        a21,
-        &FROBENIUS_GAMMA21,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    result[32..40].copy_from_slice(&scalar_mul_fp2_bn254(
-        a22,
-        &FROBENIUS_GAMMA23,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    result[40..48].copy_from_slice(&scalar_mul_fp2_bn254(
-        a23,
-        &FROBENIUS_GAMMA25,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    result[24..32].copy_from_slice(&scalar_mul_fp2_bn254(a21, &FROBENIUS_GAMMA21));
+    result[32..40].copy_from_slice(&scalar_mul_fp2_bn254(a22, &FROBENIUS_GAMMA23));
+    result[40..48].copy_from_slice(&scalar_mul_fp2_bn254(a23, &FROBENIUS_GAMMA25));
 
     result
 }
@@ -452,10 +209,7 @@ pub fn frobenius2_fp12_bn254(
 //      - c1 = a̅11     + a̅12·γ32·v + a̅13·γ34·v²
 //      - c2 = a̅21·γ31 + a̅22·γ33·v + a̅23·γ35·v²
 #[inline]
-pub fn frobenius3_fp12_bn254(
-    a: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn frobenius3_fp12_bn254(a: &[u64; 48]) -> [u64; 48] {
     let a11 = &a[0..8].try_into().unwrap();
     let a12 = &a[8..16].try_into().unwrap();
     let a13 = &a[16..24].try_into().unwrap();
@@ -466,68 +220,19 @@ pub fn frobenius3_fp12_bn254(
     let mut result = [0; 48];
 
     // c1 = a̅11 + a̅12·γ32·v + a̅13·γ34·v²
-    result[0..8].copy_from_slice(&conjugate_fp2_bn254(
-        a11,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    let mut tmp = conjugate_fp2_bn254(
-        a12,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[8..16].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA32,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    tmp = conjugate_fp2_bn254(
-        a13,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[16..24].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA34,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    result[0..8].copy_from_slice(&conjugate_fp2_bn254(a11));
+    let mut tmp = conjugate_fp2_bn254(a12);
+    result[8..16].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA32));
+    tmp = conjugate_fp2_bn254(a13);
+    result[16..24].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA34));
 
     // c2 = a̅21·γ31 + a̅22·γ33·v + a̅23·γ35·v²
-    tmp = conjugate_fp2_bn254(
-        a21,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[24..32].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA31,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    tmp = conjugate_fp2_bn254(
-        a22,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[32..40].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA33,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
-    tmp = conjugate_fp2_bn254(
-        a23,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    result[40..48].copy_from_slice(&mul_fp2_bn254(
-        &tmp,
-        &FROBENIUS_GAMMA35,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    tmp = conjugate_fp2_bn254(a21);
+    result[24..32].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA31));
+    tmp = conjugate_fp2_bn254(a22);
+    result[32..40].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA33));
+    tmp = conjugate_fp2_bn254(a23);
+    result[40..48].copy_from_slice(&mul_fp2_bn254(&tmp, &FROBENIUS_GAMMA35));
 
     result
 }
@@ -537,11 +242,7 @@ pub fn frobenius3_fp12_bn254(
 // in: e, (a1 + a2·w) ∈ Fp12, where e ∈ [0,p¹²-2] ai ∈ Fp6
 // out: (c1 + c2·w) = (a1 + a2·w)^e ∈ Fp12
 #[inline]
-pub fn exp_fp12_bn254(
-    e: u64,
-    a: &[u64; 48],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn exp_fp12_bn254(e: u64, a: &[u64; 48]) -> [u64; 48] {
     let mut one = [0; 48];
     one[0] = 1;
     if eq(a, &[0; 48]) {
@@ -556,12 +257,7 @@ pub fn exp_fp12_bn254(
         return *a;
     }
 
-    let (_, max_bit) = fcall_msb_pos_256(
-        &[e, 0, 0, 0],
-        &[0, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (_, max_bit) = fcall_msb_pos_256(&[e, 0, 0, 0], &[0, 0, 0, 0]);
 
     // Perform the loop, based on the binary representation of e
 
@@ -577,21 +273,12 @@ pub fn exp_fp12_bn254(
     let _max_bit = max_bit as usize;
     for i in (0.._max_bit).rev() {
         // Always square
-        result = square_fp12_bn254(
-            &result,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        result = square_fp12_bn254(&result);
 
         // Get the next bit b of e
         // If b == 1, we should multiply it by a, otherwise start the next iteration
         if ((e >> i) & 1) == 1 {
-            result = mul_fp12_bn254(
-                &result,
-                a,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            result = mul_fp12_bn254(&result, a);
 
             // Reconstruct e
             e_rec |= 1 << i;

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/fp2.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/fp2.rs
@@ -13,21 +13,13 @@ use super::constants::P_MINUS_ONE;
 
 /// Addition in the degree 2 extension of the BN254 curve
 #[inline]
-pub fn add_fp2_bn254(
-    a: &[u64; 8],
-    b: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 8] {
+pub fn add_fp2_bn254(a: &[u64; 8], b: &[u64; 8]) -> [u64; 8] {
     let mut f1 =
         SyscallComplex256 { x: a[0..4].try_into().unwrap(), y: a[4..8].try_into().unwrap() };
     let f2 = SyscallComplex256 { x: b[0..4].try_into().unwrap(), y: b[4..8].try_into().unwrap() };
 
     let mut params = SyscallBn254ComplexAddParams { f1: &mut f1, f2: &f2 };
-    syscall_bn254_complex_add(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_complex_add(&mut params);
     let res_x = params.f1.x;
     let res_y = params.f1.y;
     [res_x[0], res_x[1], res_x[2], res_x[3], res_y[0], res_y[1], res_y[2], res_y[3]]
@@ -35,17 +27,13 @@ pub fn add_fp2_bn254(
 
 /// Doubling in the degree 2 extension of the BN254 curve
 #[inline]
-pub fn dbl_fp2_bn254(a: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 8] {
+pub fn dbl_fp2_bn254(a: &[u64; 8]) -> [u64; 8] {
     let mut f1 =
         SyscallComplex256 { x: a[0..4].try_into().unwrap(), y: a[4..8].try_into().unwrap() };
     let f2 = SyscallComplex256 { x: f1.x, y: f1.y };
 
     let mut params = SyscallBn254ComplexAddParams { f1: &mut f1, f2: &f2 };
-    syscall_bn254_complex_add(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_complex_add(&mut params);
     let res_x = params.f1.x;
     let res_y = params.f1.y;
     [res_x[0], res_x[1], res_x[2], res_x[3], res_y[0], res_y[1], res_y[2], res_y[3]]
@@ -53,17 +41,13 @@ pub fn dbl_fp2_bn254(a: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64
 
 /// Negation in the degree 2 extension of the BN254 curve
 #[inline]
-pub fn neg_fp2_bn254(a: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 8] {
+pub fn neg_fp2_bn254(a: &[u64; 8]) -> [u64; 8] {
     let mut f1 =
         SyscallComplex256 { x: a[0..4].try_into().unwrap(), y: a[4..8].try_into().unwrap() };
     let f2 = SyscallComplex256 { x: P_MINUS_ONE, y: [0u64; 4] };
 
     let mut params = SyscallBn254ComplexMulParams { f1: &mut f1, f2: &f2 };
-    syscall_bn254_complex_mul(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_complex_mul(&mut params);
     let res_x = params.f1.x;
     let res_y = params.f1.y;
     [res_x[0], res_x[1], res_x[2], res_x[3], res_y[0], res_y[1], res_y[2], res_y[3]]
@@ -71,21 +55,13 @@ pub fn neg_fp2_bn254(a: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64
 
 /// Subtraction in the degree 2 extension of the BN254 curve
 #[inline]
-pub fn sub_fp2_bn254(
-    a: &[u64; 8],
-    b: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 8] {
+pub fn sub_fp2_bn254(a: &[u64; 8], b: &[u64; 8]) -> [u64; 8] {
     let mut f1 =
         SyscallComplex256 { x: a[0..4].try_into().unwrap(), y: a[4..8].try_into().unwrap() };
     let f2 = SyscallComplex256 { x: b[0..4].try_into().unwrap(), y: b[4..8].try_into().unwrap() };
 
     let mut params = SyscallBn254ComplexSubParams { f1: &mut f1, f2: &f2 };
-    syscall_bn254_complex_sub(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_complex_sub(&mut params);
     let res_x = params.f1.x;
     let res_y = params.f1.y;
     [res_x[0], res_x[1], res_x[2], res_x[3], res_y[0], res_y[1], res_y[2], res_y[3]]
@@ -93,21 +69,13 @@ pub fn sub_fp2_bn254(
 
 /// Multiplication in the degree 2 extension of the BN254 curve
 #[inline]
-pub fn mul_fp2_bn254(
-    a: &[u64; 8],
-    b: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 8] {
+pub fn mul_fp2_bn254(a: &[u64; 8], b: &[u64; 8]) -> [u64; 8] {
     let mut f1 =
         SyscallComplex256 { x: a[0..4].try_into().unwrap(), y: a[4..8].try_into().unwrap() };
     let f2 = SyscallComplex256 { x: b[0..4].try_into().unwrap(), y: b[4..8].try_into().unwrap() };
 
     let mut params = SyscallBn254ComplexMulParams { f1: &mut f1, f2: &f2 };
-    syscall_bn254_complex_mul(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_complex_mul(&mut params);
     let res_x = params.f1.x;
     let res_y = params.f1.y;
     [res_x[0], res_x[1], res_x[2], res_x[3], res_y[0], res_y[1], res_y[2], res_y[3]]
@@ -115,21 +83,13 @@ pub fn mul_fp2_bn254(
 
 /// Scalar multiplication in the degree 2 extension of the BN254 curve
 #[inline]
-pub fn scalar_mul_fp2_bn254(
-    a: &[u64; 8],
-    b: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 8] {
+pub fn scalar_mul_fp2_bn254(a: &[u64; 8], b: &[u64; 4]) -> [u64; 8] {
     let mut f1 =
         SyscallComplex256 { x: a[0..4].try_into().unwrap(), y: a[4..8].try_into().unwrap() };
     let f2 = SyscallComplex256 { x: b[0..4].try_into().unwrap(), y: [0, 0, 0, 0] };
 
     let mut params = SyscallBn254ComplexMulParams { f1: &mut f1, f2: &f2 };
-    syscall_bn254_complex_mul(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_complex_mul(&mut params);
     let res_x = params.f1.x;
     let res_y = params.f1.y;
     [res_x[0], res_x[1], res_x[2], res_x[3], res_y[0], res_y[1], res_y[2], res_y[3]]
@@ -137,17 +97,13 @@ pub fn scalar_mul_fp2_bn254(
 
 /// Squaring in the degree 2 extension of the BN254 curve
 #[inline]
-pub fn square_fp2_bn254(a: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 8] {
+pub fn square_fp2_bn254(a: &[u64; 8]) -> [u64; 8] {
     let mut f1 =
         SyscallComplex256 { x: a[0..4].try_into().unwrap(), y: a[4..8].try_into().unwrap() };
     let f2 = SyscallComplex256 { x: f1.x, y: f1.y };
 
     let mut params = SyscallBn254ComplexMulParams { f1: &mut f1, f2: &f2 };
-    syscall_bn254_complex_mul(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_complex_mul(&mut params);
     let res_x = params.f1.x;
     let res_y = params.f1.y;
     [res_x[0], res_x[1], res_x[2], res_x[3], res_y[0], res_y[1], res_y[2], res_y[3]]
@@ -155,7 +111,7 @@ pub fn square_fp2_bn254(a: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<
 
 /// Inversion in the degree 2 extension of the BN254 curve
 #[inline]
-pub fn inv_fp2_bn254(a: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 8] {
+pub fn inv_fp2_bn254(a: &[u64; 8]) -> [u64; 8] {
     // if a == 0, return 0
     if eq(a, &[0, 0, 0, 0, 0, 0, 0, 0]) {
         return [0, 0, 0, 0, 0, 0, 0, 0];
@@ -165,22 +121,14 @@ pub fn inv_fp2_bn254(a: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64
 
     // Remember that an element b ∈ Fp2 is the inverse of a ∈ Fp2 if and only if a·b = 1 in Fp2
     // We will therefore hint the inverse b and check the product with a is 1
-    let inv = fcall_bn254_fp2_inv(
-        a,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let inv = fcall_bn254_fp2_inv(a);
 
     let mut f1 =
         SyscallComplex256 { x: a[0..4].try_into().unwrap(), y: a[4..8].try_into().unwrap() };
     let f2 =
         SyscallComplex256 { x: inv[0..4].try_into().unwrap(), y: inv[4..8].try_into().unwrap() };
     let mut params = SyscallBn254ComplexMulParams { f1: &mut f1, f2: &f2 };
-    syscall_bn254_complex_mul(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_complex_mul(&mut params);
     assert_eq!(params.f1.x, [1, 0, 0, 0]);
     assert_eq!(params.f1.y, [0, 0, 0, 0]);
 
@@ -189,19 +137,12 @@ pub fn inv_fp2_bn254(a: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64
 
 /// Conjugation in the degree 2 extension of the BN254 curve
 #[inline]
-pub fn conjugate_fp2_bn254(
-    a: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 8] {
+pub fn conjugate_fp2_bn254(a: &[u64; 8]) -> [u64; 8] {
     let mut f1 = SyscallComplex256 { x: a[0..4].try_into().unwrap(), y: [0, 0, 0, 0] };
     let f2 = SyscallComplex256 { x: [0, 0, 0, 0], y: a[4..8].try_into().unwrap() };
 
     let mut params = SyscallBn254ComplexSubParams { f1: &mut f1, f2: &f2 };
-    syscall_bn254_complex_sub(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_bn254_complex_sub(&mut params);
     let res_x = params.f1.x;
     let res_y = params.f1.y;
     [res_x[0], res_x[1], res_x[2], res_x[3], res_y[0], res_y[1], res_y[2], res_y[3]]

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/fp6.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/fp6.rs
@@ -7,21 +7,12 @@ use super::fp2::{
 
 /// Addition in the degree 6 extension of the BN254 curve
 #[inline]
-pub fn add_fp6_bn254(
-    a: &[u64; 24],
-    b: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn add_fp6_bn254(a: &[u64; 24], b: &[u64; 24]) -> [u64; 24] {
     let mut result = [0; 24];
     for i in 0..3 {
         let a_i = &a[i * 8..(i + 1) * 8].try_into().unwrap();
         let b_i = &b[i * 8..(i + 1) * 8].try_into().unwrap();
-        let c_i = add_fp2_bn254(
-            a_i,
-            b_i,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let c_i = add_fp2_bn254(a_i, b_i);
         result[i * 8..(i + 1) * 8].copy_from_slice(&c_i);
     }
     result
@@ -29,15 +20,11 @@ pub fn add_fp6_bn254(
 
 /// Doubling in the degree 6 extension of the BN254 curve
 #[inline]
-pub fn dbl_fp6_bn254(a: &[u64; 24], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 24] {
+pub fn dbl_fp6_bn254(a: &[u64; 24]) -> [u64; 24] {
     let mut result = [0; 24];
     for i in 0..3 {
         let a_i = &a[i * 8..(i + 1) * 8].try_into().unwrap();
-        let c_i = dbl_fp2_bn254(
-            a_i,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let c_i = dbl_fp2_bn254(a_i);
         result[i * 8..(i + 1) * 8].copy_from_slice(&c_i);
     }
     result
@@ -45,15 +32,11 @@ pub fn dbl_fp6_bn254(a: &[u64; 24], #[cfg(feature = "hints")] hints: &mut Vec<u6
 
 /// Negation in the degree 6 extension of the BN254 curve
 #[inline]
-pub fn neg_fp6_bn254(a: &[u64; 24], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 24] {
+pub fn neg_fp6_bn254(a: &[u64; 24]) -> [u64; 24] {
     let mut result = [0; 24];
     for i in 0..3 {
         let a_i = &a[i * 8..(i + 1) * 8].try_into().unwrap();
-        let c_i = neg_fp2_bn254(
-            a_i,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let c_i = neg_fp2_bn254(a_i);
         result[i * 8..(i + 1) * 8].copy_from_slice(&c_i);
     }
     result
@@ -61,21 +44,12 @@ pub fn neg_fp6_bn254(a: &[u64; 24], #[cfg(feature = "hints")] hints: &mut Vec<u6
 
 /// Subtraction in the degree 6 extension of the BN254 curve
 #[inline]
-pub fn sub_fp6_bn254(
-    a: &[u64; 24],
-    b: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn sub_fp6_bn254(a: &[u64; 24], b: &[u64; 24]) -> [u64; 24] {
     let mut result = [0; 24];
     for i in 0..3 {
         let a_i = &a[i * 8..(i + 1) * 8].try_into().unwrap();
         let b_i = &b[i * 8..(i + 1) * 8].try_into().unwrap();
-        let c_i = sub_fp2_bn254(
-            a_i,
-            b_i,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let c_i = sub_fp2_bn254(a_i, b_i);
         result[i * 8..(i + 1) * 8].copy_from_slice(&c_i);
     }
     result
@@ -89,11 +63,7 @@ pub fn sub_fp6_bn254(
 //      - c2 = (a1+a2)·(b1+b2) - a1·b1 - a2·b2 + a3·b3·(9+u)
 //      - c3 = (a1+a3)·(b1+b3) - a1·b1 + a2·b2 - a3·b3
 #[inline]
-pub fn mul_fp6_bn254(
-    a: &[u64; 24],
-    b: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn mul_fp6_bn254(a: &[u64; 24], b: &[u64; 24]) -> [u64; 24] {
     let a1 = &a[0..8].try_into().unwrap();
     let a2 = &a[8..16].try_into().unwrap();
     let a3 = &a[16..24].try_into().unwrap();
@@ -102,151 +72,36 @@ pub fn mul_fp6_bn254(
     let b3 = &b[16..24].try_into().unwrap();
 
     // a1·b1, a2·b2, a3·b3, a3·b3·(9+u)
-    let a1b1 = mul_fp2_bn254(
-        a1,
-        b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2b2 = mul_fp2_bn254(
-        a2,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a3b3 = mul_fp2_bn254(
-        a3,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a3b3xi = mul_fp2_bn254(
-        &a3b3,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1b1 = mul_fp2_bn254(a1, b1);
+    let a2b2 = mul_fp2_bn254(a2, b2);
+    let a3b3 = mul_fp2_bn254(a3, b3);
+    let a3b3xi = mul_fp2_bn254(&a3b3, &[9, 0, 0, 0, 1, 0, 0, 0]);
 
     // a2+a3, b2+b3, a1+a2, b1+b2, a1+a3, b1+b3
-    let a2_plus_a3 = add_fp2_bn254(
-        a2,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let b2_plus_b3 = add_fp2_bn254(
-        b2,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1_plus_a2 = add_fp2_bn254(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let b1_plus_b2 = add_fp2_bn254(
-        b1,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1_plus_a3 = add_fp2_bn254(
-        a1,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let b1_plus_b3 = add_fp2_bn254(
-        b1,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a2_plus_a3 = add_fp2_bn254(a2, a3);
+    let b2_plus_b3 = add_fp2_bn254(b2, b3);
+    let a1_plus_a2 = add_fp2_bn254(a1, a2);
+    let b1_plus_b2 = add_fp2_bn254(b1, b2);
+    let a1_plus_a3 = add_fp2_bn254(a1, a3);
+    let b1_plus_b3 = add_fp2_bn254(b1, b3);
 
     // c1 = [(a2+a3)·(b2+b3) - a2·b2 - a3·b3]·(9+u) + a1·b1
-    let mut c1 = mul_fp2_bn254(
-        &a2_plus_a3,
-        &b2_plus_b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = sub_fp2_bn254(
-        &c1,
-        &a2b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = sub_fp2_bn254(
-        &c1,
-        &a3b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = mul_fp2_bn254(
-        &c1,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp2_bn254(
-        &c1,
-        &a1b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bn254(&a2_plus_a3, &b2_plus_b3);
+    c1 = sub_fp2_bn254(&c1, &a2b2);
+    c1 = sub_fp2_bn254(&c1, &a3b3);
+    c1 = mul_fp2_bn254(&c1, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    c1 = add_fp2_bn254(&c1, &a1b1);
     // c2 = (a1+a2)·(b1+b2) - a1·b1 - a2·b2 + a3·b3·(9+u)
-    let mut c2 = mul_fp2_bn254(
-        &a1_plus_a2,
-        &b1_plus_b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = sub_fp2_bn254(
-        &c2,
-        &a1b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = sub_fp2_bn254(
-        &c2,
-        &a2b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp2_bn254(
-        &c2,
-        &a3b3xi,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = mul_fp2_bn254(&a1_plus_a2, &b1_plus_b2);
+    c2 = sub_fp2_bn254(&c2, &a1b1);
+    c2 = sub_fp2_bn254(&c2, &a2b2);
+    c2 = add_fp2_bn254(&c2, &a3b3xi);
 
     // c3 = (a1+a3)·(b1+b3) - a1·b1 + a2·b2 - a3·b3
-    let mut c3 = mul_fp2_bn254(
-        &a1_plus_a3,
-        &b1_plus_b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = sub_fp2_bn254(
-        &c3,
-        &a1b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bn254(
-        &c3,
-        &a2b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = sub_fp2_bn254(
-        &c3,
-        &a3b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c3 = mul_fp2_bn254(&a1_plus_a3, &b1_plus_b3);
+    c3 = sub_fp2_bn254(&c3, &a1b1);
+    c3 = add_fp2_bn254(&c3, &a2b2);
+    c3 = sub_fp2_bn254(&c3, &a3b3);
 
     let mut result = [0; 24];
     result[0..8].copy_from_slice(&c1);
@@ -263,43 +118,19 @@ pub fn mul_fp6_bn254(
 //      - c2 = b2·a1
 //      - c3 = b2·a2
 #[inline]
-pub fn sparse_mula_fp6_bn254(
-    a: &[u64; 24],
-    b2: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn sparse_mula_fp6_bn254(a: &[u64; 24], b2: &[u64; 8]) -> [u64; 24] {
     let a1 = &a[0..8].try_into().unwrap();
     let a2 = &a[8..16].try_into().unwrap();
     let a3 = &a[16..24].try_into().unwrap();
 
     // c1 = b2·a3·(9+u)
-    let mut c1 = mul_fp2_bn254(
-        b2,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = mul_fp2_bn254(
-        &c1,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bn254(b2, a3);
+    c1 = mul_fp2_bn254(&c1, &[9, 0, 0, 0, 1, 0, 0, 0]);
 
     // c2 = b2·a1
-    let c2 = mul_fp2_bn254(
-        b2,
-        a1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c2 = mul_fp2_bn254(b2, a1);
     // c3 = b2·a2
-    let c3 = mul_fp2_bn254(
-        b2,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c3 = mul_fp2_bn254(b2, a2);
 
     let mut result = [0; 24];
     result[0..8].copy_from_slice(&c1);
@@ -316,11 +147,7 @@ pub fn sparse_mula_fp6_bn254(
 //      - c2 = a1·b2 + a2·b1
 //      - c3 = a2·b2 + a3·b1
 #[inline]
-pub fn sparse_mulb_fp6_bn254(
-    a: &[u64; 24],
-    b: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn sparse_mulb_fp6_bn254(a: &[u64; 24], b: &[u64; 16]) -> [u64; 24] {
     let a1 = &a[0..8].try_into().unwrap();
     let a2 = &a[8..16].try_into().unwrap();
     let a3 = &a[16..24].try_into().unwrap();
@@ -328,66 +155,16 @@ pub fn sparse_mulb_fp6_bn254(
     let b2 = &b[8..16].try_into().unwrap();
 
     // c1 = a1·b1 + a3·b2·(9+u)
-    let mut c1 = mul_fp2_bn254(
-        a1,
-        b1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp2_bn254(
-        &c1,
-        &mul_fp2_bn254(
-            a3,
-            &mul_fp2_bn254(
-                b2,
-                &[9, 0, 0, 0, 1, 0, 0, 0],
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bn254(a1, b1);
+    c1 = add_fp2_bn254(&c1, &mul_fp2_bn254(a3, &mul_fp2_bn254(b2, &[9, 0, 0, 0, 1, 0, 0, 0])));
 
     // c2 = a1·b2 + a2·b1
-    let mut c2 = mul_fp2_bn254(
-        a1,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp2_bn254(
-        &c2,
-        &mul_fp2_bn254(
-            a2,
-            b1,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = mul_fp2_bn254(a1, b2);
+    c2 = add_fp2_bn254(&c2, &mul_fp2_bn254(a2, b1));
 
     // c3 = a2·b2 + a3·b1
-    let mut c3 = mul_fp2_bn254(
-        a2,
-        b2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bn254(
-        &c3,
-        &mul_fp2_bn254(
-            a3,
-            b1,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c3 = mul_fp2_bn254(a2, b2);
+    c3 = add_fp2_bn254(&c3, &mul_fp2_bn254(a3, b1));
 
     let mut result = [0; 24];
     result[0..8].copy_from_slice(&c1);
@@ -404,11 +181,7 @@ pub fn sparse_mulb_fp6_bn254(
 //      - c2 = a1·b2 + a3·b3·(9+u)
 //      - c3 = a1·b3 + a2·b2
 #[inline]
-pub fn sparse_mulc_fp6_bn254(
-    a: &[u64; 24],
-    b: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn sparse_mulc_fp6_bn254(a: &[u64; 24], b: &[u64; 16]) -> [u64; 24] {
     let a1 = &a[0..8].try_into().unwrap();
     let a2 = &a[8..16].try_into().unwrap();
     let a3 = &a[16..24].try_into().unwrap();
@@ -416,73 +189,18 @@ pub fn sparse_mulc_fp6_bn254(
     let b3 = &b[8..16].try_into().unwrap();
 
     // c1 = (a2·b3 + a3·b2)·(9+u)
-    let mut c1 = mul_fp2_bn254(
-        a2,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp2_bn254(
-        &c1,
-        &mul_fp2_bn254(
-            a3,
-            b2,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = mul_fp2_bn254(
-        &c1,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bn254(a2, b3);
+    c1 = add_fp2_bn254(&c1, &mul_fp2_bn254(a3, b2));
+    c1 = mul_fp2_bn254(&c1, &[9, 0, 0, 0, 1, 0, 0, 0]);
 
     // c2 = a1·b2 + a3·b3·(9+u)
-    let mut c2 = mul_fp2_bn254(
-        a3,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = mul_fp2_bn254(
-        &c2,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp2_bn254(
-        &c2,
-        &mul_fp2_bn254(
-            a1,
-            b2,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = mul_fp2_bn254(a3, b3);
+    c2 = mul_fp2_bn254(&c2, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    c2 = add_fp2_bn254(&c2, &mul_fp2_bn254(a1, b2));
 
     // c3 = a2·b3 + a2·b2
-    let mut c3 = mul_fp2_bn254(
-        a1,
-        b3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bn254(
-        &c3,
-        &mul_fp2_bn254(
-            a2,
-            b2,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c3 = mul_fp2_bn254(a1, b3);
+    c3 = add_fp2_bn254(&c3, &mul_fp2_bn254(a2, b2));
 
     let mut result = [0; 24];
     result[0..8].copy_from_slice(&c1);
@@ -499,119 +217,36 @@ pub fn sparse_mulc_fp6_bn254(
 //      - c2 = a3²·(9 + u) + 2·a1·a2
 //      - c3 = 2·a1·a2 - a3² + (a1 - a2 + a3)² + 2·a2·a3 - a1²
 #[inline]
-pub fn square_fp6_bn254(
-    a: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 24] {
+pub fn square_fp6_bn254(a: &[u64; 24]) -> [u64; 24] {
     let a1 = &a[0..8].try_into().unwrap();
     let a2 = &a[8..16].try_into().unwrap();
     let a3 = &a[16..24].try_into().unwrap();
 
-    let mut two_a1a2 = mul_fp2_bn254(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    two_a1a2 = dbl_fp2_bn254(
-        &two_a1a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut two_a1a2 = mul_fp2_bn254(a1, a2);
+    two_a1a2 = dbl_fp2_bn254(&two_a1a2);
 
-    let a3_squared = square_fp2_bn254(
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a3_squared = square_fp2_bn254(a3);
 
     // c2 = a3²·(9 + u) + 2·a1·a2
-    let mut c2 = mul_fp2_bn254(
-        &a3_squared,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2 = add_fp2_bn254(
-        &c2,
-        &two_a1a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2 = mul_fp2_bn254(&a3_squared, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    c2 = add_fp2_bn254(&c2, &two_a1a2);
 
     // a1², (a1 - a2 + a3)², 2·a2·a3
-    let a1_squared = square_fp2_bn254(
-        a1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut a1a2a3 = sub_fp2_bn254(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    a1a2a3 = add_fp2_bn254(
-        &a1a2a3,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    a1a2a3 = square_fp2_bn254(
-        &a1a2a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut two_a2a3 = mul_fp2_bn254(
-        a2,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    two_a2a3 = dbl_fp2_bn254(
-        &two_a2a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_squared = square_fp2_bn254(a1);
+    let mut a1a2a3 = sub_fp2_bn254(a1, a2);
+    a1a2a3 = add_fp2_bn254(&a1a2a3, a3);
+    a1a2a3 = square_fp2_bn254(&a1a2a3);
+    let mut two_a2a3 = mul_fp2_bn254(a2, a3);
+    two_a2a3 = dbl_fp2_bn254(&two_a2a3);
 
     // c1 = 2·a2·a3·(9 + u) + a1²
-    let mut c1 = mul_fp2_bn254(
-        &two_a2a3,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1 = add_fp2_bn254(
-        &c1,
-        &a1_squared,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1 = mul_fp2_bn254(&two_a2a3, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    c1 = add_fp2_bn254(&c1, &a1_squared);
     // c3 = 2·a1·a2 - a3² + (a1 - a2 + a3)² + 2·a2·a3 - a1²
-    let mut c3 = sub_fp2_bn254(
-        &two_a1a2,
-        &a3_squared,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bn254(
-        &c3,
-        &a1a2a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = add_fp2_bn254(
-        &c3,
-        &two_a2a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c3 = sub_fp2_bn254(
-        &c3,
-        &a1_squared,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c3 = sub_fp2_bn254(&two_a1a2, &a3_squared);
+    c3 = add_fp2_bn254(&c3, &a1a2a3);
+    c3 = add_fp2_bn254(&c3, &two_a2a3);
+    c3 = sub_fp2_bn254(&c3, &a1_squared);
 
     let mut result = [0; 24];
     result[0..8].copy_from_slice(&c1);
@@ -632,144 +267,43 @@ pub fn square_fp6_bn254(
 //      * c2mid = (9 + u)·a3² - (a1·a2)
 //      * c3mid = a2² - (a1·a3)
 #[inline]
-pub fn inv_fp6_bn254(a: &[u64; 24], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 24] {
+pub fn inv_fp6_bn254(a: &[u64; 24]) -> [u64; 24] {
     let a1 = &a[0..8].try_into().unwrap();
     let a2 = &a[8..16].try_into().unwrap();
     let a3 = &a[16..24].try_into().unwrap();
 
-    let a1_squared = square_fp2_bn254(
-        a1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2_squared = square_fp2_bn254(
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a3_squared = square_fp2_bn254(
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1_squared = square_fp2_bn254(a1);
+    let a2_squared = square_fp2_bn254(a2);
+    let a3_squared = square_fp2_bn254(a3);
 
-    let a1a2 = mul_fp2_bn254(
-        a1,
-        a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a1a3 = mul_fp2_bn254(
-        a1,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let a2a3 = mul_fp2_bn254(
-        a2,
-        a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let a1a2 = mul_fp2_bn254(a1, a2);
+    let a1a3 = mul_fp2_bn254(a1, a3);
+    let a2a3 = mul_fp2_bn254(a2, a3);
 
     // c1mid = a1² - (9 + u)·(a2·a3)
-    let mut c1mid = mul_fp2_bn254(
-        &a2a3,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c1mid = sub_fp2_bn254(
-        &a1_squared,
-        &c1mid,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c1mid = mul_fp2_bn254(&a2a3, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    c1mid = sub_fp2_bn254(&a1_squared, &c1mid);
 
     // c2mid = (9 + u)·a3² - (a1·a2)
-    let mut c2mid = mul_fp2_bn254(
-        &a3_squared,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    c2mid = sub_fp2_bn254(
-        &c2mid,
-        &a1a2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut c2mid = mul_fp2_bn254(&a3_squared, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    c2mid = sub_fp2_bn254(&c2mid, &a1a2);
     // c3mid = a2² - (a1·a3)
-    let c3mid = sub_fp2_bn254(
-        &a2_squared,
-        &a1a3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c3mid = sub_fp2_bn254(&a2_squared, &a1a3);
 
     // im = a1·c1mid
-    let im = mul_fp2_bn254(
-        a1,
-        &c1mid,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let im = mul_fp2_bn254(a1, &c1mid);
 
     // last = (im + (9 + u)·(a3·c2mid + a2·c3mid))⁻¹
-    let mut last = mul_fp2_bn254(
-        a3,
-        &c2mid,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    last = add_fp2_bn254(
-        &last,
-        &mul_fp2_bn254(
-            a2,
-            &c3mid,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    last = mul_fp2_bn254(
-        &last,
-        &[9, 0, 0, 0, 1, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    last = add_fp2_bn254(
-        &last,
-        &im,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    last = inv_fp2_bn254(
-        &last,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut last = mul_fp2_bn254(a3, &c2mid);
+    last = add_fp2_bn254(&last, &mul_fp2_bn254(a2, &c3mid));
+    last = mul_fp2_bn254(&last, &[9, 0, 0, 0, 1, 0, 0, 0]);
+    last = add_fp2_bn254(&last, &im);
+    last = inv_fp2_bn254(&last);
 
     // c1 = c1mid·last, c2 = c2mid·last, c3 = c3mid·last
-    let c1 = mul_fp2_bn254(
-        &c1mid,
-        &last,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let c2 = mul_fp2_bn254(
-        &c2mid,
-        &last,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let c3 = mul_fp2_bn254(
-        &c3mid,
-        &last,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let c1 = mul_fp2_bn254(&c1mid, &last);
+    let c2 = mul_fp2_bn254(&c2mid, &last);
+    let c3 = mul_fp2_bn254(&c3mid, &last);
 
     let mut result = [0; 24];
     result[0..8].copy_from_slice(&c1);

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/fr.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/fr.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::constants::R;
 
-pub fn reduce_fr_bn254(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 4] {
+pub fn reduce_fr_bn254(x: &[u64; 4]) -> [u64; 4] {
     if lt(x, &R) {
         return *x;
     }
@@ -18,11 +18,7 @@ pub fn reduce_fr_bn254(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u
         module: &R,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     *params.d
 }

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/miller_loop.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/miller_loop.rs
@@ -21,30 +21,13 @@ const LOOP_LENGTH: [i8; 65] = [
 ];
 
 /// Computes the Miller loop of a non-zero point `p` in G1 and a non-zero point `q` in G2
-pub fn miller_loop_bn254(
-    p: &[u64; 8],
-    q: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn miller_loop_bn254(p: &[u64; 8], q: &[u64; 16]) -> [u64; 48] {
     // Before the loop starts, compute xp' = -xp/yp and yp' = 1/yp
     let mut xp_prime: [u64; 4] = p[0..4].try_into().unwrap();
     let mut yp_prime: [u64; 4] = p[4..8].try_into().unwrap();
-    yp_prime = inv_fp_bn254(
-        &yp_prime,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    xp_prime = neg_fp_bn254(
-        &xp_prime,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    xp_prime = mul_fp_bn254(
-        &xp_prime,
-        &yp_prime,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    yp_prime = inv_fp_bn254(&yp_prime);
+    xp_prime = neg_fp_bn254(&xp_prime);
+    xp_prime = mul_fp_bn254(&xp_prime, &yp_prime);
 
     // Initialize the Miller loop with r = q and f = 1
     let mut r: [u64; 16] = q[0..16].try_into().unwrap();
@@ -52,231 +35,76 @@ pub fn miller_loop_bn254(
     f[0] = 1;
     for &bit in LOOP_LENGTH.iter().skip(1) {
         // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(r)}
-        let (lambda, mu) = fcall_bn254_twist_dbl_line_coeffs(
-            &r,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let (lambda, mu) = fcall_bn254_twist_dbl_line_coeffs(&r);
 
         // Check that the line is correct
-        assert!(is_tangent_twist_bn254(
-            &r,
-            &lambda,
-            &mu,
-            #[cfg(feature = "hints")]
-            hints,
-        ));
+        assert!(is_tangent_twist_bn254(&r, &lambda, &mu,));
 
         // Compute f = f² · line_{twist(r),twist(r)}(p)
-        f = square_fp12_bn254(
-            &f,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let l = line_eval_twist_bn254(
-            &lambda,
-            &mu,
-            &xp_prime,
-            &yp_prime,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        f = sparse_mul_fp12_bn254(
-            &f,
-            &l,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        f = square_fp12_bn254(&f);
+        let l = line_eval_twist_bn254(&lambda, &mu, &xp_prime, &yp_prime);
+        f = sparse_mul_fp12_bn254(&f, &l);
 
         // Double r
-        r = dbl_twist_with_hints_bn254(
-            &r,
-            &lambda,
-            &mu,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        r = dbl_twist_with_hints_bn254(&r, &lambda, &mu);
 
         if bit * bit == 1 {
-            let q_prime = if bit == 1 {
-                q
-            } else {
-                &neg_twist_bn254(
-                    q,
-                    #[cfg(feature = "hints")]
-                    hints,
-                )
-            };
+            let q_prime = if bit == 1 { q } else { &neg_twist_bn254(q) };
 
             // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(q')}
-            let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(
-                &r,
-                q_prime,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(&r, q_prime);
 
             // Check that the line is correct
-            assert!(is_line_twist_bn254(
-                &r,
-                q_prime,
-                &lambda,
-                &mu,
-                #[cfg(feature = "hints")]
-                hints,
-            ));
+            assert!(is_line_twist_bn254(&r, q_prime, &lambda, &mu,));
 
             // Compute f = f · line_{twist(r),twist(q')}
-            let l = line_eval_twist_bn254(
-                &lambda,
-                &mu,
-                &xp_prime,
-                &yp_prime,
-                #[cfg(feature = "hints")]
-                hints,
-            );
-            f = sparse_mul_fp12_bn254(
-                &f,
-                &l,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let l = line_eval_twist_bn254(&lambda, &mu, &xp_prime, &yp_prime);
+            f = sparse_mul_fp12_bn254(&f, &l);
 
             // Add r and q'
-            r = add_twist_with_hints_bn254(
-                &r,
-                q_prime,
-                &lambda,
-                &mu,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            r = add_twist_with_hints_bn254(&r, q_prime, &lambda, &mu);
         }
     }
 
     // Compute the last two lines
 
     // f = f · line_{twist(r),twist(utf(q))}(p)
-    let q_frob = utf_endomorphism_twist_bn254(
-        q,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let q_frob = utf_endomorphism_twist_bn254(q);
 
     // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(utf(q))}
-    let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(
-        &r,
-        &q_frob,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    assert!(is_line_twist_bn254(
-        &r,
-        &q_frob,
-        &lambda,
-        &mu,
-        #[cfg(feature = "hints")]
-        hints,
-    ));
+    let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(&r, &q_frob);
+    assert!(is_line_twist_bn254(&r, &q_frob, &lambda, &mu,));
 
-    let l = line_eval_twist_bn254(
-        &lambda,
-        &mu,
-        &xp_prime,
-        &yp_prime,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    f = sparse_mul_fp12_bn254(
-        &f,
-        &l,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let l = line_eval_twist_bn254(&lambda, &mu, &xp_prime, &yp_prime);
+    f = sparse_mul_fp12_bn254(&f, &l);
 
     // Update r by r + utf(q)
-    r = add_twist_with_hints_bn254(
-        &r,
-        &q_frob,
-        &lambda,
-        &mu,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    r = add_twist_with_hints_bn254(&r, &q_frob, &lambda, &mu);
 
     // f = f · line_{twist(r),twist(-utf(utf(q)))}(p)
-    let q_frob2 = neg_twist_bn254(
-        &utf_endomorphism_twist_bn254(
-            &q_frob,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let q_frob2 = neg_twist_bn254(&utf_endomorphism_twist_bn254(&q_frob));
 
     // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(-utf(utf(q)))}
-    let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(
-        &r,
-        &q_frob2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    assert!(is_line_twist_bn254(
-        &r,
-        &q_frob2,
-        &lambda,
-        &mu,
-        #[cfg(feature = "hints")]
-        hints
-    ));
+    let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(&r, &q_frob2);
+    assert!(is_line_twist_bn254(&r, &q_frob2, &lambda, &mu,));
 
-    let l = line_eval_twist_bn254(
-        &lambda,
-        &mu,
-        &xp_prime,
-        &yp_prime,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    f = sparse_mul_fp12_bn254(
-        &f,
-        &l,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let l = line_eval_twist_bn254(&lambda, &mu, &xp_prime, &yp_prime);
+    f = sparse_mul_fp12_bn254(&f, &l);
 
     f
 }
 
 /// Computes the Miller loop for the BN254 curve for a batch of non-zero points `p_i` in G1 and non-zero points `q_i` in G2
-pub fn miller_loop_batch_bn254(
-    g1_points: &[[u64; 8]],
-    g2_points: &[[u64; 16]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn miller_loop_batch_bn254(g1_points: &[[u64; 8]], g2_points: &[[u64; 16]]) -> [u64; 48] {
     // Before the loop starts, compute xp' = -xp/yp and yp' = 1/yp for each point p
     let mut xp_primes: Vec<[u64; 4]> = Vec::with_capacity(g1_points.len());
     let mut yp_primes: Vec<[u64; 4]> = Vec::with_capacity(g1_points.len());
     for p in g1_points.iter() {
         let mut xp_prime: [u64; 4] = p[0..4].try_into().unwrap();
         let mut yp_prime: [u64; 4] = p[4..8].try_into().unwrap();
-        yp_prime = inv_fp_bn254(
-            &yp_prime,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        xp_prime = neg_fp_bn254(
-            &xp_prime,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        xp_prime = mul_fp_bn254(
-            &xp_prime,
-            &yp_prime,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        yp_prime = inv_fp_bn254(&yp_prime);
+        xp_prime = neg_fp_bn254(&xp_prime);
+        xp_prime = mul_fp_bn254(&xp_prime, &yp_prime);
 
         xp_primes.push(xp_prime);
         yp_primes.push(yp_prime);
@@ -289,112 +117,41 @@ pub fn miller_loop_batch_bn254(
     let n = g1_points.len();
     for &bit in LOOP_LENGTH.iter().skip(1) {
         // Compute f = f² · line_{twist(r),twist(r)}(p)
-        f = square_fp12_bn254(
-            &f,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        f = square_fp12_bn254(&f);
 
         for i in 0..n {
             let r = &mut r[i];
 
             // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(r)}
-            let (lambda, mu) = fcall_bn254_twist_dbl_line_coeffs(
-                r,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let (lambda, mu) = fcall_bn254_twist_dbl_line_coeffs(r);
 
             // Check that the line is correct
-            assert!(is_tangent_twist_bn254(
-                r,
-                &lambda,
-                &mu,
-                #[cfg(feature = "hints")]
-                hints,
-            ));
+            assert!(is_tangent_twist_bn254(r, &lambda, &mu,));
 
             let xp_prime = &xp_primes[i];
             let yp_prime = &yp_primes[i];
-            let l = line_eval_twist_bn254(
-                &lambda,
-                &mu,
-                xp_prime,
-                yp_prime,
-                #[cfg(feature = "hints")]
-                hints,
-            );
-            f = sparse_mul_fp12_bn254(
-                &f,
-                &l,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            let l = line_eval_twist_bn254(&lambda, &mu, xp_prime, yp_prime);
+            f = sparse_mul_fp12_bn254(&f, &l);
 
             // Double r
-            *r = dbl_twist_with_hints_bn254(
-                r,
-                &lambda,
-                &mu,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            *r = dbl_twist_with_hints_bn254(r, &lambda, &mu);
 
             if bit * bit == 1 {
                 let q = &g2_points[i];
-                let q_prime = if bit == 1 {
-                    q
-                } else {
-                    &neg_twist_bn254(
-                        q,
-                        #[cfg(feature = "hints")]
-                        hints,
-                    )
-                };
+                let q_prime = if bit == 1 { q } else { &neg_twist_bn254(q) };
 
                 // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(q')}
-                let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(
-                    r,
-                    q_prime,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(r, q_prime);
 
                 // Check that the line is correct
-                assert!(is_line_twist_bn254(
-                    r,
-                    q_prime,
-                    &lambda,
-                    &mu,
-                    #[cfg(feature = "hints")]
-                    hints,
-                ));
+                assert!(is_line_twist_bn254(r, q_prime, &lambda, &mu,));
 
                 // Compute f = f · line_{twist(r),twist(q')}
-                let l = line_eval_twist_bn254(
-                    &lambda,
-                    &mu,
-                    xp_prime,
-                    yp_prime,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
-                f = sparse_mul_fp12_bn254(
-                    &f,
-                    &l,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                let l = line_eval_twist_bn254(&lambda, &mu, xp_prime, yp_prime);
+                f = sparse_mul_fp12_bn254(&f, &l);
 
                 // Add r and q'
-                *r = add_twist_with_hints_bn254(
-                    r,
-                    q_prime,
-                    &lambda,
-                    &mu,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                *r = add_twist_with_hints_bn254(r, q_prime, &lambda, &mu);
             }
         }
     }
@@ -407,93 +164,26 @@ pub fn miller_loop_batch_bn254(
         let yp_prime = &yp_primes[i];
 
         // f = f · line_{twist(r),twist(utf(q))}(p)
-        let q_frob = utf_endomorphism_twist_bn254(
-            q,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let q_frob = utf_endomorphism_twist_bn254(q);
 
         // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(utf(q))}
-        let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(
-            r,
-            &q_frob,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        assert!(is_line_twist_bn254(
-            r,
-            &q_frob,
-            &lambda,
-            &mu,
-            #[cfg(feature = "hints")]
-            hints,
-        ));
+        let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(r, &q_frob);
+        assert!(is_line_twist_bn254(r, &q_frob, &lambda, &mu,));
 
-        let l = line_eval_twist_bn254(
-            &lambda,
-            &mu,
-            xp_prime,
-            yp_prime,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        f = sparse_mul_fp12_bn254(
-            &f,
-            &l,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let l = line_eval_twist_bn254(&lambda, &mu, xp_prime, yp_prime);
+        f = sparse_mul_fp12_bn254(&f, &l);
 
         // Update r by r + utf(q)
-        *r = add_twist_with_hints_bn254(
-            r,
-            &q_frob,
-            &lambda,
-            &mu,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        *r = add_twist_with_hints_bn254(r, &q_frob, &lambda, &mu);
         // f = f · line_{twist(r),twist(-utf(utf(q)))}(p)
-        let q_frob2 = neg_twist_bn254(
-            &utf_endomorphism_twist_bn254(
-                &q_frob,
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let q_frob2 = neg_twist_bn254(&utf_endomorphism_twist_bn254(&q_frob));
 
         // Hint the coefficients (𝜆,𝜇) of the line l_{twist(r),twist(-utf(utf(q)))}
-        let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(
-            r,
-            &q_frob2,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        assert!(is_line_twist_bn254(
-            r,
-            &q_frob2,
-            &lambda,
-            &mu,
-            #[cfg(feature = "hints")]
-            hints,
-        ));
+        let (lambda, mu) = fcall_bn254_twist_add_line_coeffs(r, &q_frob2);
+        assert!(is_line_twist_bn254(r, &q_frob2, &lambda, &mu,));
 
-        let l = line_eval_twist_bn254(
-            &lambda,
-            &mu,
-            xp_prime,
-            yp_prime,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        f = sparse_mul_fp12_bn254(
-            &f,
-            &l,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let l = line_eval_twist_bn254(&lambda, &mu, xp_prime, yp_prime);
+        f = sparse_mul_fp12_bn254(&f, &l);
     }
 
     f
@@ -511,103 +201,41 @@ pub fn miller_loop_batch_bn254(
 
 /// Checks if the line defined by (𝜆,𝜇) passes through non-zero points `q1,q2` in G2
 #[inline]
-fn is_line_twist_bn254(
-    q1: &[u64; 16],
-    q2: &[u64; 16],
-    lambda: &[u64; 8],
-    mu: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+fn is_line_twist_bn254(q1: &[u64; 16], q2: &[u64; 16], lambda: &[u64; 8], mu: &[u64; 8]) -> bool {
     // Check if the line passes through q1
-    let check_q1 = line_check_twist_bn254(
-        q1,
-        lambda,
-        mu,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let check_q1 = line_check_twist_bn254(q1, lambda, mu);
     // Check if the line passes through q2
-    let check_q2 = line_check_twist_bn254(
-        q2,
-        lambda,
-        mu,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let check_q2 = line_check_twist_bn254(q2, lambda, mu);
     check_q1 && check_q2
 }
 
 /// Checks if the line defined by (𝜆,𝜇) is tangent to the curve at non-zero point `q` in G2
 #[inline]
-fn is_tangent_twist_bn254(
-    q: &[u64; 16],
-    lambda: &[u64; 8],
-    mu: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+fn is_tangent_twist_bn254(q: &[u64; 16], lambda: &[u64; 8], mu: &[u64; 8]) -> bool {
     // Check if the line is tangent to the curve at q
 
     // Check if the line passes through q
-    let check_q = line_check_twist_bn254(
-        q,
-        lambda,
-        mu,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let check_q = line_check_twist_bn254(q, lambda, mu);
     // Check that 2𝜆y = 3x²
     let x: &[u64; 8] = q[0..8].try_into().unwrap();
     let y: &[u64; 8] = q[8..16].try_into().unwrap();
-    let mut lhs = mul_fp2_bn254(
-        lambda,
-        y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lhs = dbl_fp2_bn254(
-        &lhs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut lhs = mul_fp2_bn254(lambda, y);
+    lhs = dbl_fp2_bn254(&lhs);
 
-    let mut rhs = square_fp2_bn254(
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = scalar_mul_fp2_bn254(
-        &rhs,
-        &[3, 0, 0, 0],
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut rhs = square_fp2_bn254(x);
+    rhs = scalar_mul_fp2_bn254(&rhs, &[3, 0, 0, 0]);
     check_q && eq(&lhs, &rhs)
 }
 
 /// Check if the line defined by (𝜆,𝜇) passes through non-zero point `q` in G2
 #[inline]
-fn line_check_twist_bn254(
-    q: &[u64; 16],
-    lambda: &[u64; 8],
-    mu: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+fn line_check_twist_bn254(q: &[u64; 16], lambda: &[u64; 8], mu: &[u64; 8]) -> bool {
     let x: &[u64; 8] = q[0..8].try_into().unwrap();
     let y: &[u64; 8] = q[8..16].try_into().unwrap();
 
     // Check if y = λx + μ
-    let mut rhs = mul_fp2_bn254(
-        lambda,
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = add_fp2_bn254(
-        &rhs,
-        mu,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut rhs = mul_fp2_bn254(lambda, x);
+    rhs = add_fp2_bn254(&rhs, mu);
     eq(&rhs, y)
 }
 
@@ -618,24 +246,9 @@ fn line_eval_twist_bn254(
     mu: &[u64; 8],
     x: &[u64; 4],
     y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 16] {
-    let coeff1 = scalar_mul_fp2_bn254(
-        lambda,
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let coeff2 = scalar_mul_fp2_bn254(
-        mu,
-        &neg_fp_bn254(
-            y,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let coeff1 = scalar_mul_fp2_bn254(lambda, x);
+    let coeff2 = scalar_mul_fp2_bn254(mu, &neg_fp_bn254(y));
 
     let mut result = [0; 16];
     result[0..8].copy_from_slice(&coeff1);
@@ -651,48 +264,19 @@ fn add_twist_with_hints_bn254(
     q2: &[u64; 16],
     lambda: &[u64; 8],
     mu: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> [u64; 16] {
     let x1: &[u64; 8] = q1[0..8].try_into().unwrap();
     let x2: &[u64; 8] = q2[0..8].try_into().unwrap();
 
     // Compute x3 = λ² - x1 - x2
-    let mut x3 = square_fp2_bn254(
-        lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bn254(
-        &x3,
-        x1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bn254(
-        &x3,
-        x2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut x3 = square_fp2_bn254(lambda);
+    x3 = sub_fp2_bn254(&x3, x1);
+    x3 = sub_fp2_bn254(&x3, x2);
 
     // Compute y3 = -λx3 - μ
-    let mut y3 = mul_fp2_bn254(
-        lambda,
-        &x3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = add_fp2_bn254(
-        mu,
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = neg_fp2_bn254(
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y3 = mul_fp2_bn254(lambda, &x3);
+    y3 = add_fp2_bn254(mu, &y3);
+    y3 = neg_fp2_bn254(&y3);
 
     [
         x3[0], x3[1], x3[2], x3[3], x3[4], x3[5], x3[6], x3[7], y3[0], y3[1], y3[2], y3[3], y3[4],
@@ -702,49 +286,17 @@ fn add_twist_with_hints_bn254(
 
 /// Doubling of a non-zero point `q` in G2 with hinted line coefficients (𝜆,𝜇)
 #[inline]
-fn dbl_twist_with_hints_bn254(
-    q: &[u64; 16],
-    lambda: &[u64; 8],
-    mu: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 16] {
+fn dbl_twist_with_hints_bn254(q: &[u64; 16], lambda: &[u64; 8], mu: &[u64; 8]) -> [u64; 16] {
     let x: &[u64; 8] = q[0..8].try_into().unwrap();
 
     // Compute x3 = λ² - 2x
-    let mut x3 = square_fp2_bn254(
-        lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bn254(
-        &x3,
-        &dbl_fp2_bn254(
-            x,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut x3 = square_fp2_bn254(lambda);
+    x3 = sub_fp2_bn254(&x3, &dbl_fp2_bn254(x));
 
     // Compute y3 = -λx3 - μ
-    let mut y3 = mul_fp2_bn254(
-        lambda,
-        &x3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = add_fp2_bn254(
-        mu,
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = neg_fp2_bn254(
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y3 = mul_fp2_bn254(lambda, &x3);
+    y3 = add_fp2_bn254(mu, &y3);
+    y3 = neg_fp2_bn254(&y3);
 
     [
         x3[0], x3[1], x3[2], x3[3], x3[4], x3[5], x3[6], x3[7], y3[0], y3[1], y3[2], y3[3], y3[4],

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/pairing.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/pairing.rs
@@ -26,11 +26,7 @@ const PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP: u8 = 6;
 ///          input: P ∈ G1 and Q ∈ G2
 ///          output: e(P,Q) ∈ GT
 ///
-pub fn pairing_bn254(
-    p: &[u64; 8],
-    q: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn pairing_bn254(p: &[u64; 8], q: &[u64; 16]) -> [u64; 48] {
     // Is p = 𝒪?
     if *p == G1_IDENTITY || *q == G2_IDENTITY {
         // e(P, 𝒪) = e(𝒪, Q) = 1;
@@ -40,29 +36,16 @@ pub fn pairing_bn254(
     }
 
     // Miller loop
-    let miller_loop = miller_loop_bn254(
-        p,
-        q,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let miller_loop = miller_loop_bn254(p, q);
 
     // Final exponentiation
-    final_exp_bn254(
-        &miller_loop,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    final_exp_bn254(&miller_loop)
 }
 
 /// Computes the optimal Ate pairing for a batch of G1 and G2 points over the BN254 curve
 /// and multiplies the results together, i.e.:
 ///     e(P₁, Q₁) · e(P₂, Q₂) · ... · e(Pₙ, Qₙ) ∈ GT
-pub fn pairing_batch_bn254(
-    g1_points: &[[u64; 8]],
-    g2_points: &[[u64; 16]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 48] {
+pub fn pairing_batch_bn254(g1_points: &[[u64; 8]], g2_points: &[[u64; 16]]) -> [u64; 48] {
     // Since each e(Pi, Qi) := FinalExp(MillerLoop(Pi, Qi))
     // We have:
     //  e(P₁, Q₁) · e(P₂, Q₂) · ... · e(Pₙ, Qₙ) = FinalExp(MillerLoop(P₁, Q₁) · MillerLoop(P₂, Q₂) · ... · MillerLoop(Pₙ, Qₙ))
@@ -94,19 +77,10 @@ pub fn pairing_batch_bn254(
     }
 
     // Compute the Miller loop for the batch
-    let miller_loop = miller_loop_batch_bn254(
-        &g1_points_ml,
-        &g2_points_ml,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let miller_loop = miller_loop_batch_bn254(&g1_points_ml, &g2_points_ml);
 
     // Final exponentiation
-    final_exp_bn254(
-        &miller_loop,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    final_exp_bn254(&miller_loop)
 }
 
 /// BN254 pairing check with validation.
@@ -125,11 +99,7 @@ pub fn pairing_batch_bn254(
 /// * `Err(PAIRING_CHECK_ERR_G2_NOT_IN_FIELD)` - G2 field element not canonical (>= P)
 /// * `Err(PAIRING_CHECK_ERR_G2_NOT_ON_CURVE)` - G2 point not on twist curve
 /// * `Err(PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP)` - G2 point not in subgroup
-pub fn pairing_check_bn254(
-    g1_points: &[[u64; 8]],
-    g2_points: &[[u64; 16]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<bool, u8> {
+pub fn pairing_check_bn254(g1_points: &[[u64; 8]], g2_points: &[[u64; 16]]) -> Result<bool, u8> {
     assert_eq!(g1_points.len(), g2_points.len(), "Number of G1 and G2 points must be equal");
 
     // Collect valid pairs
@@ -141,31 +111,17 @@ pub fn pairing_check_bn254(
 
         // If p = 𝒪 or q = 𝒪 => MillerLoop(P, 𝒪) = MillerLoop(𝒪, Q) = 1; we can skip
         if g2_is_inf {
-            if !g1_is_inf
-                && !is_on_curve_bn254(
-                    g1,
-                    #[cfg(feature = "hints")]
-                    hints,
-                )
-            {
+            if !g1_is_inf && !is_on_curve_bn254(g1) {
                 return Err(PAIRING_CHECK_ERR_G1_NOT_ON_CURVE);
             }
             continue;
         }
 
         if g1_is_inf {
-            if !is_on_curve_twist_bn254(
-                g2,
-                #[cfg(feature = "hints")]
-                hints,
-            ) {
+            if !is_on_curve_twist_bn254(g2) {
                 return Err(PAIRING_CHECK_ERR_G2_NOT_ON_CURVE);
             }
-            if !is_on_subgroup_twist_bn254(
-                g2,
-                #[cfg(feature = "hints")]
-                hints,
-            ) {
+            if !is_on_subgroup_twist_bn254(g2) {
                 return Err(PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP);
             }
             continue;
@@ -179,11 +135,7 @@ pub fn pairing_check_bn254(
         }
 
         // Verify G1 point is on curve
-        if !is_on_curve_bn254(
-            g1,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_bn254(g1) {
             return Err(PAIRING_CHECK_ERR_G1_NOT_ON_CURVE);
         }
 
@@ -197,20 +149,12 @@ pub fn pairing_check_bn254(
         }
 
         // Verify G2 point is on twist curve
-        if !is_on_curve_twist_bn254(
-            g2,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_curve_twist_bn254(g2) {
             return Err(PAIRING_CHECK_ERR_G2_NOT_ON_CURVE);
         }
 
         // Verify G2 point is in subgroup
-        if !is_on_subgroup_twist_bn254(
-            g2,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        if !is_on_subgroup_twist_bn254(g2) {
             return Err(PAIRING_CHECK_ERR_G2_NOT_IN_SUBGROUP);
         }
 
@@ -224,12 +168,7 @@ pub fn pairing_check_bn254(
     }
 
     // Compute batch pairing and check if result is 1
-    Ok(is_one(&pairing_batch_bn254(
-        &g1_valid,
-        &g2_valid,
-        #[cfg(feature = "hints")]
-        hints,
-    )))
+    Ok(is_one(&pairing_batch_bn254(&g1_valid, &g2_valid)))
 }
 
 /// BN254 pairing check with big-endian byte format
@@ -247,11 +186,7 @@ pub fn pairing_check_bn254(
 /// - 5 = G2 point not on curve
 /// - 6 = G2 point not in subgroup
 #[inline]
-pub(crate) unsafe fn bn254_pairing_check_c(
-    pairs: *const u8,
-    num_pairs: usize,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> u8 {
+pub(crate) unsafe fn bn254_pairing_check_c(pairs: *const u8, num_pairs: usize) -> u8 {
     // Parse all pairs
     let mut g1_points: Vec<[u64; 8]> = Vec::with_capacity(num_pairs);
     let mut g2_points: Vec<[u64; 16]> = Vec::with_capacity(num_pairs);
@@ -267,12 +202,7 @@ pub(crate) unsafe fn bn254_pairing_check_c(
     }
 
     // Perform pairing check with validation
-    match pairing_check_bn254(
-        &g1_points,
-        &g2_points,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    match pairing_check_bn254(&g1_points, &g2_points) {
         Ok(true) => PAIRING_CHECK_SUCCESS,
         Ok(false) => PAIRING_CHECK_FAILED,
         Err(code) => code,

--- a/ziskos/entrypoint/src/zisklib/lib/bn254/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bn254/twist.rs
@@ -11,109 +11,39 @@ use super::{
 };
 
 /// Check if a non-zero point `p` is on the BN254 twist
-pub fn is_on_curve_twist_bn254(
-    p: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+pub fn is_on_curve_twist_bn254(p: &[u64; 16]) -> bool {
     // q in E' iff y² == x³ + 3 / (9 + u)
     let x: [u64; 8] = p[0..8].try_into().unwrap();
     let y: [u64; 8] = p[8..16].try_into().unwrap();
-    let x_sq = square_fp2_bn254(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_cubed = mul_fp2_bn254(
-        &x_sq,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_cubed_plus_b = add_fp2_bn254(
-        &x_cubed,
-        &ETWISTED_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_sq = square_fp2_bn254(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let x_sq = square_fp2_bn254(&x);
+    let x_cubed = mul_fp2_bn254(&x_sq, &x);
+    let x_cubed_plus_b = add_fp2_bn254(&x_cubed, &ETWISTED_B);
+    let y_sq = square_fp2_bn254(&y);
     eq(&x_cubed_plus_b, &y_sq)
 }
 
 /// Check if a non-zero point `p` is on the BN254 twist subgroup
-pub fn is_on_subgroup_twist_bn254(
-    p: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+pub fn is_on_subgroup_twist_bn254(p: &[u64; 16]) -> bool {
     // p in subgroup iff:
     //      (x+1)·Q + 𝜓(x·Q) + 𝜓²(x·Q) == 𝜓³((2x)·Q)
     // where 𝜓 is the Frobenius endomorphism
     // as described in https://eprint.iacr.org/2022/348.pdf
-    let xp: [u64; 16] = scalar_mul_by_x_twist_bn254(
-        p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x1p = add_twist_bn254(
-        p,
-        &xp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let psi_one = utf_endomorphism_twist_bn254(
-        &xp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let psi_two = utf_endomorphism_twist_bn254(
-        &psi_one,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut lhs = add_twist_bn254(
-        &x1p,
-        &psi_one,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lhs = add_twist_bn254(
-        &lhs,
-        &psi_two,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let xp: [u64; 16] = scalar_mul_by_x_twist_bn254(p);
+    let x1p = add_twist_bn254(p, &xp);
+    let psi_one = utf_endomorphism_twist_bn254(&xp);
+    let psi_two = utf_endomorphism_twist_bn254(&psi_one);
+    let mut lhs = add_twist_bn254(&x1p, &psi_one);
+    lhs = add_twist_bn254(&lhs, &psi_two);
 
-    let mut rhs = dbl_twist_bn254(
-        &xp,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = utf_endomorphism_twist_bn254(
-        &rhs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = utf_endomorphism_twist_bn254(
-        &rhs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = utf_endomorphism_twist_bn254(
-        &rhs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut rhs = dbl_twist_bn254(&xp);
+    rhs = utf_endomorphism_twist_bn254(&rhs);
+    rhs = utf_endomorphism_twist_bn254(&rhs);
+    rhs = utf_endomorphism_twist_bn254(&rhs);
     eq(&lhs, &rhs)
 }
 
 /// Converts a point `p` on the BN254 curve from Jacobian coordinates to affine coordinates
-pub fn to_affine_twist_bn254(
-    p: &[u64; 24],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 16] {
+pub fn to_affine_twist_bn254(p: &[u64; 24]) -> [u64; 16] {
     let z: [u64; 8] = p[16..24].try_into().unwrap();
 
     if z == [0u64; 8] {
@@ -128,35 +58,12 @@ pub fn to_affine_twist_bn254(
     let x: [u64; 8] = p[0..8].try_into().unwrap();
     let y: [u64; 8] = p[8..16].try_into().unwrap();
 
-    let zinv = inv_fp2_bn254(
-        &z,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let zinv_sq = square_fp2_bn254(
-        &zinv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let zinv = inv_fp2_bn254(&z);
+    let zinv_sq = square_fp2_bn254(&zinv);
 
-    let x_res = mul_fp2_bn254(
-        &x,
-        &zinv_sq,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut y_res = mul_fp2_bn254(
-        &y,
-        &zinv_sq,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y_res = mul_fp2_bn254(
-        &y_res,
-        &zinv,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let x_res = mul_fp2_bn254(&x, &zinv_sq);
+    let mut y_res = mul_fp2_bn254(&y, &zinv_sq);
+    y_res = mul_fp2_bn254(&y_res, &zinv);
     [
         x_res[0], x_res[1], x_res[2], x_res[3], x_res[4], x_res[5], x_res[6], x_res[7], y_res[0],
         y_res[1], y_res[2], y_res[3], y_res[4], y_res[5], y_res[6], y_res[7],
@@ -164,11 +71,7 @@ pub fn to_affine_twist_bn254(
 }
 
 /// Addition of two non-zero points
-pub fn add_twist_bn254(
-    p1: &[u64; 16],
-    p2: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 16] {
+pub fn add_twist_bn254(p1: &[u64; 16], p2: &[u64; 16]) -> [u64; 16] {
     let x1: [u64; 8] = p1[0..8].try_into().unwrap();
     let y1: [u64; 8] = p1[8..16].try_into().unwrap();
     let x2: [u64; 8] = p2[0..8].try_into().unwrap();
@@ -179,11 +82,7 @@ pub fn add_twist_bn254(
         // Is y1 == y2?
         if eq(&y1, &y2) {
             // Compute the doubling
-            return dbl_twist_bn254(
-                p1,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            return dbl_twist_bn254(p1);
         } else {
             // Points are the inverse of each other, return the point at infinity
             return G2_IDENTITY;
@@ -191,66 +90,18 @@ pub fn add_twist_bn254(
     }
 
     // Compute the addition
-    let mut den = sub_fp2_bn254(
-        &x2,
-        &x1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    den = inv_fp2_bn254(
-        &den,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut lambda = sub_fp2_bn254(
-        &y2,
-        &y1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = mul_fp2_bn254(
-        &lambda,
-        &den,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut den = sub_fp2_bn254(&x2, &x1);
+    den = inv_fp2_bn254(&den);
+    let mut lambda = sub_fp2_bn254(&y2, &y1);
+    lambda = mul_fp2_bn254(&lambda, &den);
 
-    let mut x3 = square_fp2_bn254(
-        &lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bn254(
-        &x3,
-        &x1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bn254(
-        &x3,
-        &x2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut x3 = square_fp2_bn254(&lambda);
+    x3 = sub_fp2_bn254(&x3, &x1);
+    x3 = sub_fp2_bn254(&x3, &x2);
 
-    let mut y3 = sub_fp2_bn254(
-        &x1,
-        &x3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = mul_fp2_bn254(
-        &lambda,
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = sub_fp2_bn254(
-        &y3,
-        &y1,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y3 = sub_fp2_bn254(&x1, &x3);
+    y3 = mul_fp2_bn254(&lambda, &y3);
+    y3 = sub_fp2_bn254(&y3, &y1);
     [
         x3[0], x3[1], x3[2], x3[3], x3[4], x3[5], x3[6], x3[7], y3[0], y3[1], y3[2], y3[3], y3[4],
         y3[5], y3[6], y3[7],
@@ -258,76 +109,24 @@ pub fn add_twist_bn254(
 }
 
 /// Doubling of a non-zero point
-pub fn dbl_twist_bn254(p: &[u64; 16], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 16] {
+pub fn dbl_twist_bn254(p: &[u64; 16]) -> [u64; 16] {
     let x: [u64; 8] = p[0..8].try_into().unwrap();
     let y: [u64; 8] = p[8..16].try_into().unwrap();
 
     // Compute the doubling
-    let mut lambda = dbl_fp2_bn254(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = inv_fp2_bn254(
-        &lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = scalar_mul_fp2_bn254(
-        &lambda,
-        &E_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = mul_fp2_bn254(
-        &lambda,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    lambda = mul_fp2_bn254(
-        &lambda,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut lambda = dbl_fp2_bn254(&y);
+    lambda = inv_fp2_bn254(&lambda);
+    lambda = scalar_mul_fp2_bn254(&lambda, &E_B);
+    lambda = mul_fp2_bn254(&lambda, &x);
+    lambda = mul_fp2_bn254(&lambda, &x);
 
-    let mut x3 = square_fp2_bn254(
-        &lambda,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bn254(
-        &x3,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    x3 = sub_fp2_bn254(
-        &x3,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut x3 = square_fp2_bn254(&lambda);
+    x3 = sub_fp2_bn254(&x3, &x);
+    x3 = sub_fp2_bn254(&x3, &x);
 
-    let mut y3 = sub_fp2_bn254(
-        &x,
-        &x3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = mul_fp2_bn254(
-        &lambda,
-        &y3,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y3 = sub_fp2_bn254(
-        &y3,
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let mut y3 = sub_fp2_bn254(&x, &x3);
+    y3 = mul_fp2_bn254(&lambda, &y3);
+    y3 = sub_fp2_bn254(&y3, &y);
 
     [
         x3[0], x3[1], x3[2], x3[3], x3[4], x3[5], x3[6], x3[7], y3[0], y3[1], y3[2], y3[3], y3[4],
@@ -336,16 +135,12 @@ pub fn dbl_twist_bn254(p: &[u64; 16], #[cfg(feature = "hints")] hints: &mut Vec<
 }
 
 /// Negation of a point
-pub fn neg_twist_bn254(p: &[u64; 16], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 16] {
+pub fn neg_twist_bn254(p: &[u64; 16]) -> [u64; 16] {
     let x: [u64; 8] = p[0..8].try_into().unwrap();
     let y: [u64; 8] = p[8..16].try_into().unwrap();
 
     // Compute the negation
-    let y_neg = neg_fp2_bn254(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let y_neg = neg_fp2_bn254(&y);
     [
         x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], y_neg[0], y_neg[1], y_neg[2], y_neg[3],
         y_neg[4], y_neg[5], y_neg[6], y_neg[7],
@@ -353,10 +148,7 @@ pub fn neg_twist_bn254(p: &[u64; 16], #[cfg(feature = "hints")] hints: &mut Vec<
 }
 
 /// Scalar multiplication of a non-zero point by x
-pub fn scalar_mul_by_x_twist_bn254(
-    p: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 16] {
+pub fn scalar_mul_by_x_twist_bn254(p: &[u64; 16]) -> [u64; 16] {
     // Binary representation of the exponent x = 4965661367192848881 in big-endian format
     const X_BIN_BE: [u8; 63] = [
         1, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0,
@@ -366,56 +158,26 @@ pub fn scalar_mul_by_x_twist_bn254(
 
     let mut q = *p;
     for &bit in X_BIN_BE.iter().skip(1) {
-        q = dbl_twist_bn254(
-            &q,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        q = dbl_twist_bn254(&q);
         if bit == 1 {
-            q = add_twist_bn254(
-                &q,
-                p,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            q = add_twist_bn254(&q, p);
         }
     }
     q
 }
 
 /// Compute the untwist-frobenius-twist (utf) endomorphism 𝜓: (x,y) = (𝛾₁₂·x̄,𝛾₁₃·ȳ)
-pub fn utf_endomorphism_twist_bn254(
-    p: &[u64; 16],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 16] {
+pub fn utf_endomorphism_twist_bn254(p: &[u64; 16]) -> [u64; 16] {
     let mut x: [u64; 8] = p[0..8].try_into().unwrap();
     let mut y: [u64; 8] = p[8..16].try_into().unwrap();
 
     // Compute the conjugate of x and y
-    x = conjugate_fp2_bn254(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    y = conjugate_fp2_bn254(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    x = conjugate_fp2_bn254(&x);
+    y = conjugate_fp2_bn254(&y);
 
     // Compute the multiplication
-    let qx = mul_fp2_bn254(
-        &FROBENIUS_GAMMA12,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let qy = mul_fp2_bn254(
-        &FROBENIUS_GAMMA13,
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let qx = mul_fp2_bn254(&FROBENIUS_GAMMA12, &x);
+    let qy = mul_fp2_bn254(&FROBENIUS_GAMMA13, &y);
 
     [
         qx[0], qx[1], qx[2], qx[3], qx[4], qx[5], qx[6], qx[7], qy[0], qy[1], qy[2], qy[3], qy[4],

--- a/ziskos/entrypoint/src/zisklib/lib/keccak256.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/keccak256.rs
@@ -35,7 +35,7 @@ pub fn hint_log<S: AsRef<str>>(msg: S) {
 const KECCAK256_RATE: usize = 136;
 
 /// Keccak-256 hash function. For reference: https://keccak.team/keccak_specs_summary.html
-pub fn keccak256(input: &[u8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u8; 32] {
+pub fn keccak256(input: &[u8]) -> [u8; 32] {
     let mut state = [0u64; 25];
     let input_len = input.len();
 
@@ -46,11 +46,7 @@ pub fn keccak256(input: &[u8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -
         xor_block_into_state(&mut state, &input[offset..offset + KECCAK256_RATE]);
         // Apply Keccak-f permutation
         unsafe {
-            syscall_keccak_f(
-                &mut state,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            syscall_keccak_f(&mut state);
         }
         offset += KECCAK256_RATE;
     }
@@ -72,11 +68,7 @@ pub fn keccak256(input: &[u8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -
 
     // Final permutation
     unsafe {
-        syscall_keccak_f(
-            &mut state,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_keccak_f(&mut state);
     }
 
     // Squeeze phase: extract first 32 bytes (256 bits) from state
@@ -103,18 +95,9 @@ fn xor_block_into_state(state: &mut [u64; 25], block: &[u8]) {
 /// - `input` must point to at least `input_len` bytes
 /// - `output` must point to a writable buffer of at least 32 bytes
 #[inline]
-pub(crate) unsafe fn keccak256_c(
-    input: *const u8,
-    input_len: usize,
-    output: *mut u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub(crate) unsafe fn keccak256_c(input: *const u8, input_len: usize, output: *mut u8) {
     let input_slice = core::slice::from_raw_parts(input, input_len);
-    let hash = keccak256(
-        input_slice,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let hash = keccak256(input_slice);
     let output_slice = core::slice::from_raw_parts_mut(output, 32);
     output_slice.copy_from_slice(&hash);
 }
@@ -138,13 +121,7 @@ pub unsafe extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: 
 
     #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
     {
-        keccak256_c(
-            bytes,
-            len,
-            output,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        keccak256_c(bytes, len, output);
     }
 
     #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]

--- a/ziskos/entrypoint/src/zisklib/lib/ripemd160.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/ripemd160.rs
@@ -1,6 +1,6 @@
 /// Compute RIPEMD-160 hash
 #[inline]
-pub fn ripemd160(input: &[u8], #[cfg(feature = "hints")] _hints: &mut Vec<u64>) -> [u8; 32] {
+pub fn ripemd160(input: &[u8]) -> [u8; 32] {
     use ripemd::Digest;
     let mut hasher = ripemd::Ripemd160::new();
     hasher.update(input);
@@ -16,18 +16,9 @@ pub fn ripemd160(input: &[u8], #[cfg(feature = "hints")] _hints: &mut Vec<u64>) 
 /// - `input` must point to at least `input_len` bytes
 /// - `output` must point to a writable buffer of at least 32 bytes
 #[inline]
-pub(crate) unsafe fn ripemd160_c(
-    input: *const u8,
-    input_len: usize,
-    output: *mut u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub(crate) unsafe fn ripemd160_c(input: *const u8, input_len: usize, output: *mut u8) {
     let input_slice = core::slice::from_raw_parts(input, input_len);
-    let hash = ripemd160(
-        input_slice,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let hash = ripemd160(input_slice);
     let output_slice = core::slice::from_raw_parts_mut(output, 32);
     output_slice.copy_from_slice(&hash);
 }

--- a/ziskos/entrypoint/src/zisklib/lib/secp256k1/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/secp256k1/curve.rs
@@ -20,35 +20,12 @@ const IDENTITY_POINT256: SyscallPoint256 = SyscallPoint256 { x: IDENTITY_X, y: I
 const G_POINT256: SyscallPoint256 = SyscallPoint256 { x: G_X, y: G_Y };
 
 /// Given a x-coordinate and a parity bit, returns the corresponding point (x, y) on the curve if it exists
-pub fn secp256k1_lift_x(
-    x: &[u64; 4],
-    y_is_odd: bool,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 8], bool> {
+pub fn secp256k1_lift_x(x: &[u64; 4], y_is_odd: bool) -> Result<[u64; 8], bool> {
     // Calculate the y-coordinate of the point: y = sqrt(x³ + 7)
-    let x_sq = secp256k1_fp_square(
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let x_cb = secp256k1_fp_mul(
-        &x_sq,
-        x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let y_sq = secp256k1_fp_add(
-        &x_cb,
-        &E_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let (y, has_sqrt) = secp256k1_fp_sqrt(
-        &y_sq,
-        y_is_odd as u64,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let x_sq = secp256k1_fp_square(x);
+    let x_cb = secp256k1_fp_mul(&x_sq, x);
+    let y_sq = secp256k1_fp_add(&x_cb, &E_B);
+    let (y, has_sqrt) = secp256k1_fp_sqrt(&y_sq, y_is_odd as u64);
 
     if !has_sqrt {
         return Err(false);
@@ -63,33 +40,15 @@ pub fn secp256k1_lift_x(
 
 /// Checks whether the given point `p` is on the Secp256k1 curve.
 /// It assumes that `p` is not the point at infinity.
-pub fn secp256k1_is_on_curve(p: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> bool {
+pub fn secp256k1_is_on_curve(p: &[u64; 8]) -> bool {
     let x: [u64; 4] = p[0..4].try_into().unwrap();
     let y: [u64; 4] = p[4..8].try_into().unwrap();
 
     // p in E iff y² == x³ + 7
-    let lhs = secp256k1_fp_square(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut rhs = secp256k1_fp_square(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = secp256k1_fp_mul(
-        &rhs,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = secp256k1_fp_add(
-        &rhs,
-        &E_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let lhs = secp256k1_fp_square(&y);
+    let mut rhs = secp256k1_fp_square(&x);
+    rhs = secp256k1_fp_mul(&rhs, &x);
+    rhs = secp256k1_fp_add(&rhs, &E_B);
     eq(&lhs, &rhs)
 }
 
@@ -97,25 +56,13 @@ pub fn secp256k1_is_on_curve(p: &[u64; 8], #[cfg(feature = "hints")] hints: &mut
 /// It assumes that `p1` and `p2` are from the Secp256k1 curve, that `p1,p2 != 𝒪`
 /// Returns true if the result is the point at infinity.
 #[inline]
-fn secp256k1_add_non_infinity_points(
-    p1: &mut SyscallPoint256,
-    p2: &SyscallPoint256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+fn secp256k1_add_non_infinity_points(p1: &mut SyscallPoint256, p2: &SyscallPoint256) -> bool {
     if p1.x != p2.x {
         let mut params = SyscallSecp256k1AddParams { p1, p2 };
-        syscall_secp256k1_add(
-            &mut params,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_secp256k1_add(&mut params);
         false
     } else if p1.y == p2.y {
-        syscall_secp256k1_dbl(
-            p1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_secp256k1_dbl(p1);
         false
     } else {
         // p1 + (-p1) = 𝒪
@@ -125,20 +72,11 @@ fn secp256k1_add_non_infinity_points(
 
 /// Adds two points on the secp256k1 curve. Assumes both are non-infinity.
 /// Returns None if the result is the point at infinity.
-pub fn secp256k1_point_add(
-    p1: &[u64; 8],
-    p2: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Option<[u64; 8]> {
+pub fn secp256k1_point_add(p1: &[u64; 8], p2: &[u64; 8]) -> Option<[u64; 8]> {
     let mut r =
         SyscallPoint256 { x: [p1[0], p1[1], p1[2], p1[3]], y: [p1[4], p1[5], p1[6], p1[7]] };
     let q = SyscallPoint256 { x: [p2[0], p2[1], p2[2], p2[3]], y: [p2[4], p2[5], p2[6], p2[7]] };
-    let is_inf = secp256k1_add_non_infinity_points(
-        &mut r,
-        &q,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let is_inf = secp256k1_add_non_infinity_points(&mut r, &q);
     if is_inf {
         None
     } else {
@@ -150,11 +88,7 @@ pub fn secp256k1_point_add(
 ///
 /// Note: There are no (non-infinity) points of order 2 in Secp256k1.
 ///       All (non-infinity) points are of prime order N.
-pub fn secp256k1_scalar_mul(
-    k: &[u64; 4],
-    p: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Option<[u64; 8]> {
+pub fn secp256k1_scalar_mul(k: &[u64; 4], p: &[u64; 8]) -> Option<[u64; 8]> {
     // Direct cases: k = 0, k = 1, k = 2
     if eq(k, &ZERO_256) {
         return None;
@@ -162,11 +96,7 @@ pub fn secp256k1_scalar_mul(
         return Some(*p);
     } else if eq(k, &TWO_256) {
         let mut res = SyscallPoint256 { x: [p[0], p[1], p[2], p[3]], y: [p[4], p[5], p[6], p[7]] };
-        syscall_secp256k1_dbl(
-            &mut res,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_secp256k1_dbl(&mut res);
         return Some([
             res.x[0], res.x[1], res.x[2], res.x[3], res.y[0], res.y[1], res.y[2], res.y[3],
         ]);
@@ -176,12 +106,7 @@ pub fn secp256k1_scalar_mul(
     // Hint the length the binary representations of k
     // We will verify the output by recomposing k
     // Moreover, we should check that the first received bit is 1
-    let (max_limb, max_bit) = fcall_msb_pos_256(
-        k,
-        &ZERO_256,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (max_limb, max_bit) = fcall_msb_pos_256(k, &ZERO_256);
 
     // Perform the loop, based on the binary representation of k
 
@@ -212,21 +137,13 @@ pub fn secp256k1_scalar_mul(
     for i in (0..=limb).rev() {
         for j in (0..=bit).rev() {
             // Always double
-            syscall_secp256k1_dbl(
-                &mut res,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            syscall_secp256k1_dbl(&mut res);
 
             // Get the next bit b of k.
             // If b == 1, we should add P
             if ((k[i] >> j) & 1) == 1 {
                 let mut params = SyscallSecp256k1AddParams { p1: &mut res, p2: &p };
-                syscall_secp256k1_add(
-                    &mut params,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                syscall_secp256k1_add(&mut params);
 
                 // Reconstruct k
                 k_rec[i] |= 1 << j;
@@ -248,7 +165,6 @@ pub fn secp256k1_double_scalar_mul_with_g(
     k1: &[u64; 4],
     k2: &[u64; 4],
     p: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> Option<[u64; 8]> {
     // Handle zero scalars
     let k1_zero = eq(k1, &ZERO_256);
@@ -257,47 +173,22 @@ pub fn secp256k1_double_scalar_mul_with_g(
         return None;
     }
     if k1_zero {
-        return secp256k1_scalar_mul(
-            k2,
-            p,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        return secp256k1_scalar_mul(k2, p);
     }
     if k2_zero {
-        return secp256k1_scalar_mul(
-            k1,
-            &G,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        return secp256k1_scalar_mul(k1, &G);
     }
 
     let p = SyscallPoint256 { x: [p[0], p[1], p[2], p[3]], y: [p[4], p[5], p[6], p[7]] };
 
     // Start by precomputing g + p
     let mut gp = G_POINT256;
-    let gp_is_infinity = secp256k1_add_non_infinity_points(
-        &mut gp,
-        &p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let gp_is_infinity = secp256k1_add_non_infinity_points(&mut gp, &p);
 
     // If G + P = 𝒪 => P = -G and therefore the operation is k1·G + (-k2)·G = (k1-k2)·G
     // Fall back to scalar mul
     if gp_is_infinity {
-        return secp256k1_scalar_mul(
-            &secp256k1_fn_sub(
-                k1,
-                k2,
-                #[cfg(feature = "hints")]
-                hints,
-            ),
-            &G,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        return secp256k1_scalar_mul(&secp256k1_fn_sub(k1, k2), &G);
     }
 
     if is_one(k1) && is_one(k2) {
@@ -309,12 +200,7 @@ pub fn secp256k1_double_scalar_mul_with_g(
     // Hint the maximum length between the binary representations of k1 and k2
     // We will verify the output by recomposing both k1 and k2
     // Moreover, we should check that the first received bit (of either k1 or k2) is 1
-    let (max_limb, max_bit) = fcall_msb_pos_256(
-        k1,
-        k2,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (max_limb, max_bit) = fcall_msb_pos_256(k1, k2);
 
     // Perform the loop, based on the binary representation of k1 and k2
 
@@ -389,11 +275,7 @@ pub fn secp256k1_double_scalar_mul_with_g(
                 (0, 0) => {
                     // If res is 𝒪, do nothing; otherwise, double
                     if !res_is_infinity {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
                     }
                 }
                 (0, 1) => {
@@ -403,17 +285,8 @@ pub fn secp256k1_double_scalar_mul_with_g(
                         res.y = p.y;
                         res_is_infinity = false;
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
-                        res_is_infinity = secp256k1_add_non_infinity_points(
-                            &mut res,
-                            &p,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
+                        res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &p);
                     }
 
                     // Update k2_rec
@@ -426,17 +299,8 @@ pub fn secp256k1_double_scalar_mul_with_g(
                         res.y = G_POINT256.y;
                         res_is_infinity = false;
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
-                        res_is_infinity = secp256k1_add_non_infinity_points(
-                            &mut res,
-                            &G_POINT256,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
+                        res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &G_POINT256);
                     }
 
                     // Update k1_rec
@@ -451,18 +315,9 @@ pub fn secp256k1_double_scalar_mul_with_g(
                             res_is_infinity = false;
                         }
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
                         if !gp_is_infinity {
-                            res_is_infinity = secp256k1_add_non_infinity_points(
-                                &mut res,
-                                &gp,
-                                #[cfg(feature = "hints")]
-                                hints,
-                            );
+                            res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &gp);
                         }
                     }
 
@@ -495,35 +350,19 @@ pub fn secp256k1_triple_scalar_mul_with_g(
     t: &[u64; 4],
     p: &[u64; 8],
     q: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> Option<[u64; 8]> {
     let p = SyscallPoint256 { x: [p[0], p[1], p[2], p[3]], y: [p[4], p[5], p[6], p[7]] };
     let q = SyscallPoint256 { x: [q[0], q[1], q[2], q[3]], y: [q[4], q[5], q[6], q[7]] };
 
     // Precompute g + p, g + q, p + q, g + p + q
     let mut gp = G_POINT256;
-    let gp_is_infinity = secp256k1_add_non_infinity_points(
-        &mut gp,
-        &p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let gp_is_infinity = secp256k1_add_non_infinity_points(&mut gp, &p);
 
     let mut gq = G_POINT256;
-    let gq_is_infinity = secp256k1_add_non_infinity_points(
-        &mut gq,
-        &q,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let gq_is_infinity = secp256k1_add_non_infinity_points(&mut gq, &q);
 
     let mut pq = SyscallPoint256 { x: p.x, y: p.y };
-    let pq_is_infinity = secp256k1_add_non_infinity_points(
-        &mut pq,
-        &q,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let pq_is_infinity = secp256k1_add_non_infinity_points(&mut pq, &q);
 
     let (gpq, gpq_is_infinity) = if gp_is_infinity {
         // G + P = 𝒪, so G + P + Q = Q
@@ -534,12 +373,7 @@ pub fn secp256k1_triple_scalar_mul_with_g(
     } else {
         // Normal case: add Q to (G + P)
         let mut gpq_temp = SyscallPoint256 { x: gp.x, y: gp.y };
-        let is_inf = secp256k1_add_non_infinity_points(
-            &mut gpq_temp,
-            &q,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let is_inf = secp256k1_add_non_infinity_points(&mut gpq_temp, &q);
         (gpq_temp, is_inf)
     };
 
@@ -556,13 +390,7 @@ pub fn secp256k1_triple_scalar_mul_with_g(
     // From here on, at least one of r,s,t is greater than 1
 
     // Hint the maximum length between the binary representations of r,s and t
-    let (max_limb, max_bit) = fcall_msb_pos_256_3(
-        r,
-        s,
-        t,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (max_limb, max_bit) = fcall_msb_pos_256_3(r, s, t);
 
     // Perform the loop, based on the binary representation of r,s and t
 
@@ -686,11 +514,7 @@ pub fn secp256k1_triple_scalar_mul_with_g(
                 (0, 0, 0) => {
                     // If res is 𝒪, do nothing; otherwise, double
                     if !res_is_infinity {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
                     }
                 }
                 (0, 0, 1) => {
@@ -700,17 +524,8 @@ pub fn secp256k1_triple_scalar_mul_with_g(
                         res.y = q.y;
                         res_is_infinity = false;
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
-                        res_is_infinity = secp256k1_add_non_infinity_points(
-                            &mut res,
-                            &q,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
+                        res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &q);
                     }
 
                     // Update t_rec
@@ -723,17 +538,8 @@ pub fn secp256k1_triple_scalar_mul_with_g(
                         res.y = p.y;
                         res_is_infinity = false;
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
-                        res_is_infinity = secp256k1_add_non_infinity_points(
-                            &mut res,
-                            &p,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
+                        res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &p);
                     }
 
                     // Update s_rec
@@ -748,18 +554,9 @@ pub fn secp256k1_triple_scalar_mul_with_g(
                             res_is_infinity = false;
                         }
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
                         if !pq_is_infinity {
-                            res_is_infinity = secp256k1_add_non_infinity_points(
-                                &mut res,
-                                &pq,
-                                #[cfg(feature = "hints")]
-                                hints,
-                            );
+                            res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &pq);
                         }
                     }
 
@@ -774,17 +571,8 @@ pub fn secp256k1_triple_scalar_mul_with_g(
                         res.y = G_POINT256.y;
                         res_is_infinity = false;
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
-                        res_is_infinity = secp256k1_add_non_infinity_points(
-                            &mut res,
-                            &G_POINT256,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
+                        res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &G_POINT256);
                     }
 
                     // Update r_rec
@@ -799,18 +587,9 @@ pub fn secp256k1_triple_scalar_mul_with_g(
                             res_is_infinity = false;
                         }
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
                         if !gq_is_infinity {
-                            res_is_infinity = secp256k1_add_non_infinity_points(
-                                &mut res,
-                                &gq,
-                                #[cfg(feature = "hints")]
-                                hints,
-                            );
+                            res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &gq);
                         }
                     }
 
@@ -827,18 +606,9 @@ pub fn secp256k1_triple_scalar_mul_with_g(
                             res_is_infinity = false;
                         }
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
                         if !gp_is_infinity {
-                            res_is_infinity = secp256k1_add_non_infinity_points(
-                                &mut res,
-                                &gp,
-                                #[cfg(feature = "hints")]
-                                hints,
-                            );
+                            res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &gp);
                         }
                     }
 
@@ -855,18 +625,9 @@ pub fn secp256k1_triple_scalar_mul_with_g(
                             res_is_infinity = false;
                         }
                     } else {
-                        syscall_secp256k1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256k1_dbl(&mut res);
                         if !gpq_is_infinity {
-                            res_is_infinity = secp256k1_add_non_infinity_points(
-                                &mut res,
-                                &gpq,
-                                #[cfg(feature = "hints")]
-                                hints,
-                            );
+                            res_is_infinity = secp256k1_add_non_infinity_points(&mut res, &gpq);
                         }
                     }
 
@@ -937,11 +698,7 @@ fn optimal_window_size(n: usize) -> usize {
 /// Multi-scalar multiplication using Pippenger's bucket method: Σ kᵢ·Pᵢ.
 /// Returns None if the result is the point at infinity.
 /// Assumes all points are non-infinity and on the curve. Scalars must be in [0, N-1].
-pub fn secp256k1_multi_scalar_mul(
-    scalars: &[[u64; 4]],
-    points: &[[u64; 8]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Option<[u64; 8]> {
+pub fn secp256k1_multi_scalar_mul(scalars: &[[u64; 4]], points: &[[u64; 8]]) -> Option<[u64; 8]> {
     let n = scalars.len();
     assert_eq!(n, points.len());
     if n == 0 {
@@ -967,11 +724,7 @@ pub fn secp256k1_multi_scalar_mul(
         // Double the accumulator w times (combine with previous windows)
         if !result_is_inf {
             for _ in 0..w {
-                syscall_secp256k1_dbl(
-                    &mut result,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                syscall_secp256k1_dbl(&mut result);
             }
         }
 
@@ -997,12 +750,8 @@ pub fn secp256k1_multi_scalar_mul(
                 buckets[bucket_idx] = p;
                 bucket_is_inf[bucket_idx] = false;
             } else {
-                bucket_is_inf[bucket_idx] = secp256k1_add_non_infinity_points(
-                    &mut buckets[bucket_idx],
-                    &p,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                bucket_is_inf[bucket_idx] =
+                    secp256k1_add_non_infinity_points(&mut buckets[bucket_idx], &p);
             }
         }
 
@@ -1020,12 +769,8 @@ pub fn secp256k1_multi_scalar_mul(
                     running_sum = SyscallPoint256 { x: buckets[j].x, y: buckets[j].y };
                     running_is_inf = false;
                 } else {
-                    running_is_inf = secp256k1_add_non_infinity_points(
-                        &mut running_sum,
-                        &buckets[j],
-                        #[cfg(feature = "hints")]
-                        hints,
-                    );
+                    running_is_inf =
+                        secp256k1_add_non_infinity_points(&mut running_sum, &buckets[j]);
                 }
             }
 
@@ -1035,12 +780,8 @@ pub fn secp256k1_multi_scalar_mul(
                     partial_sum = SyscallPoint256 { x: running_sum.x, y: running_sum.y };
                     partial_is_inf = false;
                 } else {
-                    partial_is_inf = secp256k1_add_non_infinity_points(
-                        &mut partial_sum,
-                        &running_sum,
-                        #[cfg(feature = "hints")]
-                        hints,
-                    );
+                    partial_is_inf =
+                        secp256k1_add_non_infinity_points(&mut partial_sum, &running_sum);
                 }
             }
         }
@@ -1051,12 +792,7 @@ pub fn secp256k1_multi_scalar_mul(
                 result = partial_sum;
                 result_is_inf = false;
             } else {
-                result_is_inf = secp256k1_add_non_infinity_points(
-                    &mut result,
-                    &partial_sum,
-                    #[cfg(feature = "hints")]
-                    hints,
-                );
+                result_is_inf = secp256k1_add_non_infinity_points(&mut result, &partial_sum);
             }
         }
     }

--- a/ziskos/entrypoint/src/zisklib/lib/secp256k1/ecdsa.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/secp256k1/ecdsa.rs
@@ -20,19 +20,9 @@ pub const ECDSA_RECOVER_ERR_RECOVERY_FAILED: u8 = 5;
 /// - 0 = valid signature
 /// - 1 = public key not on curve
 /// - 2 = invalid signature
-pub fn secp256k1_ecdsa_verify(
-    pk: &[u64; 8],
-    z: &[u64; 4],
-    r: &[u64; 4],
-    s: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+pub fn secp256k1_ecdsa_verify(pk: &[u64; 8], z: &[u64; 4], r: &[u64; 4], s: &[u64; 4]) -> bool {
     // pk must be on the curve
-    if !secp256k1_is_on_curve(
-        pk,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !secp256k1_is_on_curve(pk) {
         return false;
     }
 
@@ -43,55 +33,23 @@ pub fn secp256k1_ecdsa_verify(
     // and ensure that x ≡ r (mod n), saving us from expensive fn arithmetic
 
     // Hint the result
-    let point = fcall_secp256k1_ecdsa_verify(
-        pk,
-        z,
-        r,
-        s,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let point = fcall_secp256k1_ecdsa_verify(pk, z, r, s);
 
     // Check the recovered point is valid
     // Note: Identity point would be raised here
-    if !secp256k1_is_on_curve(
-        &point,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !secp256k1_is_on_curve(&point) {
         return false;
     }
 
     // Check that [z]G + [r]PK + [-s](x,y) == 𝒪
-    let neg_s = secp256k1_fn_neg(
-        s,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    if secp256k1_triple_scalar_mul_with_g(
-        z,
-        r,
-        &neg_s,
-        pk,
-        &point,
-        #[cfg(feature = "hints")]
-        hints,
-    )
-    .is_some()
-    {
+    let neg_s = secp256k1_fn_neg(s);
+    if secp256k1_triple_scalar_mul_with_g(z, r, &neg_s, pk, &point).is_some() {
         return false;
     }
 
     // Check that x ≡ r (mod n)
     let point_x: [u64; 4] = [point[0], point[1], point[2], point[3]];
-    eq(
-        &secp256k1_fn_reduce(
-            &point_x,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        r,
-    )
+    eq(&secp256k1_fn_reduce(&point_x), r)
 }
 
 /// Recover the public key point from an ECDSA signature (r, s) over the message hash z and recovery id recid
@@ -108,7 +66,6 @@ pub fn secp256k1_ecdsa_recover(
     s: &[u64; 4],
     z: &[u64; 4],
     recid: u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> Result<[u64; 8], u8> {
     // Validate r
     if *r == ZERO_256 || gt(r, &N_MINUS_ONE) {
@@ -136,13 +93,8 @@ pub fn secp256k1_ecdsa_recover(
 
     // Compute the y-coordinate from x and the parity bit
     let y_is_odd = (recid & 1) == 1;
-    let r_point = secp256k1_lift_x(
-        &x,
-        y_is_odd,
-        #[cfg(feature = "hints")]
-        hints,
-    )
-    .map_err(|_| ECDSA_RECOVER_ERR_POINT_NOT_ON_CURVE)?;
+    let r_point =
+        secp256k1_lift_x(&x, y_is_odd).map_err(|_| ECDSA_RECOVER_ERR_POINT_NOT_ON_CURVE)?;
 
     // Check that [z]G + [-s]R + [r](xQ,yQ) == 𝒪
 
@@ -150,47 +102,18 @@ pub fn secp256k1_ecdsa_recover(
     // The following functions hints (x,y) satisfying
     //    (x, y) == [s⁻¹·z (mod n)]G + [s⁻¹·r (mod n)]R iff  [z]G + [r]R + [-s](x, y) == 𝒪
     // We can use it by flipping the signs of r and s and its order
-    let neg_s = secp256k1_fn_neg(
-        s,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let neg_r = secp256k1_fn_neg(
-        r,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let point = fcall_secp256k1_ecdsa_verify(
-        &r_point,
-        z,
-        &neg_s,
-        &neg_r,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let neg_s = secp256k1_fn_neg(s);
+    let neg_r = secp256k1_fn_neg(r);
+    let point = fcall_secp256k1_ecdsa_verify(&r_point, z, &neg_s, &neg_r);
 
     // Check the recovered point is valid
     // Note: Identity point would be raised here
-    if !secp256k1_is_on_curve(
-        &point,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !secp256k1_is_on_curve(&point) {
         return Err(ECDSA_RECOVER_ERR_RECOVERY_FAILED);
     }
 
     // Check that [z]G + [-s]R + [r](xQ,yQ) == 𝒪
-    if secp256k1_triple_scalar_mul_with_g(
-        z,
-        &neg_s,
-        r,
-        &r_point,
-        &point,
-        #[cfg(feature = "hints")]
-        hints,
-    )
-    .is_some()
-    {
+    if secp256k1_triple_scalar_mul_with_g(z, &neg_s, r, &r_point, &point).is_some() {
         return Err(ECDSA_RECOVER_ERR_RECOVERY_FAILED);
     }
 
@@ -220,7 +143,6 @@ pub(crate) unsafe fn secp256k1_ecdsa_verify_c(
     sig: *const u8,
     msg: *const u8,
     pk: *const u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> bool {
     let sig_bytes: &[u8; 64] = &*(sig as *const [u8; 64]);
     let msg_bytes: &[u8; 32] = &*(msg as *const [u8; 32]);
@@ -242,14 +164,7 @@ pub(crate) unsafe fn secp256k1_ecdsa_verify_c(
     let pk_y = bytes_be_to_u64_le(&pk_y_bytes);
 
     let pk_arr: [u64; 8] = [pk_x[0], pk_x[1], pk_x[2], pk_x[3], pk_y[0], pk_y[1], pk_y[2], pk_y[3]];
-    secp256k1_ecdsa_verify(
-        &pk_arr,
-        &z,
-        &r,
-        &s,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    secp256k1_ecdsa_verify(&pk_arr, &z, &r, &s)
 }
 
 /// C-compatible wrapper for secp256k1_ecdsa_recover
@@ -274,7 +189,6 @@ pub(crate) unsafe fn secp256k1_ecdsa_recover_c(
     recid: u8,
     msg: *const u8,
     output: *mut u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> u8 {
     let sig_bytes: &[u8; 64] = &*(sig as *const [u8; 64]);
     let msg_bytes: &[u8; 32] = &*(msg as *const [u8; 32]);
@@ -289,14 +203,7 @@ pub(crate) unsafe fn secp256k1_ecdsa_recover_c(
     let z = bytes_be_to_u64_le(msg_bytes);
 
     // Perform ecrecover
-    match secp256k1_ecdsa_recover(
-        &r,
-        &s,
-        &z,
-        recid,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    match secp256k1_ecdsa_recover(&r, &s, &z, recid) {
         Ok(pk) => {
             // pk is [u64; 8]: x in limbs [0..4] and y in limbs [4..8], little-endian
             let x = [pk[0], pk[1], pk[2], pk[3]];

--- a/ziskos/entrypoint/src/zisklib/lib/secp256k1/field.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/secp256k1/field.rs
@@ -5,65 +5,33 @@ use crate::{
 
 use super::constants::{NQR, P};
 
-pub fn secp256k1_fp_add(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256k1_fp_add(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·1 + y
     let mut params =
         SyscallArith256ModParams { a: x, b: &[1, 0, 0, 0], c: y, module: &P, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
-pub fn secp256k1_fp_mul(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256k1_fp_mul(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·y + 0
     let mut params =
         SyscallArith256ModParams { a: x, b: y, c: &[0, 0, 0, 0], module: &P, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
-pub fn secp256k1_fp_square(
-    x: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256k1_fp_square(x: &[u64; 4]) -> [u64; 4] {
     // x·x + 0
     let mut params =
         SyscallArith256ModParams { a: x, b: x, c: &[0, 0, 0, 0], module: &P, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
-pub fn secp256k1_fp_sqrt(
-    x: &[u64; 4],
-    parity: u64,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> ([u64; 4], bool) {
+pub fn secp256k1_fp_sqrt(x: &[u64; 4], parity: u64) -> ([u64; 4], bool) {
     // Hint the sqrt
-    let hint = fcall_secp256k1_fp_sqrt(
-        x,
-        parity,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let hint = fcall_secp256k1_fp_sqrt(x, parity);
     let is_qr = hint[0] == 1;
     let sqrt = hint[1..5].try_into().unwrap();
 
@@ -75,11 +43,7 @@ pub fn secp256k1_fp_sqrt(
         module: &P,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     if is_qr {
         // Check that sqrt * sqrt == x
@@ -87,12 +51,7 @@ pub fn secp256k1_fp_sqrt(
         (sqrt, true)
     } else {
         // Check that sqrt * sqrt == x * NQR
-        let nqr = secp256k1_fp_mul(
-            x,
-            &NQR,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let nqr = secp256k1_fp_mul(x, &NQR);
         assert_eq!(*params.d, nqr);
         (sqrt, false)
     }

--- a/ziskos/entrypoint/src/zisklib/lib/secp256k1/scalar.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/secp256k1/scalar.rs
@@ -5,10 +5,7 @@ use crate::{
 
 use super::constants::{N, N_MINUS_ONE};
 
-pub fn secp256k1_fn_reduce(
-    x: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256k1_fn_reduce(x: &[u64; 4]) -> [u64; 4] {
     if lt(x, &N) {
         return *x;
     }
@@ -21,16 +18,12 @@ pub fn secp256k1_fn_reduce(
         module: &N,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     *params.d
 }
 
-pub fn secp256k1_fn_neg(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 4] {
+pub fn secp256k1_fn_neg(x: &[u64; 4]) -> [u64; 4] {
     // x·(-1) + 0
     let mut params = SyscallArith256ModParams {
         a: x,
@@ -39,62 +32,34 @@ pub fn secp256k1_fn_neg(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<
         module: &N,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     *params.d
 }
 
-pub fn secp256k1_fn_add(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256k1_fn_add(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·1 + y
     let mut params =
         SyscallArith256ModParams { a: x, b: &[1, 0, 0, 0], c: y, module: &N, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     *params.d
 }
 
-pub fn secp256k1_fn_mul(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256k1_fn_mul(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·y + 0
     let mut params =
         SyscallArith256ModParams { a: x, b: y, c: &[0, 0, 0, 0], module: &N, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     *params.d
 }
 
-pub fn secp256k1_fn_sub(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256k1_fn_sub(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // y·(-1) + x
     let mut params =
         SyscallArith256ModParams { a: y, b: &N_MINUS_ONE, c: x, module: &N, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     *params.d
 }

--- a/ziskos/entrypoint/src/zisklib/lib/secp256k1/schnorr.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/secp256k1/schnorr.rs
@@ -28,7 +28,6 @@ pub fn secp256k1_schnorr_verify(
     pk_x: &[u8; 32],
     sig_r: &[u8; 32],
     sig_s: &[u8; 32],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> bool {
     let r = bytes_be_to_u64_le(sig_r);
     let s = bytes_be_to_u64_le(sig_s);
@@ -44,21 +43,12 @@ pub fn secp256k1_schnorr_verify(
         return false;
     }
 
-    let point_p = match secp256k1_lift_x(
-        &pk_x_le,
-        false,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let point_p = match secp256k1_lift_x(&pk_x_le, false) {
         Ok(pt) => pt,
         Err(_) => return false,
     };
 
-    let tag = sha256(
-        b"BIP0340/challenge",
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let tag = sha256(b"BIP0340/challenge");
     let mut buf = Vec::with_capacity(64 + 32 + 32 + msg.len());
     buf.extend_from_slice(&tag);
     buf.extend_from_slice(&tag);
@@ -66,29 +56,11 @@ pub fn secp256k1_schnorr_verify(
     buf.extend_from_slice(pk_x);
     buf.extend_from_slice(msg);
 
-    let e_hash = sha256(
-        &buf,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let e = secp256k1_fn_reduce(
-        &bytes_be_to_u64_le(&e_hash),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let neg_e = secp256k1_fn_neg(
-        &e,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let e_hash = sha256(&buf);
+    let e = secp256k1_fn_reduce(&bytes_be_to_u64_le(&e_hash));
+    let neg_e = secp256k1_fn_neg(&e);
 
-    let point_r = match secp256k1_double_scalar_mul_with_g(
-        &s,
-        &neg_e,
-        &point_p,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    let point_r = match secp256k1_double_scalar_mul_with_g(&s, &neg_e, &point_p) {
         Some(pt) => pt,
         None => return false,
     };
@@ -110,7 +82,6 @@ pub(crate) unsafe fn secp256k1_schnorr_verify_c(
     msg_len: usize,
     pk_x: *const u8,
     sig: *const u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> u8 {
     let msg_bytes: &[u8] =
         if msg_len == 0 { &[] } else { core::slice::from_raw_parts(msg, msg_len) };
@@ -120,14 +91,7 @@ pub(crate) unsafe fn secp256k1_schnorr_verify_c(
     let mut s = [0u8; 32];
     r.copy_from_slice(&sig_bytes[..32]);
     s.copy_from_slice(&sig_bytes[32..]);
-    if secp256k1_schnorr_verify(
-        msg_bytes,
-        &pk_bytes,
-        &r,
-        &s,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if secp256k1_schnorr_verify(msg_bytes, &pk_bytes, &r, &s) {
         0
     } else {
         1
@@ -144,7 +108,6 @@ pub fn secp256k1_schnorr_batch_verify(
     pk_xs: &[&[u8; 32]],
     sig_rs: &[&[u8; 32]],
     sig_ss: &[&[u8; 32]],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> bool {
     let u = msgs.len();
     if u == 0 {
@@ -156,14 +119,7 @@ pub fn secp256k1_schnorr_batch_verify(
 
     // For u=1, delegate to single verification (avoids extra lift_x(r))
     if u == 1 {
-        return secp256k1_schnorr_verify(
-            msgs[0],
-            pk_xs[0],
-            sig_rs[0],
-            sig_ss[0],
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        return secp256k1_schnorr_verify(msgs[0], pk_xs[0], sig_rs[0], sig_ss[0]);
     }
 
     let mut r_vals = Vec::with_capacity(u);
@@ -194,21 +150,11 @@ pub fn secp256k1_schnorr_batch_verify(
     let mut points_r = Vec::with_capacity(u);
 
     for i in 0..u {
-        let point_p = match secp256k1_lift_x(
-            &pk_vals[i],
-            false,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        let point_p = match secp256k1_lift_x(&pk_vals[i], false) {
             Ok(pt) => pt,
             Err(_) => return false,
         };
-        let point_r = match secp256k1_lift_x(
-            &r_vals[i],
-            false,
-            #[cfg(feature = "hints")]
-            hints,
-        ) {
+        let point_r = match secp256k1_lift_x(&r_vals[i], false) {
             Ok(pt) => pt,
             Err(_) => return false,
         };
@@ -216,11 +162,7 @@ pub fn secp256k1_schnorr_batch_verify(
         points_r.push(point_r);
     }
 
-    let tag = sha256(
-        b"BIP0340/challenge",
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let tag = sha256(b"BIP0340/challenge");
     let mut challenges = Vec::with_capacity(u);
 
     for i in 0..u {
@@ -230,26 +172,14 @@ pub fn secp256k1_schnorr_batch_verify(
         buf.extend_from_slice(sig_rs[i]);
         buf.extend_from_slice(pk_xs[i]);
         buf.extend_from_slice(msgs[i]);
-        let e_hash = sha256(
-            &buf,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let e = secp256k1_fn_reduce(
-            &bytes_be_to_u64_le(&e_hash),
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let e_hash = sha256(&buf);
+        let e = secp256k1_fn_reduce(&bytes_be_to_u64_le(&e_hash));
         challenges.push(e);
     }
 
     // Deterministic random coefficients seeded by all inputs.
     // SHA256 counter mode (equivalent security to BIP-340's recommended ChaCha20).
-    let batch_tag = sha256(
-        b"BIP0340/batch",
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let batch_tag = sha256(b"BIP0340/batch");
     let mut seed_buf = Vec::new();
     seed_buf.extend_from_slice(&batch_tag);
     seed_buf.extend_from_slice(&batch_tag);
@@ -265,11 +195,7 @@ pub fn secp256k1_schnorr_batch_verify(
         seed_buf.extend_from_slice(*r);
         seed_buf.extend_from_slice(*s);
     }
-    let seed = sha256(
-        &seed_buf,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let seed = sha256(&seed_buf);
 
     let mut coeffs = Vec::with_capacity(u);
     coeffs.push([1u64, 0, 0, 0]);
@@ -277,16 +203,8 @@ pub fn secp256k1_schnorr_batch_verify(
         let mut coeff_buf = [0u8; 36];
         coeff_buf[..32].copy_from_slice(&seed);
         coeff_buf[32..36].copy_from_slice(&((i - 1) as u32).to_le_bytes());
-        let hash = sha256(
-            &coeff_buf,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let a = secp256k1_fn_reduce(
-            &bytes_be_to_u64_le(&hash),
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let hash = sha256(&coeff_buf);
+        let a = secp256k1_fn_reduce(&bytes_be_to_u64_le(&hash));
         if eq(&a, &ZERO_256) {
             return false;
         }
@@ -296,18 +214,8 @@ pub fn secp256k1_schnorr_batch_verify(
     // MSM batch equation: (Σ aᵢ·sᵢ)·G + Σ (-aᵢ)·Rᵢ + Σ (-aᵢ·eᵢ)·Pᵢ = O
     let mut s_total = s_vals[0];
     for i in 1..u {
-        let ai_si = secp256k1_fn_mul(
-            &coeffs[i],
-            &s_vals[i],
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        s_total = secp256k1_fn_add(
-            &s_total,
-            &ai_si,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let ai_si = secp256k1_fn_mul(&coeffs[i], &s_vals[i]);
+        s_total = secp256k1_fn_add(&s_total, &ai_si);
     }
 
     let mut msm_scalars = Vec::with_capacity(2 * u + 1);
@@ -319,22 +227,9 @@ pub fn secp256k1_schnorr_batch_verify(
     }
 
     for i in 0..u {
-        let neg_ai = secp256k1_fn_neg(
-            &coeffs[i],
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let ai_ei = secp256k1_fn_mul(
-            &coeffs[i],
-            &challenges[i],
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        let neg_ai_ei = secp256k1_fn_neg(
-            &ai_ei,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let neg_ai = secp256k1_fn_neg(&coeffs[i]);
+        let ai_ei = secp256k1_fn_mul(&coeffs[i], &challenges[i]);
+        let neg_ai_ei = secp256k1_fn_neg(&ai_ei);
 
         msm_scalars.push(neg_ai);
         msm_points.push(points_r[i]);
@@ -345,13 +240,7 @@ pub fn secp256k1_schnorr_batch_verify(
         }
     }
 
-    secp256k1_multi_scalar_mul(
-        &msm_scalars,
-        &msm_points,
-        #[cfg(feature = "hints")]
-        hints,
-    )
-    .is_none()
+    secp256k1_multi_scalar_mul(&msm_scalars, &msm_points).is_none()
 }
 
 /// C FFI for batch verification where all signatures share the same message.
@@ -370,7 +259,6 @@ pub(crate) unsafe fn secp256k1_schnorr_batch_verify_c(
     msg_len: usize,
     pk_xs: *const u8,
     sigs: *const u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> u8 {
     let msg_bytes: &[u8] =
         if msg_len == 0 { &[] } else { core::slice::from_raw_parts(msg, msg_len) };
@@ -404,14 +292,7 @@ pub(crate) unsafe fn secp256k1_schnorr_batch_verify_c(
         s_refs.push(&s_bufs[i]);
     }
 
-    if secp256k1_schnorr_batch_verify(
-        &msgs_refs,
-        &pk_refs,
-        &r_refs,
-        &s_refs,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if secp256k1_schnorr_batch_verify(&msgs_refs, &pk_refs, &r_refs, &s_refs) {
         0
     } else {
         1

--- a/ziskos/entrypoint/src/zisklib/lib/secp256r1/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/secp256r1/curve.rs
@@ -18,25 +18,13 @@ const G_POINT256: SyscallPoint256 = SyscallPoint256 { x: G_X, y: G_Y };
 /// It assumes that `p1` and `p2` are from the Secp256r1 curve, that `p1,p2 != 𝒪`
 /// Returns true if the result is the point at infinity.
 #[inline]
-fn secp256r1_add_non_infinity_points(
-    p1: &mut SyscallPoint256,
-    p2: &SyscallPoint256,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+fn secp256r1_add_non_infinity_points(p1: &mut SyscallPoint256, p2: &SyscallPoint256) -> bool {
     if p1.x != p2.x {
         let mut params = SyscallSecp256r1AddParams { p1, p2 };
-        syscall_secp256r1_add(
-            &mut params,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_secp256r1_add(&mut params);
         false
     } else if p1.y == p2.y {
-        syscall_secp256r1_dbl(
-            p1,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        syscall_secp256r1_dbl(p1);
         false
     } else {
         // p1 + (-p1) = 𝒪
@@ -46,44 +34,16 @@ fn secp256r1_add_non_infinity_points(
 
 /// Checks whether the given point `p` is on the Secp256r1 curve.
 /// It assumes that `p` is not the point at infinity.
-pub fn secp256r1_is_on_curve(p: &[u64; 8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> bool {
+pub fn secp256r1_is_on_curve(p: &[u64; 8]) -> bool {
     let x: [u64; 4] = p[0..4].try_into().unwrap();
     let y: [u64; 4] = p[4..8].try_into().unwrap();
 
     // p in E iff y² == x³ + a·x + b
-    let lhs = secp256r1_fp_square(
-        &y,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    let mut rhs = secp256r1_fp_square(
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = secp256r1_fp_mul(
-        &rhs,
-        &x,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = secp256r1_fp_add(
-        &rhs,
-        &secp256r1_fp_mul(
-            &x,
-            &E_A,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    rhs = secp256r1_fp_add(
-        &rhs,
-        &E_B,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let lhs = secp256r1_fp_square(&y);
+    let mut rhs = secp256r1_fp_square(&x);
+    rhs = secp256r1_fp_mul(&rhs, &x);
+    rhs = secp256r1_fp_add(&rhs, &secp256r1_fp_mul(&x, &E_A));
+    rhs = secp256r1_fp_add(&rhs, &E_B);
     eq(&lhs, &rhs)
 }
 
@@ -95,35 +55,19 @@ pub fn secp256r1_triple_scalar_mul_with_g(
     t: &[u64; 4],
     p: &[u64; 8],
     q: &[u64; 8],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> Option<[u64; 8]> {
     let p = SyscallPoint256 { x: [p[0], p[1], p[2], p[3]], y: [p[4], p[5], p[6], p[7]] };
     let q = SyscallPoint256 { x: [q[0], q[1], q[2], q[3]], y: [q[4], q[5], q[6], q[7]] };
 
     // Precompute g + p, g + q, p + q, g + p + q
     let mut gp = G_POINT256;
-    let gp_is_infinity = secp256r1_add_non_infinity_points(
-        &mut gp,
-        &p,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let gp_is_infinity = secp256r1_add_non_infinity_points(&mut gp, &p);
 
     let mut gq = G_POINT256;
-    let gq_is_infinity = secp256r1_add_non_infinity_points(
-        &mut gq,
-        &q,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let gq_is_infinity = secp256r1_add_non_infinity_points(&mut gq, &q);
 
     let mut pq = SyscallPoint256 { x: p.x, y: p.y };
-    let pq_is_infinity = secp256r1_add_non_infinity_points(
-        &mut pq,
-        &q,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let pq_is_infinity = secp256r1_add_non_infinity_points(&mut pq, &q);
 
     let (gpq, gpq_is_infinity) = if gp_is_infinity {
         // G + P = 𝒪, so G + P + Q = Q
@@ -134,12 +78,7 @@ pub fn secp256r1_triple_scalar_mul_with_g(
     } else {
         // Normal case: add Q to (G + P)
         let mut gpq_temp = SyscallPoint256 { x: gp.x, y: gp.y };
-        let is_inf = secp256r1_add_non_infinity_points(
-            &mut gpq_temp,
-            &q,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        let is_inf = secp256r1_add_non_infinity_points(&mut gpq_temp, &q);
         (gpq_temp, is_inf)
     };
 
@@ -156,13 +95,7 @@ pub fn secp256r1_triple_scalar_mul_with_g(
     // From here on, at least one of r,s,t is greater than 1
 
     // Hint the maximum length between the binary representations of r,s and t
-    let (max_limb, max_bit) = fcall_msb_pos_256_3(
-        r,
-        s,
-        t,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let (max_limb, max_bit) = fcall_msb_pos_256_3(r, s, t);
 
     // Perform the loop, based on the binary representation of r,s and t
 
@@ -286,11 +219,7 @@ pub fn secp256r1_triple_scalar_mul_with_g(
                 (0, 0, 0) => {
                     // If res is 𝒪, do nothing; otherwise, double
                     if !res_is_infinity {
-                        syscall_secp256r1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256r1_dbl(&mut res);
                     }
                 }
                 (0, 0, 1) => {
@@ -300,17 +229,8 @@ pub fn secp256r1_triple_scalar_mul_with_g(
                         res.y = q.y;
                         res_is_infinity = false;
                     } else {
-                        syscall_secp256r1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
-                        res_is_infinity = secp256r1_add_non_infinity_points(
-                            &mut res,
-                            &q,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256r1_dbl(&mut res);
+                        res_is_infinity = secp256r1_add_non_infinity_points(&mut res, &q);
                     }
 
                     // Update t_rec
@@ -323,17 +243,8 @@ pub fn secp256r1_triple_scalar_mul_with_g(
                         res.y = p.y;
                         res_is_infinity = false;
                     } else {
-                        syscall_secp256r1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
-                        res_is_infinity = secp256r1_add_non_infinity_points(
-                            &mut res,
-                            &p,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256r1_dbl(&mut res);
+                        res_is_infinity = secp256r1_add_non_infinity_points(&mut res, &p);
                     }
 
                     // Update s_rec
@@ -348,18 +259,9 @@ pub fn secp256r1_triple_scalar_mul_with_g(
                             res_is_infinity = false;
                         }
                     } else {
-                        syscall_secp256r1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256r1_dbl(&mut res);
                         if !pq_is_infinity {
-                            res_is_infinity = secp256r1_add_non_infinity_points(
-                                &mut res,
-                                &pq,
-                                #[cfg(feature = "hints")]
-                                hints,
-                            );
+                            res_is_infinity = secp256r1_add_non_infinity_points(&mut res, &pq);
                         }
                     }
 
@@ -374,17 +276,8 @@ pub fn secp256r1_triple_scalar_mul_with_g(
                         res.y = G_POINT256.y;
                         res_is_infinity = false;
                     } else {
-                        syscall_secp256r1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
-                        res_is_infinity = secp256r1_add_non_infinity_points(
-                            &mut res,
-                            &G_POINT256,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256r1_dbl(&mut res);
+                        res_is_infinity = secp256r1_add_non_infinity_points(&mut res, &G_POINT256);
                     }
 
                     // Update r_rec
@@ -399,18 +292,9 @@ pub fn secp256r1_triple_scalar_mul_with_g(
                             res_is_infinity = false;
                         }
                     } else {
-                        syscall_secp256r1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256r1_dbl(&mut res);
                         if !gq_is_infinity {
-                            res_is_infinity = secp256r1_add_non_infinity_points(
-                                &mut res,
-                                &gq,
-                                #[cfg(feature = "hints")]
-                                hints,
-                            );
+                            res_is_infinity = secp256r1_add_non_infinity_points(&mut res, &gq);
                         }
                     }
 
@@ -427,18 +311,9 @@ pub fn secp256r1_triple_scalar_mul_with_g(
                             res_is_infinity = false;
                         }
                     } else {
-                        syscall_secp256r1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256r1_dbl(&mut res);
                         if !gp_is_infinity {
-                            res_is_infinity = secp256r1_add_non_infinity_points(
-                                &mut res,
-                                &gp,
-                                #[cfg(feature = "hints")]
-                                hints,
-                            );
+                            res_is_infinity = secp256r1_add_non_infinity_points(&mut res, &gp);
                         }
                     }
 
@@ -455,18 +330,9 @@ pub fn secp256r1_triple_scalar_mul_with_g(
                             res_is_infinity = false;
                         }
                     } else {
-                        syscall_secp256r1_dbl(
-                            &mut res,
-                            #[cfg(feature = "hints")]
-                            hints,
-                        );
+                        syscall_secp256r1_dbl(&mut res);
                         if !gpq_is_infinity {
-                            res_is_infinity = secp256r1_add_non_infinity_points(
-                                &mut res,
-                                &gpq,
-                                #[cfg(feature = "hints")]
-                                hints,
-                            );
+                            res_is_infinity = secp256r1_add_non_infinity_points(&mut res, &gpq);
                         }
                     }
 

--- a/ziskos/entrypoint/src/zisklib/lib/secp256r1/ecdsa.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/secp256r1/ecdsa.rs
@@ -8,13 +8,7 @@ use super::{
 
 /// Verifies the signature (r, s) over the message hash z using the public key pk
 /// Returns true if the signature is valid, false otherwise
-pub fn secp256r1_ecdsa_verify(
-    pk: &[u64; 8],
-    z: &[u64; 4],
-    r: &[u64; 4],
-    s: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> bool {
+pub fn secp256r1_ecdsa_verify(pk: &[u64; 8], z: &[u64; 4], r: &[u64; 4], s: &[u64; 4]) -> bool {
     // r and s must be in the range [1, n-1]
     if is_zero(r) || gt(r, &N_MINUS_ONE) {
         return false;
@@ -34,11 +28,7 @@ pub fn secp256r1_ecdsa_verify(
     if gt(&pk_x, &P_MINUS_ONE) || gt(&pk_y, &P_MINUS_ONE) {
         return false;
     }
-    if !secp256r1_is_on_curve(
-        pk,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !secp256r1_is_on_curve(pk) {
         return false;
     }
 
@@ -49,55 +39,23 @@ pub fn secp256r1_ecdsa_verify(
     // and ensure that x ≡ r (mod n), saving us from expensive fn arithmetic
 
     // Hint the result
-    let point = fcall_secp256r1_ecdsa_verify(
-        pk,
-        z,
-        r,
-        s,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let point = fcall_secp256r1_ecdsa_verify(pk, z, r, s);
 
     // Check the recovered point is valid
     // Note: Identity point would be raised here
-    if !secp256r1_is_on_curve(
-        &point,
-        #[cfg(feature = "hints")]
-        hints,
-    ) {
+    if !secp256r1_is_on_curve(&point) {
         return false;
     }
 
     // Check that [z]G + [r]PK + [-s](x,y) == 𝒪
-    let neg_s = secp256r1_fn_neg(
-        s,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-    if secp256r1_triple_scalar_mul_with_g(
-        z,
-        r,
-        &neg_s,
-        pk,
-        &point,
-        #[cfg(feature = "hints")]
-        hints,
-    )
-    .is_some()
-    {
+    let neg_s = secp256r1_fn_neg(s);
+    if secp256r1_triple_scalar_mul_with_g(z, r, &neg_s, pk, &point).is_some() {
         return false;
     }
 
     // Check that x ≡ r (mod n)
     let point_x: [u64; 4] = [point[0], point[1], point[2], point[3]];
-    eq(
-        &secp256r1_fn_reduce(
-            &point_x,
-            #[cfg(feature = "hints")]
-            hints,
-        ),
-        r,
-    )
+    eq(&secp256r1_fn_reduce(&point_x), r)
 }
 
 // ==================== C FFI Functions ====================
@@ -113,7 +71,6 @@ pub(crate) unsafe fn secp256r1_ecdsa_verify_c(
     msg: *const u8,
     sig: *const u8,
     pk: *const u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> bool {
     let msg_bytes: &[u8; 32] = &*(msg as *const [u8; 32]);
     let sig_bytes: &[u8; 64] = &*(sig as *const [u8; 64]);
@@ -135,14 +92,7 @@ pub(crate) unsafe fn secp256r1_ecdsa_verify_c(
     let pk_y = bytes_be_to_u64_le(&pk_y_bytes);
 
     let pk: [u64; 8] = [pk_x[0], pk_x[1], pk_x[2], pk_x[3], pk_y[0], pk_y[1], pk_y[2], pk_y[3]];
-    secp256r1_ecdsa_verify(
-        &pk,
-        &z,
-        &r,
-        &s,
-        #[cfg(feature = "hints")]
-        hints,
-    )
+    secp256r1_ecdsa_verify(&pk, &z, &r, &s)
 }
 
 /// Convert big-endian bytes to little-endian u64 limbs (32 bytes -> [u64; 4])

--- a/ziskos/entrypoint/src/zisklib/lib/secp256r1/field.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/secp256r1/field.rs
@@ -2,49 +2,26 @@ use crate::syscalls::{syscall_arith256_mod, SyscallArith256ModParams};
 
 use super::constants::P;
 
-pub fn secp256r1_fp_add(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256r1_fp_add(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·1 + y
     let mut params =
         SyscallArith256ModParams { a: x, b: &[1, 0, 0, 0], c: y, module: &P, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
-pub fn secp256r1_fp_mul(
-    x: &[u64; 4],
-    y: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256r1_fp_mul(x: &[u64; 4], y: &[u64; 4]) -> [u64; 4] {
     // x·y + 0
     let mut params =
         SyscallArith256ModParams { a: x, b: y, c: &[0, 0, 0, 0], module: &P, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }
 
-pub fn secp256r1_fp_square(
-    x: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256r1_fp_square(x: &[u64; 4]) -> [u64; 4] {
     // x·x + 0
     let mut params =
         SyscallArith256ModParams { a: x, b: x, c: &[0, 0, 0, 0], module: &P, d: &mut [0, 0, 0, 0] };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
     *params.d
 }

--- a/ziskos/entrypoint/src/zisklib/lib/secp256r1/scalar.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/secp256r1/scalar.rs
@@ -5,10 +5,7 @@ use crate::{
 
 use super::constants::{N, N_MINUS_ONE};
 
-pub fn secp256r1_fn_reduce(
-    x: &[u64; 4],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> [u64; 4] {
+pub fn secp256r1_fn_reduce(x: &[u64; 4]) -> [u64; 4] {
     if lt(x, &N) {
         return *x;
     }
@@ -21,16 +18,12 @@ pub fn secp256r1_fn_reduce(
         module: &N,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     *params.d
 }
 
-pub fn secp256r1_fn_neg(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 4] {
+pub fn secp256r1_fn_neg(x: &[u64; 4]) -> [u64; 4] {
     // x·(-1) + 0
     let mut params = SyscallArith256ModParams {
         a: x,
@@ -39,11 +32,7 @@ pub fn secp256r1_fn_neg(x: &[u64; 4], #[cfg(feature = "hints")] hints: &mut Vec<
         module: &N,
         d: &mut [0, 0, 0, 0],
     };
-    syscall_arith256_mod(
-        &mut params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_arith256_mod(&mut params);
 
     *params.d
 }

--- a/ziskos/entrypoint/src/zisklib/lib/sha256.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/sha256.rs
@@ -8,7 +8,7 @@ const SHA256_INIT: [u32; 8] = [
 ];
 
 /// SHA-256 hash function. For reference: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub fn sha256(input: &[u8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u8; 32] {
+pub fn sha256(input: &[u8]) -> [u8; 32] {
     let mut state = SHA256_INIT;
     let input_len = input.len();
 
@@ -18,12 +18,7 @@ pub fn sha256(input: &[u8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [
         // Fast path: input is aligned, use directly
         while offset + 64 <= input_len {
             let block: &[u8; 64] = input[offset..offset + 64].try_into().unwrap();
-            compress_block(
-                &mut state,
-                block,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            compress_block(&mut state, block);
             offset += 64;
         }
     } else {
@@ -31,12 +26,7 @@ pub fn sha256(input: &[u8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [
         let mut aligned_block = [0u8; 64];
         while offset + 64 <= input_len {
             aligned_block.copy_from_slice(&input[offset..offset + 64]);
-            compress_block(
-                &mut state,
-                &aligned_block,
-                #[cfg(feature = "hints")]
-                hints,
-            );
+            compress_block(&mut state, &aligned_block);
             offset += 64;
         }
     }
@@ -57,31 +47,16 @@ pub fn sha256(input: &[u8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [
     // If remaining + 9 > 64, we need 2 blocks
     if remaining + 9 > 64 {
         // First block
-        compress_block(
-            &mut state,
-            &final_block,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        compress_block(&mut state, &final_block);
 
         // Second block
         final_block = [0u8; 64];
         final_block[56..64].copy_from_slice(&bit_len.to_be_bytes());
-        compress_block(
-            &mut state,
-            &final_block,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        compress_block(&mut state, &final_block);
     } else {
         // Single final block
         final_block[56..64].copy_from_slice(&bit_len.to_be_bytes());
-        compress_block(
-            &mut state,
-            &final_block,
-            #[cfg(feature = "hints")]
-            hints,
-        );
+        compress_block(&mut state, &final_block);
     }
 
     // Convert state to big-endian bytes
@@ -95,19 +70,11 @@ pub fn sha256(input: &[u8], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [
 
 /// Compress a single 64-byte block into the state
 #[inline]
-fn compress_block(
-    state: &mut [u32; 8],
-    block: &[u8; 64],
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+fn compress_block(state: &mut [u32; 8], block: &[u8; 64]) {
     let state_64: &mut [u64; 4] = unsafe { &mut *(state.as_mut_ptr() as *mut [u64; 4]) };
     let input_u64: &[u64; 8] = unsafe { &*(block.as_ptr() as *const [u64; 8]) };
     let mut sha256_params = SyscallSha256Params { state: state_64, input: input_u64 };
-    syscall_sha256_f(
-        &mut sha256_params,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    syscall_sha256_f(&mut sha256_params);
 }
 
 /// C-compatible wrapper for full SHA-256 hash
@@ -116,18 +83,9 @@ fn compress_block(
 /// - `input` must point to at least `input_len` bytes
 /// - `output` must point to a writable buffer of at least 32 bytes
 #[inline]
-pub(crate) unsafe fn sha256_c(
-    input: *const u8,
-    input_len: usize,
-    output: *mut u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) {
+pub(crate) unsafe fn sha256_c(input: *const u8, input_len: usize, output: *mut u8) {
     let input_slice = core::slice::from_raw_parts(input, input_len);
-    let hash = sha256(
-        input_slice,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let hash = sha256(input_slice);
     let output_slice = core::slice::from_raw_parts_mut(output, 32);
     output_slice.copy_from_slice(&hash);
 }

--- a/ziskos/entrypoint/src/zisklib/lib/zkvm_accelerators.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/zkvm_accelerators.rs
@@ -24,15 +24,8 @@ pub unsafe extern "C" fn zkvm_keccak256(
     data: *const u8,
     len: usize,
     output: *mut zkvm_keccak256_hash,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    super::keccak256_c(
-        data,
-        len,
-        (*output).data.as_mut_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    super::keccak256_c(data, len, (*output).data.as_mut_ptr());
     ZKVM_EOK
 }
 
@@ -42,15 +35,8 @@ pub unsafe extern "C" fn zkvm_sha256(
     data: *const u8,
     len: usize,
     output: *mut zkvm_sha256_hash,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    super::sha256_c(
-        data,
-        len,
-        (*output).data.as_mut_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    super::sha256_c(data, len, (*output).data.as_mut_ptr());
     ZKVM_EOK
 }
 
@@ -60,15 +46,8 @@ pub unsafe extern "C" fn zkvm_ripemd160(
     data: *const u8,
     len: usize,
     output: *mut zkvm_ripemd160_hash,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    super::ripemd160_c(
-        data,
-        len,
-        (*output).data.as_mut_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    super::ripemd160_c(data, len, (*output).data.as_mut_ptr());
     ZKVM_EOK
 }
 
@@ -82,19 +61,8 @@ pub unsafe extern "C" fn zkvm_modexp(
     modulus: *const u8,
     mod_len: usize,
     output: *mut u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    super::modexp_bytes_c(
-        base,
-        base_len,
-        exp,
-        exp_len,
-        modulus,
-        mod_len,
-        output,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    super::modexp_bytes_c(base, base_len, exp, exp_len, modulus, mod_len, output);
     ZKVM_EOK
 }
 
@@ -104,14 +72,11 @@ pub unsafe extern "C" fn zkvm_bn254_g1_add(
     p1: *const zkvm_bn254_g1_point,
     p2: *const zkvm_bn254_g1_point,
     result: *mut zkvm_bn254_g1_point,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
     let ret = super::bn254_g1_add_c(
         (*p1).data.as_ptr(),
         (*p2).data.as_ptr(),
         (*result).data.as_mut_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
     );
     if matches!(ret, bn254::G1_ADD_SUCCESS | bn254::G1_ADD_SUCCESS_INFINITY) {
         ZKVM_EOK
@@ -126,14 +91,11 @@ pub unsafe extern "C" fn zkvm_bn254_g1_mul(
     point: *const zkvm_bn254_g1_point,
     scalar: *const zkvm_bn254_scalar,
     result: *mut zkvm_bn254_g1_point,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
     let ret = super::bn254_g1_mul_c(
         (*point).data.as_ptr(),
         (*scalar).data.as_ptr(),
         (*result).data.as_mut_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
     );
     if matches!(ret, bn254::G1_MUL_SUCCESS | bn254::G1_MUL_SUCCESS_INFINITY) {
         ZKVM_EOK
@@ -148,14 +110,8 @@ pub unsafe extern "C" fn zkvm_bn254_pairing(
     pairs: *const zkvm_bn254_pairing_pair,
     num_pairs: usize,
     verified: *mut bool,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    let ret = super::bn254_pairing_check_c(
-        pairs as *const u8,
-        num_pairs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let ret = super::bn254_pairing_check_c(pairs as *const u8, num_pairs);
     match ret {
         bn254::PAIRING_CHECK_SUCCESS => {
             *verified = true;
@@ -177,7 +133,6 @@ pub unsafe extern "C" fn zkvm_blake2f(
     m: *const zkvm_blake2f_message,
     t: *const zkvm_blake2f_offset,
     f: u8,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
     super::blake2b_compress_c(
         rounds,
@@ -185,8 +140,6 @@ pub unsafe extern "C" fn zkvm_blake2f(
         (*m).data.as_ptr() as *const u64,
         (*t).data.as_ptr() as *const u64,
         f,
-        #[cfg(feature = "hints")]
-        hints,
     );
     ZKVM_EOK
 }
@@ -199,7 +152,6 @@ pub unsafe extern "C" fn zkvm_kzg_point_eval(
     y: *const zkvm_kzg_field_element,
     proof: *const zkvm_kzg_proof,
     verified: *mut bool,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
     // verify_kzg_proof_c takes (z, y, commitment, proof)
     *verified = super::verify_kzg_proof_c(
@@ -207,8 +159,6 @@ pub unsafe extern "C" fn zkvm_kzg_point_eval(
         (*y).data.as_ptr(),
         (*commitment).data.as_ptr(),
         (*proof).data.as_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
     );
     ZKVM_EOK
 }
@@ -219,14 +169,11 @@ pub unsafe extern "C" fn zkvm_bls12_g1_add(
     p1: *const zkvm_bls12_381_g1_point,
     p2: *const zkvm_bls12_381_g1_point,
     result: *mut zkvm_bls12_381_g1_point,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
     let ret = super::bls12_381_g1_add_c(
         (*result).data.as_mut_ptr(),
         (*p1).data.as_ptr(),
         (*p2).data.as_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
     );
     if matches!(ret, bls12_381::G1_ADD_SUCCESS | bls12_381::G1_ADD_SUCCESS_INFINITY) {
         ZKVM_EOK
@@ -241,15 +188,8 @@ pub unsafe extern "C" fn zkvm_bls12_g1_msm(
     pairs: *const zkvm_bls12_381_g1_msm_pair,
     num_pairs: usize,
     result: *mut zkvm_bls12_381_g1_point,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    let ret = super::bls12_381_g1_msm_c(
-        (*result).data.as_mut_ptr(),
-        pairs as *const u8,
-        num_pairs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let ret = super::bls12_381_g1_msm_c((*result).data.as_mut_ptr(), pairs as *const u8, num_pairs);
     if matches!(ret, bls12_381::G1_MSM_SUCCESS | bls12_381::G1_MSM_SUCCESS_INFINITY) {
         ZKVM_EOK
     } else {
@@ -263,14 +203,11 @@ pub unsafe extern "C" fn zkvm_bls12_g2_add(
     p1: *const zkvm_bls12_381_g2_point,
     p2: *const zkvm_bls12_381_g2_point,
     result: *mut zkvm_bls12_381_g2_point,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
     let ret = super::bls12_381_g2_add_c(
         (*result).data.as_mut_ptr(),
         (*p1).data.as_ptr(),
         (*p2).data.as_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
     );
     if matches!(ret, bls12_381::G2_ADD_SUCCESS | bls12_381::G2_ADD_SUCCESS_INFINITY) {
         ZKVM_EOK
@@ -285,15 +222,8 @@ pub unsafe extern "C" fn zkvm_bls12_g2_msm(
     pairs: *const zkvm_bls12_381_g2_msm_pair,
     num_pairs: usize,
     result: *mut zkvm_bls12_381_g2_point,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    let ret = super::bls12_381_g2_msm_c(
-        (*result).data.as_mut_ptr(),
-        pairs as *const u8,
-        num_pairs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let ret = super::bls12_381_g2_msm_c((*result).data.as_mut_ptr(), pairs as *const u8, num_pairs);
     if matches!(ret, bls12_381::G2_MSM_SUCCESS | bls12_381::G2_MSM_SUCCESS_INFINITY) {
         ZKVM_EOK
     } else {
@@ -307,14 +237,8 @@ pub unsafe extern "C" fn zkvm_bls12_pairing(
     pairs: *const zkvm_bls12_381_pairing_pair,
     num_pairs: usize,
     verified: *mut bool,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    let ret = super::bls12_381_pairing_check_c(
-        pairs as *const u8,
-        num_pairs,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let ret = super::bls12_381_pairing_check_c(pairs as *const u8, num_pairs);
     match ret {
         bls12_381::PAIRING_CHECK_SUCCESS => {
             *verified = true;
@@ -333,14 +257,9 @@ pub unsafe extern "C" fn zkvm_bls12_pairing(
 pub unsafe extern "C" fn zkvm_bls12_map_fp_to_g1(
     field_element: *const zkvm_bls12_381_fp,
     result: *mut zkvm_bls12_381_g1_point,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    let ret = super::bls12_381_fp_to_g1_c(
-        (*result).data.as_mut_ptr(),
-        (*field_element).data.as_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let ret =
+        super::bls12_381_fp_to_g1_c((*result).data.as_mut_ptr(), (*field_element).data.as_ptr());
     if ret == bls12_381::FP_TO_G1_SUCCESS {
         ZKVM_EOK
     } else {
@@ -353,14 +272,9 @@ pub unsafe extern "C" fn zkvm_bls12_map_fp_to_g1(
 pub unsafe extern "C" fn zkvm_bls12_map_fp2_to_g2(
     field_element: *const zkvm_bls12_381_fp2,
     result: *mut zkvm_bls12_381_g2_point,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    let ret = super::bls12_381_fp2_to_g2_c(
-        (*result).data.as_mut_ptr(),
-        (*field_element).data.as_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    let ret =
+        super::bls12_381_fp2_to_g2_c((*result).data.as_mut_ptr(), (*field_element).data.as_ptr());
     if ret == bls12_381::FP2_TO_G2_SUCCESS {
         ZKVM_EOK
     } else {
@@ -375,14 +289,11 @@ pub unsafe extern "C" fn zkvm_secp256r1_verify(
     sig: *const zkvm_secp256r1_signature,
     pubkey: *const zkvm_secp256r1_pubkey,
     verified: *mut bool,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
     *verified = super::secp256r1_ecdsa_verify_c(
         (*msg).data.as_ptr(),
         (*sig).data.as_ptr(),
         (*pubkey).data.as_ptr(),
-        #[cfg(feature = "hints")]
-        hints,
     );
     ZKVM_EOK
 }
@@ -394,15 +305,9 @@ pub unsafe extern "C" fn zkvm_secp256k1_verify(
     sig: *const zkvm_secp256k1_signature,
     pubkey: *const zkvm_secp256k1_pubkey,
     verified: *mut bool,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
-    *verified = super::secp256k1_ecdsa_verify_c(
-        sig as *const u8,
-        msg as *const u8,
-        pubkey as *const u8,
-        #[cfg(feature = "hints")]
-        hints,
-    );
+    *verified =
+        super::secp256k1_ecdsa_verify_c(sig as *const u8, msg as *const u8, pubkey as *const u8);
 
     ZKVM_EOK
 }
@@ -414,15 +319,12 @@ pub unsafe extern "C" fn zkvm_secp256k1_ecrecover(
     sig: *const zkvm_secp256k1_signature,
     recid: u8,
     output: *mut zkvm_secp256k1_pubkey,
-    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> zkvm_status {
     let ret = super::secp256k1_ecdsa_recover_c(
         sig as *const u8,
         recid,
         msg as *const u8,
         output as *mut u8,
-        #[cfg(feature = "hints")]
-        hints,
     );
 
     if ret == super::ECDSA_RECOVER_SUCCESS {
@@ -442,9 +344,7 @@ pub unsafe extern "C" fn zkvm_secp256k1_ecrecover(
 // doesn't exist) and signature mismatches (if the parameter or return types differ).
 // No types are written manually here — they are all derived from the generated source.
 //
-// Only applicable in the non-hints build (hints adds an extra parameter).
 // ---------------------------------------------------------------------------
-#[cfg(not(feature = "hints"))]
 #[allow(dead_code)]
 mod _interface_type_checks {
     use super::*;


### PR DESCRIPTION
Removes the threading of hints across many functions.

It seems that the word hints is used differently in two places:

- precompile input: The first usage logs the inputs to precompiles, this is logged into `HINT_BUFFER` and eventually saved to .bin file

- syscall output: The second is what this PR edits, its the output for the syscalls that are made. This is not saved to disk.

Example: If we were doing `sha256(a,b,c)`, we would save `a,b,c` to disk since its the precompile input. We would then save the output of the syscall `sha256f`. A single sha256 call can have many sha256f calls so we would actually save multiple permutation calls.

It may make sense to rename the usages of hint, if the above understanding is correct