### PR TITLE
Adding zkvm_init and zkvm_deinit

### DIFF
--- a/book/getting_started/hints_stream.md
+++ b/book/getting_started/hints_stream.md
@@ -327,36 +327,66 @@ As a result, for each `zisklib` function invocation, the `HintsProcessor` may ge
 
 ### 5.2 Initialize/Finalize Hint Stream
 
-To start hints generation from your guest program you must call one of the following functions from the `ziskos::hints` crate:
+When using the `ziskos::entrypoint!(main)` macro, hint generation is initialized and finalized **automatically** around your guest entry function. You only need to compile with `--cfg zisk_hints` (see [5.3](#53-enable-hints-at-compile-time)) and, optionally, set environment variables to control the output paths.
+
+The macro expands to roughly:
+
+```rust
+fn main() {
+    zkvm_init();         // initialize hints
+    super::ZISK_ENTRY();  // your guest entry function
+    zkvm_deinit();       // closes hints
+}
+```
+
+`zkvm_init` and `zkvm_deinit` are also exposed as `extern "C"` symbols so they can be called from C guest programs (see [5.7 Using Hints from C Guest Programs](#57-using-hints-from-c-guest-programs)).
+
+#### 5.2.1 Environment Variables
+
+| Variable           | Description                                            | Default            |
+|--------------------|--------------------------------------------------------|--------------------|
+| `ZISK_HINTS_OUTPUT`| Path to the hints binary file written by `zkvm_init`.  | `./tmp/hints.bin`  |
+| `ZISK_INPUT_FILE`  | Path to the input file consumed by `read_input_slice`. | `build/input.bin`  |
+
+The `./tmp/` directory is created automatically if it does not exist.
+
+#### 5.2.2 Manual API
+
+If you need finer control (e.g., streaming hints over a Unix socket, configuring a debug file, providing a synchronization signal to the host), call the lower-level functions directly instead of relying on the `entrypoint!` macro.
 
 ```rust
 pub fn init_hints_file(hints_file_path: PathBuf, ready: Option<oneshot::Sender<()>>) -> Result<()>
 ```
 
-This function stores the generated hints in the file specified by the `hints_file_path` parameter.
+Stores the generated hints in the file specified by `hints_file_path`.
 
 ```rust
-pub fn init_hints_socket(socket_path: PathBuf, debug_file: Option<PathBuf>, ready: Option<oneshot::Sender<()>>) -> Result<()>
+pub fn init_hints_socket(
+    socket_path: PathBuf,
+    debug_file: Option<PathBuf>,
+    write_flush_threshold: Option<usize>,
+    ready: Option<oneshot::Sender<()>>,
+) -> Result<()>
 ```
 
-This function sends the hints through the Unix socket specified by the `socket_path` parameter.
+Sends the hints through the Unix socket specified by `socket_path`.
 
-The optional `ready` parameter can be used for synchronization with the host when the guest program is executed in a separate thread to generate hints in parallel. It signals `ready` when the hints generation is ready to start writing hints through the Unix socket.
+- The optional `debug_file` stores a copy of the hints sent through the socket, useful for later debugging.
+- The optional `write_flush_threshold` controls the buffered-write flush size; `None` uses the default.
+- The optional `ready` parameter can be used for synchronization with the host when the guest is executed in a separate thread to generate hints in parallel. It signals `ready` when the writer is ready to start sending hints over the socket.
 
-The optional `debug_file` parameter can be used to store, in the specified file, a copy of the hints sent through the socket. This file can later be used for debugging purposes.
-
-To close hints generation you must call:
+To close hints generation:
 
 ```rust
 pub fn close_hints() -> Result<()>
 ```
 
-You should call these functions only when the guest is compiled for the native target used for hints generation. This can be achieved by placing the code under the following configuration flag:
+Place these calls under `#[cfg(zisk_hints)]` so they are only compiled into the native target used for hints generation:
 
 ```rust
 #[cfg(zisk_hints)]
 {
-    // Initialization/Finalize Hints generation code
+    // Initialization / finalization code
     ...
 }
 ```
@@ -373,7 +403,7 @@ Once the guest program is set up to generate hints for the native target, it mus
 RUSTFLAGS='--cfg zisk_hints' cargo build --release
 ```
 
-After compiling, executing the guest program will generate the hints binary file at the specified location (if `init_hints_file` was used) or start writing hints to the specified Unix socket (if `init_hints_socket` was used).
+After compiling, executing the guest program will generate the hints. By default — when relying on the `entrypoint!` macro — the binary file is written to `./tmp/hints.bin`; set `ZISK_HINTS_OUTPUT` to override the path. If you used the manual API instead, the file/socket location follows what was passed to `init_hints_file`/`init_hints_socket`.
 
 If a hints file was generated, it can be consumed using the `--hints` flag in the `cargo-zisk` commands that support hints (as explained in [Hints in CLI Execution](#2-hints-in-cli-execution)).
 
@@ -428,3 +458,35 @@ fn hint_custom(hint_id: u32, data_ptr: *const u8, data_len: usize, is_result: u8
 ```
 
 and following the same guidelines described for the built-in FFI hint helper functions.
+
+### 5.7 Using Hints from C Guest Programs
+
+The `ziskos` crate is published as both an `rlib` and a `staticlib`, so C guest programs can link against the resulting `.a` archive and call the hint lifecycle functions through the C ABI. Two symbols are exposed:
+
+```c
+extern void zkvm_init(void);
+extern void zkvm_deinit(void);
+```
+
+`zkvm_init` initializes the hint stream and `zkvm_deinit` finalizes it. They are no-ops when compiled without `--cfg zisk_hints`, so the same C code works for both native (hint generation) and zkVM target builds without modification.
+
+A minimal C guest program looks like:
+
+```c
+extern void zkvm_init(void);
+extern void zkvm_deinit(void);
+
+int main(void) {
+    zkvm_init();
+
+    // Guest logic, including any FFI hint calls
+    // (hint_sha256, hint_keccak256, hint_input_data, ...)
+
+    zkvm_deinit();
+    return 0;
+}
+```
+
+When linking the C guest against `ziskos` for native hint generation, the same environment variables described in [5.2.1](#521-environment-variables) (`ZISK_HINTS_OUTPUT`, `ZISK_INPUT_FILE`) control the file paths used by `zkvm_init` and the input reader.
+
+The FFI hint helper functions listed in [5.5 FFI Hints Helper Functions](#55-ffi-hints-helper-functions) are all `extern "C"` and use the same signatures from C — declare them with `extern` in your C source and link against the same `ziskos` archive.

--- a/ziskos/entrypoint/src/io.rs
+++ b/ziskos/entrypoint/src/io.rs
@@ -2,7 +2,9 @@
 //!
 //! This module provides a high-level API for reading inputs and committing public outputs.
 
-use crate::{read_input, set_output};
+#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+use crate::read_input;
+use crate::set_output;
 use serde::{de::DeserializeOwned, Serialize};
 
 /// Read a deserializable object from the input stream.

--- a/ziskos/entrypoint/src/lib.rs
+++ b/ziskos/entrypoint/src/lib.rs
@@ -55,6 +55,38 @@ pub fn hint_log<S: AsRef<str>>(msg: S) {
     }
 }
 
+#[cfg_attr(not(feature = "hints"), no_mangle)]
+#[cfg_attr(feature = "hints", export_name = "hints_zkvm_init")]
+pub extern "C" fn zkvm_init() {
+    #[cfg(all(
+        not(all(target_os = "zkvm", target_vendor = "zisk")),
+        zisk_hints,
+        feature = "user-hints"
+    ))]
+    {
+        let path =
+            std::env::var("ZISK_HINTS_OUTPUT").map(std::path::PathBuf::from).unwrap_or_else(|_| {
+                let dir = std::path::PathBuf::from("./tmp");
+                std::fs::create_dir_all(&dir).expect("failed to create tmp dir");
+                dir.join("hints.bin")
+            });
+        crate::hints::init_hints_file(path, None).expect("hints init failed");
+    }
+}
+
+#[cfg_attr(not(feature = "hints"), no_mangle)]
+#[cfg_attr(feature = "hints", export_name = "hints_zkvm_deinit")]
+pub extern "C" fn zkvm_deinit() {
+    #[cfg(all(
+        not(all(target_os = "zkvm", target_vendor = "zisk")),
+        zisk_hints,
+        feature = "user-hints"
+    ))]
+    {
+        crate::hints::close_hints().expect("hints close failed");
+    }
+}
+
 #[macro_export]
 macro_rules! entrypoint {
     ($path:path) => {
@@ -63,7 +95,9 @@ macro_rules! entrypoint {
         mod zkvm_generated_main {
             #[no_mangle]
             fn main() {
-                super::ZISK_ENTRY()
+                $crate::zkvm_init();
+                super::ZISK_ENTRY();
+                $crate::zkvm_deinit();
             }
         }
     };
@@ -93,6 +127,15 @@ static mut INPUT_POS: usize = INPUT_INITIAL_OFFSET;
 /// Reset the input position to the beginning.
 pub fn read_reset() {
     unsafe { INPUT_POS = INPUT_INITIAL_OFFSET };
+}
+
+#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+static NATIVE_INPUT: std::sync::Mutex<Option<Vec<u8>>> = std::sync::Mutex::new(None);
+
+#[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
+pub fn set_native_input(data: Vec<u8>) {
+    *NATIVE_INPUT.lock().unwrap() = Some(data);
+    read_reset();
 }
 
 /// Read a slice directly from INPUT_ADDR without copying (zero-copy).
@@ -138,40 +181,54 @@ pub(crate) fn read_slice_zerocopy<'a>() -> &'a [u8] {
     data_slice
 }
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
-pub(crate) fn read_input() -> Vec<u8> {
-    read_slice_zerocopy().to_vec()
-}
-
 #[cfg(not(all(target_os = "zkvm", target_vendor = "zisk")))]
 pub(crate) fn read_input() -> Vec<u8> {
-    use std::{
-        fs::File,
-        io::{Read, Seek, SeekFrom},
-    };
-
     let input_pos = unsafe { INPUT_POS };
 
-    let mut file =
-        File::open("build/input.bin").expect("Error opening input file at: build/input.bin");
+    let data = if let Some(buf) = NATIVE_INPUT.lock().unwrap().as_ref() {
+        let len_bytes: [u8; 8] = buf
+            .get(input_pos..input_pos + 8)
+            .expect("Failed to read length prefix from native input")
+            .try_into()
+            .unwrap();
+        let len = u64::from_le_bytes(len_bytes) as usize;
+        let data = buf
+            .get(input_pos + 8..input_pos + 8 + len)
+            .expect("Failed to read data from native input")
+            .to_vec();
+        let aligned_len = (len + 7) & !0x7;
+        unsafe { INPUT_POS = input_pos + 8 + aligned_len };
+        data
+    } else {
+        use std::{
+            fs::File,
+            io::{Read, Seek, SeekFrom},
+        };
 
-    // Seek to the current position
-    file.seek(SeekFrom::Start(input_pos as u64)).expect("Failed to seek in input file");
+        let path =
+            std::env::var("ZISK_INPUT_FILE").unwrap_or_else(|_| "build/input.bin".to_string());
 
-    // Read the 8-byte length prefix
-    let mut len_bytes = [0u8; 8];
-    file.read_exact(&mut len_bytes).expect("Failed to read length prefix from input file");
-    let len = u64::from_le_bytes(len_bytes) as usize;
+        let mut file = File::open(&path)
+            .unwrap_or_else(|e| panic!("Error opening input file at {}: {}", path, e));
 
-    // Read the actual data
-    let mut data = vec![0u8; len];
-    file.read_exact(&mut data).expect("Failed to read data from input file");
+        // Seek to the current position
+        file.seek(SeekFrom::Start(input_pos as u64)).expect("Failed to seek in input file");
 
-    // Advance INPUT_POS: 8 bytes for length + 8-byte aligned data
-    let aligned_len = (len + 7) & !0x7;
-    unsafe {
-        INPUT_POS = input_pos + 8 + aligned_len;
-    }
+        // Read the 8-byte length prefix
+        let mut len_bytes = [0u8; 8];
+        file.read_exact(&mut len_bytes).expect("Failed to read length prefix from input file");
+        let len = u64::from_le_bytes(len_bytes) as usize;
+
+        // Read the actual data
+        let mut data = vec![0u8; len];
+        file.read_exact(&mut data).expect("Failed to read data from input file");
+
+        // Advance INPUT_POS: 8 bytes for length + 8-byte aligned data
+        let aligned_len = (len + 7) & !0x7;
+        unsafe { INPUT_POS = input_pos + 8 + aligned_len };
+
+        data
+    };
 
     #[cfg(zisk_hints)]
     unsafe {


### PR DESCRIPTION
This PR contains 5 changes:

- Removes read_input for the zkvm + zisk target and fixes the corresponding import in io.rs
- Adds zkvm_init and zkvm_deinit so these functions can be used in C guest programs
- Wires these functions into the entrypoint! macro, so the user doesn't have to add them in the guest — they are inserted automatically when using ziskos::entrypoint!(main) and compiling with the zisk_hints flags
- Adds environment variables so we can specify the input file for native reads (instead of always using build/input.bin) and also specify the output file for hints
 - Adds a set_native_input call so that on native we can pass an in-memory region rather than only reading from a file
