### PR TITLE
fix: memory bug in assembly planner

### DIFF
--- a/core/src/zisk_rom_2_asm.rs
+++ b/core/src/zisk_rom_2_asm.rs
@@ -8351,6 +8351,10 @@ impl ZiskRom2Asm {
         let mut previous_size = 0;
 
         for (i, size) in load_sizes.iter().enumerate() {
+            if *size == 0 {
+                continue;
+            }
+
             // Store next aligned address value in mem_reads, and advance it
             *code += &format!(
                 "\tmov {REG_VALUE}, [{REG_ADDRESS} + {i}*8] {}\n",

--- a/precompiles/blake2/src/blake2_gen_mem_inputs.rs
+++ b/precompiles/blake2/src/blake2_gen_mem_inputs.rs
@@ -38,9 +38,7 @@ pub fn generate_blake2_mem_inputs<P: MemProcessor>(
 
     // Generate memory load params
     for iparam in 0..READ_PARAMS {
-        // let param_idx = if iparam >= DIRECT_READ_PARAM_POS { iparam + 1 } else { iparam };
         let param_idx = iparam + 1;
-
         let param_addr = data[OPERATION_PRECOMPILED_BUS_DATA_SIZE + param_idx] as u32;
         for ichunk in 0..PARAM_CHUNKS {
             MemBusHelpers::mem_aligned_read(


### PR DESCRIPTION
This pull request introduces a small bug fix and a minor code cleanup in the `core` and `precompiles/blake2` modules. The main functional change is a guard to skip processing when a load size is zero, preventing potential issues with zero-sized memory operations.

Fixes #903.