### PR TITLE
Fix: update function name in `zkvm_accelerators.rs`

### DIFF
--- a/ziskos/entrypoint/src/zisklib/lib/zkvm_accelerators.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/zkvm_accelerators.rs
@@ -1088,7 +1088,7 @@ pub unsafe extern "C" fn zkvm_secp256k1_verify(
 
             #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
             {
-                *verified = super::secp256k1_ecdsa_verify_c(
+                *verified = super::secp256k1_ecdsa_verify_bytes_c(
                     sig as *const u8,
                     msg as *const u8,
                     pubkey as *const u8,


### PR DESCRIPTION
Commit d80a5cd62 ("Adding k256 functions") renamed secp256k1_ecdsa_verify_c → secp256k1_ecdsa_verify_bytes_c in secp256k1/ecdsa.rs and updated one call site in zkvm_accelerators.rs, but missed a second call at line 1091 inside a #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))] block. That block is excluded from host builds, so the bug was invisible until cargo-zisk compiled for the zkvm target.