### PR TITLE
fix: bug in msb_pos_256 hint

### DIFF
--- a/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_256.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/msb_pos_256.rs
@@ -27,7 +27,7 @@ pub fn fcall_msb_pos_256(
         let (i, pos) = msb_pos_256(x, 1);
         #[cfg(feature = "hints")]
         {
-            hints.push(1);
+            hints.push(2);
             hints.push(i as u64);
             hints.push(pos as u64);
         }

--- a/ziskos/entrypoint/src/zisklib/fcalls/uint256/inv.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/uint256/inv.rs
@@ -32,6 +32,7 @@ pub fn fcall_uint256_inv(
                 hints.push(4);
                 hints.extend_from_slice(inv);
             } else {
+                hints.push(1);
                 hints.push(0);
             }
         }

--- a/ziskos/entrypoint/src/zisklib/fcalls/uint256/inv_mod.rs
+++ b/ziskos/entrypoint/src/zisklib/fcalls/uint256/inv_mod.rs
@@ -33,6 +33,7 @@ pub fn fcall_uint256_inv_mod(
                 hints.push(4);
                 hints.extend_from_slice(inv);
             } else {
+                hints.push(1);
                 hints.push(0);
             }
         }


### PR DESCRIPTION
This pull request makes a minor change to the hint values in the `fcall_msb_pos_256` function. Specifically, it updates the value pushed to the `hints` vector when the `hints` feature is enabled. 