### PR TITLE
Update ziskbook contents to match frontend refactor.

### DIFF
--- a/book/getting_started/distributed_execution.md
+++ b/book/getting_started/distributed_execution.md
@@ -159,14 +159,6 @@ The coordinator binds three default ports on startup:
 | 50051 | Worker-facing gRPC port. Workers connect here.              |
 | 9090  | Prometheus metrics endpoint and `/health` liveness probe.   |
 
-A healthy startup log shows three "listening on" lines:
-
-```
-INFO Starting ZisK Coordinator
-INFO server listening on 0.0.0.0:7000
-INFO metrics listening on 0.0.0.0:9090
-```
-
 If the coordinator exits with `Address already in use`, override the
 offending port:
 
@@ -184,7 +176,7 @@ cargo run --release --bin zisk-worker -- \
     --config distributed/deploy/config/worker.toml
 ```
 
-`dev.toml` points the worker at `http://127.0.0.1:50051`, advertises
+`worker.toml` points the worker at `http://127.0.0.1:50051`, advertises
 ten compute units, and sets the log level to debug. On a successful
 handshake:
 
@@ -267,18 +259,9 @@ The script:
 
 Verify the service:
 
-In Linux: 
-
 ```bash
 sudo systemctl status zisk-coordinator
-journalctl -u zisk-coordinator -f
-```
-
-In Macos:
-
-```bash
-sudo launchctl print system/com.zisk.coordinator 
-tail -f /var/log/zisk-coordinator/zisk-coordinator.log 
+sudo journalctl -u zisk-coordinator -f
 ```
 
 You should see the same two "listening on" lines from the
@@ -336,32 +319,39 @@ Edit `/etc/zisk/coordinator.toml`:
 
 After editing:
 
-In Linux:
-
 ```bash
 sudo systemctl restart zisk-coordinator
 ```
 
-In Macos:
-```bash
-sudo launchctl kickstart -k system/com.zisk.coordinator
-```
-
 ### Install workers
 
-On each worker host:
+Workers need the proving keys on local disk before they can start.
+On each worker host, download and extract them first:
 
 ```bash
-sudo distributed/deploy/scripts/worker/install.sh
+wget https://storage.googleapis.com/zisk-setup/zisk-provingkey-0.16.0.tar.gz
+tar -xzf zisk-provingkey-0.16.0.tar.gz
 ```
 
-The worker is now running with the default
-`http://127.0.0.1:50051` coordinator URL — it has nothing to talk to
-until you point it at your real coordinator.
+Then run the installer, pointing it at the extracted directory:
+
+```bash
+sudo distributed/deploy/scripts/worker/install.sh \
+    --proving-key /path/to/provingKey --gpu
+```
+
+If you skip `--proving-key`, the installer falls back to
+`/var/lib/zisk-worker/provingKey`; place (or symlink) the extracted
+keys there if you prefer the default. The --gpu flag can be ommited 
+if want to work with cpu.
+
+The worker starts immediately, but its default coordinator URL
+(`http://127.0.0.1:50051`) points at localhost — it will keep retrying
+this address until you redirect it to your real coordinator.
 
 #### Point the worker at the coordinator
 
-Edit `/etc/zisk/worker.toml`:
+Edit `/etc/zisk/worker.toml` and set the coordinator URL:
 
 ```toml
 [coordinator]
@@ -370,7 +360,7 @@ url = "http://<coordinator-host>:50051"
 
 ```bash
 sudo systemctl restart zisk-worker
-journalctl -u zisk-worker -f
+sudo journalctl -u zisk-worker -f
 ```
 
 Workers retry the connection every `reconnect_interval_seconds`
@@ -414,14 +404,10 @@ table.
 
 After editing:
 
-In Linux:
+* In Linux:
+
 ```bash
 sudo systemctl restart zisk-worker
-```
-
-In Macos:
-```bash
-sudo launchctl kickstart -k system/com.zisk.coordinator
 ```
 
 ### Add more workers
@@ -467,10 +453,10 @@ TOML:
 | ---                             | ---                   | ---                                      |
 | `--proving-key`                 | `~/.zisk/provingKey`  | Path to the proving-key folder           |
 | `--elf`                         | (none)                | Path to the ELF file                     |
-| `--hints`                       | `false`               | Enable precompile hints processing       |
 | `--shared-tables`               | `false`               | Share tables when running in a cluster   |
 | `--verify-constraints`          | `false`               | Verify constraints after witness gen     |
 | `-n`, `--number-threads-witness`| (none)                | Threads for witness computation          |
+| `-g`, `--gpu`                   | `false`               | Enable GPU mode (CUDA build only)        |
 | `-t`, `--max-streams`           | (none)                | Maximum GPU streams                      |
 
 CLI flags override the config file for one-off testing:

--- a/book/getting_started/distributed_execution.md
+++ b/book/getting_started/distributed_execution.md
@@ -1,561 +1,478 @@
-# Distributed Proving
+# Distributed Execution
 
-Generating a ZisK proof can be computationally intensive, especially for large programs. The distributed proving system lets you split the workload across multiple machines, reducing proof generation time by parallelizing the work.
+Generating a ZisK proof means proving the full execution trace of a
+program. For real workloads, that trace is too large and too slow to
+prove on a single machine. A ZisK cluster splits the trace into
+**segments**, proves each segment in parallel on separate machines,
+and aggregates the results into a single final proof. Throughput and
+latency scale with the number of machines you give it.
 
-This chapter covers how to set up and run a distributed proving cluster, from launching a coordinator to connecting workers and submitting proof requests.
+This guide covers the three things you need to run distributed
+proving: the cluster's architecture, a single-host quickstart that
+gets a job through the binaries, and the production path that
+deploys the same binaries on bare Linux hosts with systemd.
 
-## How It Works
+---
 
-A distributed proving cluster consists of two roles:
+## Architecture
 
-- A **Coordinator** that receives proof requests and orchestrates the work.
-- One or more **Workers** that execute the actual proof computation.
+A ZisK cluster is two binaries: a single `zisk-coordinator` and one
+or more `zisk-worker` instances.
 
-When you submit a proof request, the process unfolds in three phases:
+```mermaid
+flowchart TB
+    Host(["Host application<br/>RemoteClient"])
 
-1. **Partial Contributions** — The coordinator assigns segments of the work to available workers based on their compute capacity. Each worker computes its partial challenges independently.
-2. **Prove** — Workers compute the global challenge and generate their respective partial proofs.
-3. **Aggregation** — The first worker to finish is selected as the aggregator. It collects all partial proofs and produces the final proof.
+    subgraph Cluster["ZisK cluster"]
+        Coord["zisk-coordinator<br/>:7000  :50051  :9090"]
+        W1[zisk-worker 1]
+        W2[zisk-worker 2]
+        W3[zisk-worker 3]
+        Agg[Aggregation tree]
+    end
 
-The coordinator returns the final proof to the client once aggregation completes.
+    Out(["Final proof"])
 
-Workers report their compute capacity when they register. The coordinator selects workers sequentially from the available pool until the requested capacity is met. While assigned to a job, a worker is marked as busy and won't receive new tasks.
+    Host -->|"gRPC :7000 prove request"| Coord
+    Coord -->|assign segments| W1
+    Coord -->|assign segments| W2
+    Coord -->|assign segments| W3
+    W1 -->|segment proof| Agg
+    W2 -->|segment proof| Agg
+    W3 -->|segment proof| Agg
+    Agg --> Out
+    Out -->|return proof| Host
+```
 
-## Getting Started
+### The coordinator
 
-### Building
+The coordinator is the only stateful process in the cluster. It
+exposes a public gRPC interface that hosts use to submit proof
+requests, poll job status, and retrieve results. From the host's
+point of view, the coordinator is the only endpoint it ever talks
+to; workers are an invisible implementation detail.
 
-From the project root, build both binaries:
+Internally, the coordinator splits each job into segments, assigns
+them to workers, and returns the final proof. It also caches the
+proving keys derived from each uploaded guest ELF, so subsequent
+jobs for the same program skip the expensive setup step.
+
+### Workers
+
+Workers are the proving processes. Each worker connects outbound to
+the coordinator and waits for segment assignments. Workers are
+stateless across jobs, holding only the segments they are currently
+proving. You can add, remove, or restart them without touching the
+coordinator or losing cluster state.
+
+The first worker to send its partial proof to the coordinator is
+automatically promoted to aggregator for that job. The aggregator
+collects the remaining segment proofs and assembles the final proof,
+then returns it to the coordinator.
+
+### Proving pipeline
+
+Once a job is submitted, the coordinator selects workers from the
+available pool and runs three phases:
+
+1. **Partial contributions.** Each assigned worker processes its
+   segments and returns partial challenges. The coordinator collects
+   them and derives a single global challenge.
+2. **Prove.** The coordinator broadcasts the global challenge to all
+   workers. Each worker computes its partial proofs and returns
+   them.
+3. **Aggregation.** As partial proofs arrive, the coordinator builds
+   an opportunistic binary aggregation tree, folding proofs in as
+   they land. The first worker to deliver its partial proof is
+   promoted to aggregator and assembles the final proof.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant Coord as Coordinator
+    participant W as Workers
+
+    C->>Coord: prove(request)
+    Coord->>W: assign segments
+
+    Note over Coord,W: Phase 1: Partial contributions
+    W->>Coord: partial challenges
+
+    Note over Coord,W: Phase 2: Prove
+    Coord->>W: global challenge
+    W->>Coord: partial proofs
+
+    Note over Coord,W: Phase 3: Aggregation
+    Note over W: First worker to reply<br/>becomes aggregator
+    Coord->>W: aggregate
+    W->>Coord: final proof
+    Coord->>C: return proof
+```
+
+---
+
+## Quickstart: single-host cluster
+
+This brings up one coordinator and one worker on the same machine,
+then submits a real proving job. It is the smallest deployment that
+exercises the production binaries end-to-end.
+
+### Prerequisites
+
+- Linux x86_64
+- Rust toolchain (`cargo --version` should work)
+- ~32 GB free RAM (Assembly emulator preallocates large shared regions)
+
+Clone the repo:
+
+```bash
+git clone https://github.com/0xPolygonHermez/zisk.git
+cd zisk
+```
+
+### Build the binaries
 
 ```bash
 cargo build --release --bin zisk-coordinator --bin zisk-worker
 ```
 
-### Running Locally
+The first build takes several minutes. The output binaries land at:
 
-**1. Start the coordinator:**
+```
+target/release/zisk-coordinator
+target/release/zisk-worker
+```
+
+These are the same binaries used in every later deployment.
+
+### Start the coordinator
 
 ```bash
 cargo run --release --bin zisk-coordinator
 ```
 
-**2. Start a worker** (in a separate terminal):
+The coordinator binds three default ports on startup:
 
-```bash
-cargo run --release --bin zisk-worker -- --elf <elf-file-path> --inputs-folder <inputs-folder>
+| Port  | Purpose                                                     |
+| ---   | ---                                                         |
+| 7000  | Client-facing gRPC API. Host applications connect here.     |
+| 50051 | Worker-facing gRPC port. Workers connect here.              |
+| 9090  | Prometheus metrics endpoint and `/health` liveness probe.   |
+
+A healthy startup log shows three "listening on" lines:
+
+```
+INFO Starting ZisK Coordinator
+INFO server listening on 0.0.0.0:7000
+INFO worker port listening on 0.0.0.0:50051
+INFO metrics listening on 0.0.0.0:9090
 ```
 
-**3. Submit a proof request** (in a separate terminal):
+If the coordinator exits with `Address already in use`, override the
+offending port:
 
 ```bash
-cargo run --release --bin zisk-coordinator prove --inputs-uri <input-filename> --compute-capacity 10
+cargo run --release --bin zisk-coordinator -- \
+    --api-port 8000 --cluster-port 60000 --metrics-port 5245
 ```
 
-The `--compute-capacity` flag specifies how many compute units the proof requires. The coordinator assigns workers until this capacity is covered.
+### Start a worker
 
-### Docker Deployment
-
-For multi-machine setups, Docker simplifies deployment:
+In a second terminal:
 
 ```bash
-# Build coordinator + worker images (CPU-only)
-docker build -t zisk-coordinator:latest -f distributed/deploy/docker/Dockerfile.coordinator .
-docker build -t zisk-worker:latest      -f distributed/deploy/docker/Dockerfile.worker      .
-
-# Build the worker image with GPU support
-docker build --build-arg GPU=true -t zisk-worker:gpu -f distributed/deploy/docker/Dockerfile.worker .
-
-# Create a network for container DNS resolution
-docker network create zisk-net || true
+cargo run --release --bin zisk-worker -- \
+    --config distributed/crates/worker/config/dev.toml
 ```
 
-**Start the coordinator:**
+`dev.toml` points the worker at `http://127.0.0.1:50051`, advertises
+ten compute units, and sets the log level to debug. On a successful
+handshake:
+
+```
+INFO connecting to coordinator http://127.0.0.1:50051
+INFO registered as worker <random-uuid> (capacity 10)
+INFO heartbeat ok
+```
+
+The coordinator logs the matching side:
+
+```
+INFO worker registered: <uuid> capacity=10
+```
+
+### Health check
 
 ```bash
-LOGS_DIR="<logs-folder>"
-docker run -d --rm --name zisk-coordinator \
-  --network zisk-net \
-  -v "$LOGS_DIR:/var/log/distributed" \
-  -e RUST_LOG=info \
-  zisk-distributed:latest \
-  zisk-coordinator --config /app/config/coordinator/dev.toml
+curl http://127.0.0.1:9090/health
 ```
 
-**Start a worker:**
+A healthy coordinator returns `200 OK` with an empty body.
+
+### Submit a proving job
+
+Any compiled ZisK guest works. The host program below talks to the
+**remote** prover:
+
+```rust
+use zisk_sdk::{GuestProgram, ProverClient, ZiskStdin, load_program};
+
+static PROGRAM: GuestProgram = load_program!("guest");
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
+
+    client.setup(&PROGRAM).run()?.await?;
+
+    let mut stdin = ZiskStdin::new();
+    stdin.write(&"Hello Zisk".to_string());
+
+    let proof = client.prove(&PROGRAM, stdin).run()?.await?;
+    proof.verify()?;
+
+    let digest: [u8; 32] = proof.get_publics().read()?;
+    println!("verified digest = 0x{}", hex::encode(digest));
+    Ok(())
+}
+```
 
 ```bash
-LOGS_DIR="<logs-folder>"
-PROVING_KEY_DIR="<provingKey-folder>"
-ELF_DIR="<elf-folder>"
-INPUTS_DIR="<inputs-folder>"
-docker run -d --rm --name zisk-worker-1 \
-  --network zisk-net --shm-size=20g \
-  -v "$LOGS_DIR:/var/log/distributed" \
-  -v "$HOME/.zisk/cache:/app/.zisk/cache:ro" \
-  -v "$PROVING_KEY_DIR:/app/proving-keys:ro" \
-  -v "$ELF_DIR:/app/elf:ro" \
-  -v "$INPUTS_DIR:/app/inputs:ro" \
-  -e RUST_LOG=info \
-  zisk-distributed:latest zisk-worker --coordinator-url http://zisk-coordinator:50051 \
-    --elf /app/elf/zec.elf --proving-key /app/proving-keys --inputs-folder /app/inputs
+cargo run --release
 ```
 
-**Submit a proof:**
+The host uploads the ELF, the coordinator splits the job into
+segments and hands them to the worker, the worker produces STARK
+proofs, and the coordinator aggregates them into a final proof.
+Verification runs locally in milliseconds.
+
+---
+
+## Deployment on Linux
+
+This section deploys the same two binaries on bare Linux hosts under
+systemd, the canonical path for a ZisK cluster.
+
+### Prerequisites
+
+- One Linux host with `sudo` for the coordinator
+- One or more Linux hosts with `sudo` for workers, each with 64 GB
+  RAM (Assembly emulator) or 32 GB (Rust emulator)
+- Every worker must reach the coordinator; keep all hosts on the
+  same private network for low coordinator/worker latency
+
+Clone the repo on every host:
 
 ```bash
-docker exec -it zisk-coordinator \
-  zisk-coordinator prove --inputs-uri <input-filename> --compute-capacity 10
+git clone https://github.com/0xPolygonHermez/zisk.git
+cd zisk
 ```
 
-> **Note:** Use the filename only when submitting proofs, not the full path. Workers resolve files relative to their `--inputs-folder`.
+### Install the coordinator
 
-**Container paths reference:**
-
-| Path | Purpose |
-|------|---------|
-| `/app/config/{coordinator,worker}/` | Configuration files |
-| `/app/bin/` | Binaries |
-| `/app/.zisk/cache/` | Cache (mount from host `$HOME/.zisk/cache`) |
-| `/var/log/distributed/` | Log files |
-
-## Coordinator
-
-The coordinator is responsible for managing the distributed proof generation process. It receives proof requests from clients and assigns work to available workers.
-
-To start a coordinator instance with default settings:
+On the coordinator host:
 
 ```bash
-cargo run --release --bin zisk-coordinator
+sudo distributed/crates/coordinator-server/scripts/install.sh
 ```
 
-### Coordinator Configuration
+The script:
 
-The coordinator can be configured using either a **TOML configuration file** or **command-line arguments**.
-If no configuration file is explicitly provided, the system falls back to the `ZISK_COORDINATOR_CONFIG_PATH` environment variable to locate one. If neither the CLI argument nor environment variable is set, built-in defaults are used.
+- Creates the `zisk-coordinator` system user
+- Drops the binary at `/usr/local/bin/zisk-coordinator`
+- Writes the config at `/etc/zisk/coordinator.toml` (mode `640`)
+- Creates the working directory at `/var/lib/zisk`
+- Installs the systemd unit and runs `systemctl enable --now`
 
-**Example:**
+Verify the service:
 
 ```bash
-# You can specify the configuration file path using a command line argument:
-cargo run --release --bin zisk-coordinator -- --config /path/to/my-config.toml
-
-# You can specify the configuration file path using an environment variable:
-export ZISK_COORDINATOR_CONFIG_PATH="/path/to/my-config.toml"
-cargo run --release --bin zisk-coordinator
+sudo systemctl status zisk-coordinator
+journalctl -u zisk-coordinator -f
 ```
 
-The table below lists the available configuration options for the Coordinator:
+You should see the same three "listening on" lines from the
+quickstart. If the service is `failed`, journalctl shows the
+underlying error (most often a port conflict or missing config
+field).
 
-| TOML Key              | CLI Argument     | Environment Variable| Type | Default | Description |
-|-----------------------|--------------|---------------------|------|---------|-------------|
-| `service.name` | - | - | String | ZisK Distributed Coordinator | Service name |
-| `service.environment` | - | - | String | development | Service environment (development, staging, production) |
-| `server.host` | - | - | String | 0.0.0.0 | Server host |
-| `server.port` | `--port` | - | Number | 50051 | Server port |
-| `server.proofs_dir` | `--proofs-dir` | - | String | proofs | Directory to save generated proofs (conflicts with `--no-save-proofs`) |
-| - | `--no-save-proofs` | - | Boolean | false | Disable saving proofs (conflicts with `--proofs-dir`) |
-| - | `-c`, `--compressed-proofs` | - | Boolean | false | Generate compressed proofs |
-| `server.shutdown_timeout_seconds` | - | - | Number | 30 | Graceful shutdown timeout in seconds |
-| `logging.level` | - | RUST_LOG | String | debug | Logging level (error, warn, info, debug, trace) |
-| `logging.format` | - | - | String | pretty | Logging format (pretty, json, compact) |
-| `logging.file_path` | - | - | String | - | *Optional*. Log file path (enables file logging) |
-| `coordinator.max_workers_per_job` | - | - | Number | 10 | Maximum workers per proof job |
-| `coordinator.max_total_workers` | - | - | Number | 1000 | Maximum total registered workers |
-| `coordinator.phase1_timeout_seconds` | - | - | Number | 300 | Phase 1 timeout in seconds |
-| `coordinator.phase2_timeout_seconds` | - | - | Number | 600 | Phase 2 timeout in seconds |
-| `coordinator.reconnect_grace_period_ms` | - | - | Number | 500 | Grace period (ms) before failing a disconnected computing worker's job. Increase for cross-datacenter deployments. |
-| `coordinator.webhook_url` | `--webhook-url` | - | String | - | *Optional*. Webhook URL to notify on job completion |
+#### Configure the coordinator
 
+Every setting is optional; the binary falls back to a built-in
+default for anything you leave out.
 
-#### Configuration Files examples
+Override precedence (later wins): built-in defaults → config file →
+`ZISK_COORDINATOR_*` environment variables → CLI flags.
 
-Example development configuration file:
+Edit `/etc/zisk/coordinator.toml`:
+
+**`[service]`** — coordinator identity.
+
+| Setting       | Default              | Notes                                                            |
+| ---           | ---                  | ---                                                              |
+| `name`        | `"ZisK Coordinator"` | Shown in logs and status output.                                 |
+| `environment` | `development`        | One of `development`, `staging`, `production`. Use `production`. |
+
+**`[server]`** — client-facing gRPC API.
+
+| Setting                     | Default     | Notes                                                                  |
+| ---                         | ---         | ---                                                                    |
+| `host`                      | `0.0.0.0`   | Listen address. Bind to a specific interface to restrict access.       |
+| `port`                      | `7000`      | Client gRPC port. CLI: `--api-port`, env: `ZISK_COORDINATOR_API_PORT`. |
+| `shutdown_timeout_seconds`  | `30`        | Drain time after a shutdown signal before forced exit.                 |
+
+**`[coordinator]`** — worker-facing port and core tuning.
+
+| Setting       | Default | Notes                                                                       |
+| ---           | ---     | ---                                                                         |
+| `port`        | `50051` | Worker gRPC port. CLI: `--cluster-port`, env: `ZISK_COORDINATOR_CLUSTER_PORT`. |
+| `config_file` | (none)  | Optional path to a coordinator-core tuning file.                            |
+
+**`[metrics]`** — Prometheus endpoint.
+
+| Setting   | Default   | Notes                                                                     |
+| ---       | ---       | ---                                                                       |
+| `enabled` | `true`    | Set `false` to disable `/metrics`. `/health` stays available either way.  |
+| `host`    | `0.0.0.0` | Listen address for the scrape endpoint.                                   |
+| `port`    | `9090`    | Scrape port. CLI: `--metrics-port`, env: `ZISK_COORDINATOR_METRICS_PORT`. |
+
+**`[logging]`** — what gets logged and where.
+
+| Setting     | Default  | Notes                                                                              |
+| ---         | ---      | ---                                                                                |
+| `level`     | `info`   | `trace`, `debug`, `info`, `warn`, `error`. `RUST_LOG` takes precedence.            |
+| `format`    | `pretty` | `pretty`, `json` (production aggregators), or `compact`.                           |
+| `file_path` | (none)   | Rotating daily log file. Leave unset on systemd hosts; journald captures stdout.   |
+
+After editing:
+
+```bash
+sudo systemctl restart zisk-coordinator
+```
+
+### Install workers
+
+On each worker host:
+
+```bash
+sudo distributed/crates/worker/scripts/install.sh
+```
+
+The worker is now running with the default
+`http://127.0.0.1:50051` coordinator URL — it has nothing to talk to
+until you point it at your real coordinator.
+
+#### Point the worker at the coordinator
+
+Edit `/etc/zisk/worker.toml`:
 
 ```toml
-[service]
-name = "ZisK Distributed Coordinator"
-environment = "development"
-
-[logging]
-level = "debug"
-format = "pretty"
-```
-
-Example production configuration file:
-
-```toml
-[service]
-name = "ZisK Distributed Coordinator"  
-environment = "production"
-
-[server]
-host = "0.0.0.0"
-port = 50051
-proofs_dir = "proofs"
-
-[logging]
-level = "info"
-format = "json"
-file_path = "/var/log/distributed/coordinator.log"
-
 [coordinator]
-max_workers_per_job = 20      # Maximum workers per proof job
-max_total_workers = 5000      # Maximum total registered workers  
-phase1_timeout_seconds = 600  # 10 minutes for phase 1
-phase2_timeout_seconds = 1200 # 20 minutes for phase 2
-webhook_url = "http://webhook.example.com/notify?job_id={$job_id}"
+url = "http://<coordinator-host>:50051"
 ```
-
-### Webhook URL
-
-The Coordinator can notify an external service when a job finishes by sending a request to a configured webhook URL.
-The placeholder {$job_id} can be included in the URL and will be replaced with the finished job’s ID.
-If no placeholder is provided, the Coordinator automatically appends /{job_id} to the end of the URL.
-
-All webhook notifications are sent as JSON POST requests with the following structure:
-
-```json
-{
-  "job_id": "job_12345",
-  "success": true,
-  "duration_ms": 45000,
-  "proof": <array of u64...>,
-  "timestamp": "2025-10-03T14:30:00Z",
-  "error": null
-}
-```
-
-##### Fields Description
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `job_id` | `string` | Unique identifier for the proof generation job |
-| `success` | `boolean` | `true` if proof generation completed successfully, `false` if it failed |
-| `duration_ms` | `number` | Total execution time in milliseconds from job start to completion |
-| `proof` | `array<u64>` \| `null` | Final proof data as array of integers (only present on success) |
-| `timestamp` | `string` | ISO 8601 timestamp when the notification was sent |
-| `error` | `object` \| `null` | Error details (only present on failure) |
-
-##### Error Object Structure
-
-When `success` is `false`, the `error` field contains:
-
-```json
-{
-  "code": "WORKER_FAILURE",
-  "message": "Worker node-003 failed during proof generation: Out of memory"
-}
-```
-
-**Successful Proof Generation Example:**
-
-```json
-{
-  "job_id": "job_abc123",
-  "success": true,
-  "duration_ms": 32500,
-  "proof": [1234567890, 9876543210, 1357924680, ...],
-  "timestamp": "2025-10-03T14:30:25Z",
-  "error": null
-}
-```
-
-**Failed Job Example:**
-
-```json
-{
-  "job_id": "job_def456",
-  "success": false,
-  "duration_ms": 15000,
-  "proof": null,
-  "timestamp": "2025-10-03T14:31:10Z",
-  "error": {
-    "code": "WORKER_ERROR",
-    "message": "Memory exhaustion during proof generation"
-  }
-}
-```
-
-#### Webhook Implementation Guidelines
-
-*HTTP Requirements:*
-
-- **Method**: POST
-- **Content-Type**: `application/json`
-- **Timeout**: 10 seconds (configurable)
-- **Retry**: Currently no automatic retries (implement idempotency)
-
-*Recommended Response:*
-
-Your webhook endpoint should respond with:
-
-- **Success**: HTTP 200-299 status code
-- **Body**: Any valid response (ignored by coordinator)
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{"received": true, "job_id": "job_abc123"}
-```
-
-If your webhook endpoint is unavailable or returns an error:
-
-- The coordinator logs the failure but continues operation
-- No automatic retries are performed
-- Consider implementing your own retry mechanism or message queue
-
-### Command Line Arguments
 
 ```bash
-# Show help
-cargo run --release --bin zisk-coordinator -- --help
-
-# Run coordinator with custom port
-cargo run --release --bin zisk-coordinator -- --port 50051
-
-# Run with specific configuration
-cargo run --release --bin zisk-coordinator -- --config production.toml
-
-# Run with webhook URL  
-cargo run --release --bin zisk-coordinator -- --webhook-url http://webhook.example.com/notify --port 50051
+sudo systemctl restart zisk-worker
+journalctl -u zisk-worker -f
 ```
 
-## Worker
+Workers retry the connection every `reconnect_interval_seconds`
+(default 5) until the coordinator answers. Start order does not
+matter.
 
-The worker is responsible for executing proof generation tasks assigned by the coordinator. It registers with the coordinator, reports its compute capacity, and waits for tasks to be assigned.
+#### Configure the worker
 
-To start a worker instance with default settings:
+Annotated example: `distributed/crates/worker/config/prod.toml`.
+
+Override precedence: built-in defaults → config file →
+`ZISK_WORKER__*` environment variables (double underscore as table
+separator) → CLI flags.
+
+Edit `/etc/zisk/worker.toml`:
+
+**`[worker]`** — identity, capacity, on-disk location.
+
+| Setting                          | Default                        | Notes                                                                                                                |
+| ---                              | ---                            | ---                                                                                                                  |
+| `worker_id`                      | random UUID                    | Pin to e.g. the hostname so log correlation works at scale.                                                          |
+| `compute_capacity.compute_units` | `10`                           | Start at one unit per physical CPU core (minus two for OS overhead), plus one per GPU stream.                        |
+| `environment`                    | `development`                  | `development` or `production`.                                                                                       |
+| `inputs_folder`                  | `/var/lib/zisk-worker/inputs`  | Where the worker writes intermediate input files. Override only for a faster disk or separate partition.             |
+
+**`[coordinator]`** — registration target.
+
+| Setting | Default                    | Notes                                              |
+| ---     | ---                        | ---                                                |
+| `url`   | `http://127.0.0.1:50051`   | gRPC URL of the coordinator's worker-facing port.  |
+
+**`[connection]`** — reaction to network trouble.
+
+| Setting                      | Default | Notes                                                                |
+| ---                          | ---     | ---                                                                  |
+| `reconnect_interval_seconds` | `5`     | Backoff between reconnect attempts when the coordinator is unreachable. |
+| `heartbeat_timeout_seconds`  | `30`    | How long to wait for a heartbeat before treating the connection dead.   |
+
+**`[logging]`** — same shape as the coordinator's `[logging]`
+table.
+
+After editing:
 
 ```bash
-cargo run --release --bin zisk-worker -- --elf <elf-file-path> --inputs-folder <inputs-folder>
+sudo systemctl restart zisk-worker
 ```
 
-### Worker Configuration
+### Add more workers
 
-The worker can be configured using either a **TOML configuration file** or **command-line arguments**.
-If no configuration file is explicitly provided, the system falls back to the `ZISK_WORKER_CONFIG_PATH` environment variable to locate one. If neither the CLI argument nor environment variable is set, built-in defaults are used.
+Run the install script on as many hosts as you want. All workers
+register against the same coordinator and receive work proportional
+to their advertised capacity.
 
-**Example:**
+```mermaid
+flowchart TB
+    subgraph App["Application host"]
+        AP["host program<br/>RemoteClient"]
+    end
+
+    subgraph H1["Coordinator host"]
+        C["zisk-coordinator<br/>:7000  :50051  :9090"]
+    end
+
+    subgraph H2["Worker host A (32 units)"]
+        WA[zisk-worker]
+    end
+
+    subgraph H3["Worker host B (32 units)"]
+        WB[zisk-worker]
+    end
+
+    subgraph H4["Worker host C (16 units)"]
+        WC[zisk-worker]
+    end
+
+    AP -->|":7000"| C
+    WA -->|":50051"| C
+    WB -->|":50051"| C
+    WC -->|":50051"| C
+```
+
+### CLI references
+
+A handful of operational knobs are CLI-only and not exposed in the
+TOML:
+
+| Flag                            | Default               | Description                              |
+| ---                             | ---                   | ---                                      |
+| `--proving-key`                 | `~/.zisk/provingKey`  | Path to the proving-key folder           |
+| `--elf`                         | (none)                | Path to the ELF file                     |
+| `--hints`                       | `false`               | Enable precompile hints processing       |
+| `--shared-tables`               | `false`               | Share tables when running in a cluster   |
+| `--verify-constraints`          | `false`               | Verify constraints after witness gen     |
+| `-n`, `--number-threads-witness`| (none)                | Threads for witness computation          |
+| `-t`, `--max-streams`           | (none)                | Maximum GPU streams                      |
+
+CLI flags override the config file for one-off testing:
 
 ```bash
-# You can specify the configuration file path using a command line argument:
-cargo run --release --bin zisk-worker -- --config /path/to/my-config.toml
-
-# You can specify the configuration file path using an environment variable:
-export ZISK_WORKER_CONFIG_PATH="/path/to/my-config.toml"
-cargo run --release --bin zisk-worker
-```
-
-### Input Files Handling
-
-Workers need to know where to find input files for proof generation. The `--inputs-folder` parameter specifies the base directory where input files are stored:
-
-- **Default**: Current working directory (`.`) if not specified
-- **Usage**: When the coordinator sends a prove command with an input filename, the worker combines `--inputs-folder` + `filename` to locate the file
-- **Benefits**: Allows input files to be organized in a dedicated directory, separate from the worker executable
-
-**Example:**
-```bash
-# Worker with inputs in specific folder
-cargo run --release --bin zisk-worker -- --elf program.elf --inputs-folder /data/inputs/
-
-# Coordinator requests proof for "input.bin" -> Worker looks for "/data/inputs/input.bin"
-cargo run --release --bin zisk-coordinator -- prove --inputs-uri input.bin --compute-capacity 10
-```
-
-The table below lists the available configuration options for the Worker:
-
-| TOML Key              | CLI Argument     | Environment Variable| Type | Default | Description |
-|-----------------------|--------------|---------------------|------|---------|-------------|
-| `worker.worker_id` | `--worker-id` | - | String | Auto-generated UUID | Unique worker identifier |
-| `worker.compute_capacity.compute_units` | `--compute-capacity` | - | Number | 10 | Worker compute capacity (in compute units) |
-| `worker.environment` | - | - | String | development | Service environment (development, staging, production) |
-| `worker.inputs_folder` | `--inputs-folder` | - | String | . | Path to folder containing input files |
-| `coordinator.url` | `--coordinator-url` | - | String | http://127.0.0.1:50051 | Coordinator server URL |
-| `connection.reconnect_interval_seconds` | - | - | Number | 5 | Reconnection interval in seconds |
-| `connection.heartbeat_timeout_seconds` | - | - | Number | 30 | Heartbeat timeout in seconds |
-| `logging.level` | - | RUST_LOG | String | debug | Logging level (error, warn, info, debug, trace) |
-| `logging.format` | - | - | String | pretty | Logging format (pretty, json, compact) |
-| `logging.file_path` | - | - | String | - | *Optional*. Log file path (enables file logging) |
-| - | `--proving-key` | - | String | ~/.zisk/provingKey | Path to setup folder |
-| - | `--elf` | - | String | - | Path to ELF file |
-| - | `--asm` | - | String | ~/.zisk/cache | Path to ASM file (mutually exclusive with `--emulator`) |
-| - | `--emulator` | - | Boolean | false | Use prebuilt emulator (mutually exclusive with `--asm`) |
-| - | `--shared-tables` | - | Boolean | false | Whether to share tables when worker is running in a cluster |
-| - | `-v`, `-vv`, `-vvv`, ... | - | Number | 0 | Verbosity level (0=error, 1=warn, 2=info, 3=debug, 4=trace) |
-| - | `-d`, `--debug` | - | String | - | Enable debug mode with optional component filter |
-| - | `--verify-constraints` | - | Boolean | false | Whether to verify constraints |
-| - | `--unlock-mapped-memory` | - | Boolean | false | Unlock memory map for the ROM file (mutually exclusive with `--emulator`) |
-| - | `--hints` | - | Boolean | false | Enable precompile hints processing |
-| - | `-m`, `--minimal-memory` | - | Boolean | false | Use minimal memory mode |
-| - | `-t`, `--max-streams` | - | Number | - | Maximum number of GPU streams |
-| - | `-n`, `--number-threads-witness` | - | Number | - | Number of threads for witness computation |
-| - | `-x`, `--max-witness-stored` | - | Number | - | Maximum number of witnesses to store in memory |
-
-#### Configuration Files examples
-
-Example development configuration file:
-
-```toml
-[worker]
-compute_capacity.compute_units = 10
-environment = "development"
-
-[logging]
-level = "debug"
-format = "pretty"
-```
-
-Example production configuration file:
-
-```toml
-[worker]
-worker_id = "my-worker-001"
-compute_capacity.compute_units = 10
-environment = "production"
-inputs_folder = "/app/inputs"
-
-[coordinator]
-url = "http://127.0.0.1:50051"
-
-[connection]
-reconnect_interval_seconds = 5
-heartbeat_timeout_seconds = 30
-
-[logging]
-level = "info"
-format = "pretty"
-file_path = "/var/log/distributed/worker-001.log"
-```
-
-## Launching a Proof
-
-To launch a proof generation request, use the `prove` subcommand of the `zisk-coordinator` binary. This sends an RPC request to a running coordinator instance.
-
-```bash
-cargo run --release --bin zisk-coordinator -- prove --inputs-uri <input_filename> --compute-capacity 10
-```
-
-The `--compute-capacity` flag indicates the total compute units required to generate a proof. The coordinator will assign one or more workers to meet this capacity, distributing the workload if multiple workers are needed. Requests exceeding the combined capacity of available workers will not be processed and an error will be returned.
-
-### Prove Subcommand Arguments
-
-| CLI Argument | Short | Type | Default | Description |
-|---|---|---|---|---|
-| `--inputs-uri` | - | String | - | Path to the input file for proof generation |
-| `--compute-capacity` | `-c` | Number | *required* | Total compute units required for the proof |
-| `--coordinator-url` | - | String | http://127.0.0.1:50051 | URL of the coordinator to send the request to |
-| `--data-id` | - | String | Auto (from filename or UUID) | Custom identifier for the proof job |
-| `--hints-uri` | - | String | - | Path/URI to the precompile hints source |
-| `--stream-hints` | - | Boolean | false | Stream hints from the coordinator to workers via gRPC (see [Hints Stream](hints_stream.md)) |
-| `--direct-inputs` | `-x` | Boolean | false | Send input data inline via gRPC instead of as a file path |
-| `--minimal-compute-capacity` | `-m` | Number | Same as `--compute-capacity` | Minimum acceptable compute capacity (allows partial worker allocation) |
-| `--simulated-node` | - | Number | - | Simulated node ID (for testing) |
-
-### Input and Hints Modes
-
-The `prove` subcommand supports two modes for delivering inputs and hints to workers:
-
-**Input modes** (controlled by `--inputs-uri` and `--direct-inputs`):
-- **Path mode** (default): The coordinator sends the input file path to workers. Workers must have access to the file at the specified path.
-- **Data mode** (`--direct-inputs`): The coordinator reads the input file and sends its contents inline via gRPC. Workers do not need local access to the file.
-
-**Hints modes** (controlled by `--hints-uri` and `--stream-hints`):
-- **Path mode** (default): The coordinator sends the hints URI to workers. Each worker loads hints from the specified path independently.
-- **Streaming mode** (`--stream-hints`): The coordinator reads hints from the URI and broadcasts them to all workers in real-time via gRPC. See the [Hints Stream documentation](hints_stream.md) for details.
-
-**Examples:**
-```bash
-# Basic proof with file path inputs
-zisk-coordinator prove --inputs-uri /data/inputs/my_input.bin --compute-capacity 10
-
-# Send input data directly (workers don't need local file access)
-zisk-coordinator prove --inputs-uri /data/inputs/my_input.bin -x --compute-capacity 10
-
-# With precompile hints in path mode (workers load hints locally)
-zisk-coordinator prove --inputs-uri input.bin --hints-uri /data/hints/hints.bin --compute-capacity 10
-
-# With precompile hints in streaming mode (coordinator broadcasts to workers)
-zisk-coordinator prove --inputs-uri input.bin --hints-uri unix:///tmp/hints.sock --stream-hints --compute-capacity 10
-```
-
-## Administrative Operations
-
-### Health Checks and Monitoring
-
-The coordinator exposes administrative endpoints for monitoring:
-
-```bash
-# Basic health check
-grpcurl -plaintext 127.0.0.1:50051 zisk.distributed.api.v1.ZiskDistributedApi/HealthCheck
-
-# System status
-grpcurl -plaintext 127.0.0.1:50051 zisk.distributed.api.v1.ZiskDistributedApi/SystemStatus
-
-# List active jobs
-grpcurl -plaintext -d '{"active_only": true}' \
-  127.0.0.1:50051 zisk.distributed.api.v1.ZiskDistributedApi/JobsList
-
-# List connected workers
-grpcurl -plaintext -d '{"available_only": true}' \
-  127.0.0.1:50051 zisk.distributed.api.v1.ZiskDistributedApi/WorkersList
-```
-
-## Troubleshooting
-
-### Common Issues
-
-**Worker can't connect to coordinator:**
-- Verify coordinator is running and accessible on the specified port
-- Check firewall settings if coordinator and worker are on different machines
-- Ensure correct URL format: `http://host:port` (not `https://` for default setup)
-
-**Configuration not loading:**
-- Verify TOML syntax with a TOML validator
-- Check file permissions on configuration files
-- Use CLI overrides to test specific values
-
-**Worker not receiving tasks:**
-- Check worker registration in coordinator logs
-- Verify compute capacity is appropriate for available tasks
-- Ensure worker ID is unique if running multiple workers
-- Confirm coordinator has active jobs to distribute
-
-**Input file not found errors:**
-- Verify the input file exists in the worker's `--inputs-folder` directory
-- Check file permissions - worker needs read access to input files
-- Ensure you're using the filename only (not full path) when launching proofs
-- Confirm `--inputs-folder` path is correct and accessible
-
-**Port conflicts:**
-- Use `--port` flag or update configuration file to change ports
-- Check for other services using the same ports
-
-### Debug Mode
-
-Enable detailed logging for troubleshooting by modifying configuration files or using CLI arguments:
-
-```bash
-# Coordinator with debug logging (via config file)
-cargo run --release --bin zisk-coordinator -- --config debug-coordinator.toml
-
-# Worker with debug logging (via config file)
-cargo run --release --bin zisk-worker -- --config debug-worker.toml
-```
-
-Where `debug-coordinator.toml` or `debug-worker.toml` contains:
-```toml
-[logging]
-level = "debug"
-format = "pretty"
-```
-
-### Log Files
-
-When file logging is enabled, logs are written into specified paths in the configuration files. Ensure the application has write permissions to these paths.
-
-```toml
-[logging]
-file_path = "/var/log/distributed/coordinator.log"
+zisk-coordinator --api-port 8000 --cluster-port 60000 --log-level debug
+zisk-worker --coordinator-url http://prod-coord:50051 --compute-capacity 32
 ```

--- a/book/getting_started/distributed_execution.md
+++ b/book/getting_started/distributed_execution.md
@@ -164,7 +164,6 @@ A healthy startup log shows three "listening on" lines:
 ```
 INFO Starting ZisK Coordinator
 INFO server listening on 0.0.0.0:7000
-INFO worker port listening on 0.0.0.0:50051
 INFO metrics listening on 0.0.0.0:9090
 ```
 
@@ -182,7 +181,7 @@ In a second terminal:
 
 ```bash
 cargo run --release --bin zisk-worker -- \
-    --config distributed/crates/worker/config/dev.toml
+    --config distributed/deploy/config/worker.toml
 ```
 
 `dev.toml` points the worker at `http://127.0.0.1:50051`, advertises
@@ -198,10 +197,15 @@ INFO heartbeat ok
 The coordinator logs the matching side:
 
 ```
-INFO worker registered: <uuid> capacity=10
+INFO worker registered: <random-uid> capacity=10
 ```
 
 ### Health check
+
+With the coordinator and worker both running, verify the cluster in
+two steps: a liveness probe and an end-to-end proving job.
+
+**Liveness probe.** In a third terminal:
 
 ```bash
 curl http://127.0.0.1:9090/health
@@ -209,46 +213,23 @@ curl http://127.0.0.1:9090/health
 
 A healthy coordinator returns `200 OK` with an empty body.
 
-### Submit a proving job
-
-Any compiled ZisK guest works. The host program below talks to the
-**remote** prover:
-
-```rust
-use zisk_sdk::{GuestProgram, ProverClient, ZiskStdin, load_program};
-
-static PROGRAM: GuestProgram = load_program!("guest");
-
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
-
-    client.setup(&PROGRAM).run()?.await?;
-
-    let mut stdin = ZiskStdin::new();
-    stdin.write(&"Hello Zisk".to_string());
-
-    let proof = client.prove(&PROGRAM, stdin).run()?.await?;
-    proof.verify()?;
-
-    let digest: [u8; 32] = proof.get_publics().read()?;
-    println!("verified digest = 0x{}", hex::encode(digest));
-    Ok(())
-}
-```
+**Smoke-test proof.** Submit a real job from the included example:
 
 ```bash
-cargo run --release
+cd examples/sha-hasher/host
+cargo run --release --bin prove-remote
 ```
 
-The host uploads the ELF, the coordinator splits the job into
-segments and hands them to the worker, the worker produces STARK
-proofs, and the coordinator aggregates them into a final proof.
-Verification runs locally in milliseconds.
+The `prove-remote` binary builds a `ProverClient::remote("http://127.0.0.1:7000")`,
+uploads the guest ELF, and waits for the final proof. End-to-end:
+the coordinator splits the trace into segments and hands them to the
+worker, the worker produces STARK proofs, and the coordinator
+aggregates them into the final proof. Terminals 1 and 2 show the
+matching coordinator and worker activity.
 
 ---
 
-## Deployment on Linux
+## Deployment with scripts
 
 This section deploys the same two binaries on bare Linux hosts under
 systemd, the canonical path for a ZisK cluster.
@@ -273,7 +254,7 @@ cd zisk
 On the coordinator host:
 
 ```bash
-sudo distributed/crates/coordinator-server/scripts/install.sh
+sudo distributed/deploy/scripts/coordinator/install.sh
 ```
 
 The script:
@@ -286,13 +267,22 @@ The script:
 
 Verify the service:
 
+In Linux: 
+
 ```bash
 sudo systemctl status zisk-coordinator
 journalctl -u zisk-coordinator -f
 ```
 
-You should see the same three "listening on" lines from the
-quickstart. If the service is `failed`, journalctl shows the
+In Macos:
+
+```bash
+sudo launchctl print system/com.zisk.coordinator 
+tail -f /var/log/zisk-coordinator/zisk-coordinator.log 
+```
+
+You should see the same two "listening on" lines from the
+quickstart. If the service is `failed`, shows the
 underlying error (most often a port conflict or missing config
 field).
 
@@ -346,8 +336,15 @@ Edit `/etc/zisk/coordinator.toml`:
 
 After editing:
 
+In Linux:
+
 ```bash
 sudo systemctl restart zisk-coordinator
+```
+
+In Macos:
+```bash
+sudo launchctl kickstart -k system/com.zisk.coordinator
 ```
 
 ### Install workers
@@ -355,7 +352,7 @@ sudo systemctl restart zisk-coordinator
 On each worker host:
 
 ```bash
-sudo distributed/crates/worker/scripts/install.sh
+sudo distributed/deploy/scripts/worker/install.sh
 ```
 
 The worker is now running with the default
@@ -417,8 +414,14 @@ table.
 
 After editing:
 
+In Linux:
 ```bash
 sudo systemctl restart zisk-worker
+```
+
+In Macos:
+```bash
+sudo launchctl kickstart -k system/com.zisk.coordinator
 ```
 
 ### Add more workers

--- a/book/getting_started/hints_stream.md
+++ b/book/getting_started/hints_stream.md
@@ -23,7 +23,7 @@ flowchart LR
 ## Table of Contents
 
 1. [Hint Format and Protocol](#1-hint-format-and-protocol)
-2. [Hints in CLI Execution](#2-hints-in-cli-execution)
+2. [Using Hints with the SDK](#2-using-hints-with-the-sdk)
 3. [Hints in Distributed Execution](#3-hints-in-distributed-execution)
 4. [Custom Hint Handlers](#4-custom-hint-handlers)
 5. [Generating Hints in Guest Programs](#5-generating-hints-in-guest-programs)
@@ -178,18 +178,74 @@ CTRL_START                          ← Reset state, begin stream
 CTRL_END                            ← Wait for completion, end stream
 ```
 
-## 2. Hints in CLI Execution
+## 2. Consuming Hints
 
-There are four CLI commands (`execute`, `prove`, `verify-constraints`, `stats`) that support hints stream system by providing a URI via the `--hints` option. The URI determines the input stream source for hints, which can be a file, Unix socket, QUIC stream, or other custom transport.
-The supported schemes are:
+Once a guest program has produced a hints binary file (see [Section 5](#5-generating-hints-in-guest-programs)), you can feed it to the prover either programmatically through the ZisK SDK or via the ZisK CLI.
+
+> **Note:** Hints are only supported with the **Assembly executor**. The emulator-based executor does not use the hints pipeline.
+
+### 2.1 SDK
+
+Load the file with `ZiskHints::from_file` and pass it to `.hints(...)` on the executor:
+
+```rust
+use anyhow::Result;
+use zisk_sdk::{ExecutorKind, GuestProgram, ProverClient, ZiskStdin, ZiskHints};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let elf_path = "hints/example/zec-reth.elf";
+    let program = GuestProgram::from_uri(elf_path)?;
+
+    let hints_path = "hints/example/24654300_hints.bin";
+    let hints = ZiskHints::from_file(hints_path)?;
+
+    let client = ProverClient::embedded()
+        .executor(ExecutorKind::Assembly)
+        .build()?;
+
+    client.upload(&program).run()?;
+    client.setup(&program).with_hints().run()?.await?;
+
+    let result = client
+        .execute(&program, ZiskStdin::new())
+        .hints(hints)
+        .executor(ExecutorKind::Assembly)
+        .run()?
+        .await?;
+
+    println!(
+        "Program executed successfully: {} cycles in {:.2?} ms",
+        result.get_execution_steps(),
+        result.get_execution_time()
+    );
+
+    Ok(())
+}
+```
+
+**Notes:**
+- Setup must be run with `.with_hints()` so the assembly ROM is generated with hint support enabled. Without it, the prover will not consume the hints stream.
+- `ZiskHints::from_file` loads the binary produced by the guest's hint generation. The returned value can be reused across multiple `.execute(...)` / `.prove(...)` calls.
+- The same pattern works for `prove`, `verify-constraints`, and `stats` operations exposed by `ProverClient`.
+
+A complete runnable example is available at `examples/hints/host/src/main.rs`.
+
+### 2.2 CLI
+
+Four `cargo-zisk` commands accept a `--hints` flag pointing to the hints file: `execute`, `prove`, `verify-constraints`, and `stats`. Pass the path with the `file://` scheme:
+
 ```
 --hints file://path      → File stream reader
---hints unix://path      → Unix socket stream reader
---hints quic://host:port → Quic stream reader
---hints (plain path)     → File stream reader
 ```
 
-> **Note:** Only ASM mode supports hints. The emulator mode does not use the hints pipeline.
+Example:
+
+```bash
+cargo-zisk prove --elf program.elf --hints file:///abs/path/hints.bin
+```
+
+`--hints` is mutually exclusive with `--inputs` (`-i`): if you provide hints, the inputs are recovered from the hint stream itself rather than from a separate input file.
 
 ## 3. Hints in Distributed Execution
 

--- a/book/getting_started/hints_stream.md
+++ b/book/getting_started/hints_stream.md
@@ -293,31 +293,84 @@ Each worker receives the stream of hints, buffers them if they arrive out of ord
 
 ### 3.2. Hints Mode Configuration
 
-When starting a worker, if the `--hints` option is provided, the worker prepares to receive hints from the coordinator.
-When launching a proof generation job where hints will be provided, the workers must be started to receive and process hints.
-A hints stream system can be configured in two ways:
+When calling the coordinator with `.hints()` prepares to receive hints from the coordinator. A hints system can be configured in two ways:
+
 * **Streaming mode**: Workers receive hints from the coordinator via gRPC. This is the default and recommended mode for production, as it allows real-time processing of hints as they are generated.
 * **Path mode**: Workers load hints from a local path/URI. This is useful for debugging or when hints are pre-generated and stored in a file. In this mode, the coordinator does not send hints to workers; instead, each worker reads the hints directly from the specified path.
 
 #### 3.2.1 Coordinator Hints Streaming Mode
 
-To start the coordinator in streaming mode, provide the `--hints-uri` option with a URI that the `coordinator` will connect to, and set `--stream-hints` to enable broadcasting to workers. The URI determines the input stream source for hints.
-The supported schemes are:
-```
---hints-uri file://path      → File stream reader
---hints-uri unix://path      → Unix socket stream reader
---hints-uri quic://host:port → Quic stream reader
---hints-uri (plain path)     → File stream reader
+The transport for the live hints stream is chosen on the SDK side by constructing a `ZiskStream` and passing it as the hints source on the `execute`/`prove` call.
+
+| Constructor                              | Transport                                                                |
+| ---                                      | ---                                                                      |
+| `ZiskStream::unix()`                     | Unix domain socket at an auto-assigned path under `/tmp/`                |
+| `ZiskStream::unix_at("/path")`           | Unix domain socket at an explicit path                                   |
+| `ZiskStream::quic("quic://host:port")`   | QUIC transport (use `quic://127.0.0.1:0` to let the OS pick a port)      |
+| `ZiskStream::grpc()`                     | gRPC push transport (data pushed to the coordinator via `PushJobInput`)  |
+
+Example launching a prove job with hints streamed over a Unix socket:
+
+```rust
+use anyhow::Result;
+use zisk_sdk::{ExecutorKind, GuestProgram, ProverClient, ZiskStdin, ZiskStream};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let program = GuestProgram::from_uri("hints/example/zec-reth.elf")?;
+
+    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
+    let hints = ZiskStream::unix();
+
+    let prove_handle = client
+        .prove(&program, ZiskStdin::new())
+        .hints(hints.clone())
+        .executor(ExecutorKind::Assembly)
+        .run()?;
+
+    let proof = prove_handle.await?;
+
+    Ok(())
+}
 ```
 
-Example to launch a prove command in streaming mode:
-```
-zisk-coordinator prove --hints-uri unix:///tmp/hints.sock --stream-hints ...
-```
+Switching transports is a one-line change at the call site — replace `ZiskStream::unix()` with `ZiskStream::grpc()` or `ZiskStream::quic("quic://0.0.0.0:0")`.
 
 #### 3.2.2 Worker Hints non-Streaming Mode
 
-To start a worker in non-streaming mode, provide the `--hints-uri` option with a URI that points to the local workers path where hints are stored, without the `--stream-hints` option. In this mode the worker(s) will load hints from the specified URI instead of receiving them from the coordinator. This mode is useful for debugging or when hints are pre-generated and stored in a file.
+Non-streaming mode is also selected from the SDK call. Instead of constructing a `ZiskStream`, build a `ZiskHints` from a pre-generated file (or in-memory bytes) and pass it to `.hints(...)`. The coordinator skips broadcasting in this case — each worker loads the hints directly from the URI baked into the `ZiskHints` value. This is useful for debugging or when hints are pre-generated.
+
+| Constructor                       | Source                                            |
+| ---                               | ---                                               |
+| `ZiskHints::from_file("/path")`   | Hints binary on disk (file path or `file://` URI) |
+| `ZiskHints::memory(bytes)`        | Hints already loaded into memory                  |
+| `ZiskHints::from(&value)`         | Serializable Rust value (encoded with bincode)    |
+
+Example launching a prove job that loads hints from a file:
+
+```rust
+use anyhow::Result;
+use zisk_sdk::{ExecutorKind, GuestProgram, ProverClient, ZiskStdin, ZiskHints};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let program = GuestProgram::from_uri("hints/example/zec-reth.elf")?;
+
+    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
+    let hints = ZiskHints::from_file("/var/lib/zisk/hints/24654300_hints.bin")?;
+
+    let proof = client
+        .prove(&program, ZiskStdin::new())
+        .hints(hints)
+        .executor(ExecutorKind::Assembly)
+        .run()?
+        .await?;
+
+    Ok(())
+}
+```
+
+The same `ZiskHints` value can be reused across multiple `.execute(...)` / `.prove(...)` calls. As with streaming mode, no coordinator or worker flags are required to switch between sources — the SDK call decides.
 
 ## 4. Custom Hint Handlers
 

--- a/book/getting_started/quickstart.md
+++ b/book/getting_started/quickstart.md
@@ -31,9 +31,9 @@ ZisK currently supports **Linux x86_64** and **macOS** platforms (see note below
 
 ## Create a Project
 
-The first step is to generate a new example project using the `cargo-zisk sdk new <name>` command. This command creates a new directory named `<name>` in your current directory. For example:
+The first step is to generate a new example project using the `cargo-zisk new <name>` command. This command creates a new directory named `<name>` in your current directory. For example:
 ```bash
-cargo-zisk sdk new sha_hasher
+cargo-zisk new sha_hasher
 cd sha_hasher
 ```
 

--- a/book/getting_started/writing_programs.md
+++ b/book/getting_started/writing_programs.md
@@ -121,7 +121,7 @@ In this case, the `guest` ELF file will be generated in the `./target/elf/riscv6
 
 ## Execute
 
-You can test your compiled program using the ZisK emulator (`ziskemu`) before generating a proof. Use the `-e` (`--elf`) flag to specify the location of the ELF file and the `-i` (`--inputs`) flag to specify the location of the input file:
+You can test your compiled program using the ZisK emulator before generating a proof. Use the `-e` (`--elf`) flag to specify the location of the ELF file and the `-i` (`--inputs`) flag to specify the location of the input file:
 
 ```bash
 cargo-zisk build --release
@@ -201,7 +201,7 @@ Opcodes:
 Before generating a proof (or verifying the constraints), you need to generate the program setup files. This must be done the first time after building the program ELF file, or any time it changes:
 
 ```bash
-cargo-zisk rom-setup -e target/elf/riscv64ima-zisk-zkvm-elf/release/guest -k $HOME/.zisk/provingKey
+cargo-zisk program-setup -e target/elf/riscv64ima-zisk-zkvm-elf/release/guest -k $HOME/.zisk/provingKey
 ```
 In this command:
 
@@ -212,7 +212,7 @@ The program setup files will be generated in the `cache` directory located at `$
 
 To clean the `cache` directory content, use the following command:
 ```bash
-cargo-zisk clean
+cargo-zisk utils clean-cache --all
 ```
 
 ### Verify Constraints
@@ -241,7 +241,7 @@ If everything is correct, you will see an output similar to:
 To generate a proof, run the following command:
 
 ```bash
-cargo-zisk prove -e target/elf/riscv64ima-zisk-zkvm-elf/release/guest -i host/tmp/input.bin -k $HOME/.zisk/provingKey -o proof -a -y
+cargo-zisk prove -e target/elf/riscv64ima-zisk-zkvm-elf/release/guest -i host/tmp/input.bin -k $HOME/.zisk/provingKey -o proof
 ```
 In this command:
 
@@ -249,8 +249,6 @@ In this command:
 * `-i` (`--input`) specifies the input file location.
 * `-k` (`--proving-key`) specifies the directory containing the proving key. This is optional and defaults to `$HOME/.zisk/provingKey`.
 * `-o` (`--output`) determines the output directory (in this example `proof`).
-* `-a` (`--aggregation`) indicates that a final aggregated proof (containing all generated sub-proofs) should be produced.
-* `-y` (`--verify-proofs`) instructs the tool to verify the proof immediately after it is generated (verification can also be performed later using the `cargo-zisk verify` command).
 
 If the process is successful, you should see a message similar to:
 
@@ -282,21 +280,25 @@ The total memory requirement increases proportionally with the number of process
 
 ### GPU Proof Generation
 
-Zisk proofs can also be generated using GPUs to significantly improve performance and scalability.
-Follow these steps to enable GPU support:
+Zisk proofs can also be generated on GPUs to significantly improve performance and scalability. GPU support is only available for NVIDIA GPUs.
 
-1. GPU support is only available for NVIDIA GPUs.
+To enable GPU support:
 
-2. Make sure the [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) is installed.
+1. Install the [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads).
 
-3. Build Zisk with GPU support enabled.
+2. Confirm that Zisk was built with GPU support by checking whether the version string ends in `[gpu]` rather than `[cpu]`:
 
-    **Note:** It is recommended to compile Zisk directly on the server where it will be executed. The binary will be optimized for the local GPU architecture, which can lead to better runtime performance.
+   ```bash
+   cargo-zisk --version
+   ```
 
-    GPU support must be enabled at compile time. Follow the instructions in the **Build ZisK** section under **Option 2: Building from source** in the [Installation](./installation.md) guide, but replace the build command with:
-    ```bash
-    cargo build --release --features gpu
-    ```
+3. Once GPU support is enabled, add the `--gpu` flag to your `prove` commands:
+
+   ```bash
+   cargo-zisk prove -e target/elf/riscv64ima-zisk-zkvm-elf/release/guest -i host/tmp/input.bin -k $HOME/.zisk/provingKey -o proof --gpu
+   ```
+
+> **Note:** It is recommended to compile Zisk directly on the server where it will be executed. The binary will be optimized for the local GPU architecture, which can lead to better runtime performance.
 
 You can combine GPU-based execution with concurrent proof generation using multiple processes, as described in the **Concurrent Proof Generation** section.
 

--- a/distributed/crates/coordinator/src/coordinator/contributions.rs
+++ b/distributed/crates/coordinator/src/coordinator/contributions.rs
@@ -300,12 +300,6 @@ impl Coordinator {
 
         let job_id = job.job_id.clone();
         let workers_pool = Arc::clone(&self.workers_pool);
-        eprintln!(
-            "[input-relay] initialize_input_relay spawn job={} uri={} workers={}",
-            job_id,
-            inputs_uri,
-            active_workers.len()
-        );
 
         // Grab the job Arc so the relay thread can mark it failed on error.
         let job_arc = self
@@ -354,7 +348,6 @@ impl Coordinator {
         workers: &[WorkerId],
         workers_pool: &WorkersPool,
     ) -> anyhow::Result<()> {
-        eprintln!("[input-relay] ENTER job={} uri={}", job_id, inputs_uri);
         let mut stream = StreamSource::from_uri(inputs_uri)?;
 
         // The SDK creates its listener after receiving the submit_job response, so
@@ -364,41 +357,20 @@ impl Coordinator {
             let connect_start = std::time::Instant::now();
             let deadline = connect_start + std::time::Duration::from_secs(60);
             let mut last_log = connect_start;
-            let mut attempts = 0u32;
             loop {
                 match stream.open() {
                     Ok(_) => {
-                        eprintln!(
-                            "[input-relay] open() OK job={} uri={} attempts={} elapsed={:?}",
-                            job_id,
-                            inputs_uri,
-                            attempts,
-                            connect_start.elapsed()
-                        );
                         break;
                     }
                     Err(e) => {
-                        attempts += 1;
                         let now = std::time::Instant::now();
                         if now >= deadline {
-                            eprintln!(
-                                "[input-relay] open() TIMEOUT job={} uri={} attempts={} err={}",
-                                job_id, inputs_uri, attempts, e
-                            );
                             return Err(e.context(format!(
                                 "timed out waiting for input stream socket to become available: {}",
                                 inputs_uri
                             )));
                         }
                         if now.duration_since(last_log) >= std::time::Duration::from_secs(5) {
-                            eprintln!(
-                                "[input-relay] open() still retrying job={} uri={} attempts={} elapsed={:?} last_err={}",
-                                job_id,
-                                inputs_uri,
-                                attempts,
-                                connect_start.elapsed(),
-                                e
-                            );
                             last_log = now;
                         }
                         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -408,15 +380,10 @@ impl Coordinator {
         }
 
         info!("Input relay started for job {} from {}", job_id, inputs_uri);
-        eprintln!("[input-relay] reading job={} uri={}", job_id, inputs_uri);
 
-        let mut chunks = 0u32;
-        let mut bytes = 0usize;
         loop {
             match stream.next() {
                 Ok(Some(chunk)) => {
-                    chunks += 1;
-                    bytes += chunk.len();
                     let sends = workers.iter().map(|worker_id| {
                         let job_id = job_id.clone();
                         let worker_id = worker_id.clone();
@@ -437,17 +404,9 @@ impl Coordinator {
                 }
                 Ok(None) => {
                     info!("Input relay finished for job {} (stream ended)", job_id);
-                    eprintln!(
-                        "[input-relay] EOF job={} uri={} chunks={} bytes={}",
-                        job_id, inputs_uri, chunks, bytes
-                    );
                     return Ok(());
                 }
                 Err(e) => {
-                    eprintln!(
-                        "[input-relay] ERROR job={} uri={} chunks={} bytes={} err={}",
-                        job_id, inputs_uri, chunks, bytes, e
-                    );
                     return Err(e);
                 }
             }

--- a/distributed/crates/worker/src/worker.rs
+++ b/distributed/crates/worker/src/worker.rs
@@ -452,10 +452,6 @@ impl<T: ZiskBackend + 'static> Worker<T> {
         with_hints: bool,
         is_first_partition: bool,
     ) -> Result<()> {
-        eprintln!(
-            "[worker] prepare_for_new_job hash={} with_hints={} first_part={}",
-            hash_id, with_hints, is_first_partition
-        );
         let program_id = self
             .guest_programs
             .get(hash_id)
@@ -463,13 +459,9 @@ impl<T: ZiskBackend + 'static> Worker<T> {
             .program_id
             .clone();
 
-        eprintln!("[worker] prepare_for_new_job → register_program");
         self.prover.register_program(&program_id, with_hints)?;
-        eprintln!("[worker] prepare_for_new_job → reset_resources");
         self.prover.reset_resources()?;
-        eprintln!("[worker] prepare_for_new_job → set_active_services");
         self.prover.set_active_services(is_first_partition)?;
-        eprintln!("[worker] prepare_for_new_job DONE");
         Ok(())
     }
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3207,7 +3207,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiple-program-host"
+name = "multiple-programs-host"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/examples/aggregation/host/Cargo.toml
+++ b/examples/aggregation/host/Cargo.toml
@@ -12,3 +12,7 @@ sha2 = "0.10.8"
 
 [build-dependencies]
 zisk-sdk = { workspace = true }
+
+[features]
+default = []
+gpu = []

--- a/examples/aggregation/host/src/main.rs
+++ b/examples/aggregation/host/src/main.rs
@@ -23,7 +23,10 @@ async fn main() -> Result<()> {
 
     // Create a `ProverClient` method.
     let embedded_opts = EmbeddedOpts::default().minimal_memory();
-    let client = ProverClient::embedded().with_embedded_opts(embedded_opts).gpu().build()?;
+    let builder = ProverClient::embedded().with_embedded_opts(embedded_opts);
+    #[cfg(feature = "gpu")]
+    let builder = builder.gpu();
+    let client = builder.build()?;
 
     println!("Setting up first program...");
     client.setup(&PROGRAM1).run()?.await?;
@@ -36,7 +39,7 @@ async fn main() -> Result<()> {
     let result = client.execute(&PROGRAM1, stdin.clone()).run()?.await?;
 
     println!(
-        "Program executed successfully: {} cycles in {:.2?} ms",
+        "Program executed successfully: {} cycles in {} ms",
         result.get_execution_steps(),
         result.get_execution_time()
     );

--- a/examples/big-program/host/Cargo.toml
+++ b/examples/big-program/host/Cargo.toml
@@ -12,3 +12,7 @@ sha2 = "0.10.8"
 
 [build-dependencies]
 zisk-sdk = { workspace = true }
+
+[features]
+default = []
+gpu = []

--- a/examples/big-program/host/src/main.rs
+++ b/examples/big-program/host/src/main.rs
@@ -21,7 +21,10 @@ async fn main() -> Result<()> {
     println!("Input loaded successfully");
 
     // Create a `ProverClient` method.
-    let client = ProverClient::embedded().build()?;
+    let builder = ProverClient::embedded();
+    #[cfg(feature = "gpu")]
+    let builder = builder.gpu();
+    let client = builder.build()?;
 
     client.setup(&PROGRAM).run()?.await?;
 
@@ -29,7 +32,7 @@ async fn main() -> Result<()> {
     let result = client.execute(&PROGRAM, stdin.clone()).run()?.await?;
 
     println!(
-        "ZisK has executed program with {} cycles in {:?} ms",
+        "ZisK has executed program with {} cycles in {} ms",
         result.get_execution_steps(),
         result.get_execution_time()
     );

--- a/examples/hints/host/Cargo.toml
+++ b/examples/hints/host/Cargo.toml
@@ -12,3 +12,7 @@ sha2 = "0.10.8"
 
 [build-dependencies]
 zisk-sdk = { workspace = true }
+
+[features]
+default = []
+gpu = []

--- a/examples/hints/host/src/main.rs
+++ b/examples/hints/host/src/main.rs
@@ -1,29 +1,17 @@
 use anyhow::Result;
-use std::thread;
-use zisk_sdk::{ExecutorKind, GuestProgram, ProverClient, ZiskStdin, ZiskStream};
+use zisk_sdk::{ExecutorKind, GuestProgram, ProverClient, ZiskStdin, ZiskHints};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     println!("Starting ZisK Prover Client...\n");
 
     let elf_path = "hints/example/zec-reth.elf";
-    let hints_path = "hints/example/24654300_hints.bin";
-
     let program = GuestProgram::from_uri(elf_path)?;
-
-    // Create a QUIC stream for hints.  Port 0 lets the OS pick a free port;
-    // ZiskStream resolves it to the actual bound address so the coordinator
-    // receives the correct port every run.
-    let hints_stream = ZiskStream::grpc();
-    let s = hints_stream.clone();
-    let hints_data = std::fs::read(hints_path)?;
-    thread::spawn(move || {
-        s.write_bytes(&hints_data);
-        s.flush().unwrap();
-        s.finish().unwrap();
-    });
-
-    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
+    
+    let hints_path = "hints/example/24654300_hints.bin";
+    let hints = ZiskHints::from_file(hints_path)?;
+    
+    let client = ProverClient::embedded().executor(ExecutorKind::Assembly).build()?;
 
     println!("Setting up program...");
     client.upload(&program).run()?;
@@ -32,7 +20,7 @@ async fn main() -> Result<()> {
     println!("Executing program...");
     let result = client
         .execute(&program, ZiskStdin::new())
-        .hints(hints_stream)
+        .hints(hints)
         .executor(ExecutorKind::Assembly)
         .run()?
         .await?;

--- a/examples/hints/host/src/main.rs
+++ b/examples/hints/host/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use zisk_sdk::{ExecutorKind, GuestProgram, ProverClient, ZiskStdin, ZiskHints};
+use zisk_sdk::{ExecutorKind, GuestProgram, ProverClient, ZiskHints, ZiskStdin};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -7,11 +7,14 @@ async fn main() -> Result<()> {
 
     let elf_path = "hints/example/zec-reth.elf";
     let program = GuestProgram::from_uri(elf_path)?;
-    
+
     let hints_path = "hints/example/24654300_hints.bin";
     let hints = ZiskHints::from_file(hints_path)?;
-    
-    let client = ProverClient::embedded().executor(ExecutorKind::Assembly).build()?;
+
+    let builder = ProverClient::embedded().executor(ExecutorKind::Assembly);
+    #[cfg(feature = "gpu")]
+    let builder = builder.gpu();
+    let client = builder.build()?;
 
     println!("Setting up program...");
     client.upload(&program).run()?;
@@ -26,7 +29,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!(
-        "Program executed successfully: {} cycles in {:.2?} ms",
+        "Program executed successfully: {} cycles in {} ms",
         result.get_execution_steps(),
         result.get_execution_time()
     );

--- a/examples/multiple-programs/host/Cargo.toml
+++ b/examples/multiple-programs/host/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "multiple-program-host"
+name = "multiple-programs-host"
 version = "0.1.0"
 edition = "2021"
 
@@ -12,3 +12,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 zisk-sdk = { workspace = true }
+
+[features]
+default = []
+gpu = []

--- a/examples/multiple-programs/host/src/main.rs
+++ b/examples/multiple-programs/host/src/main.rs
@@ -7,9 +7,6 @@ static PROGRAM2: GuestProgram = load_program!("multiple-program-guest-2");
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Alternative: load at runtime from a URI (file path or http(s)://)
-    // let program2 = GuestProgram::from_uri("../multiple-program-guest-2/target/guest.elf")?;
-
     println!("Starting ZisK Prover Client...\n");
 
     // Create an input stream and write '1000' to it.
@@ -17,24 +14,19 @@ async fn main() -> Result<()> {
     let stdin = ZiskStdin::new();
     stdin.write(&n);
 
-    // Stdin can be created using null(), memory(), from(), file(), or stream() methods.
-    // let _stdin = ZiskStdin::stream("unix:///tmp/stdin.sock")?;
-    // Hints can be created using memory(), from(), or file() methods.
-    // let _hints = ZiskHints::file("/path/to/hints.bin")?;
-
     // Create a `ProverClient` method.
     // let client = ProverClient::embedded().build()?;
 
-    // let embedded_opts = EmbeddedOpts::default().minimal_memory();
-    // let client = ProverClient::embedded().with_embedded_opts(embedded_opts).build()?;
-    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
-
-    // let _remote_client = ProverClient::embedded().remote("localhost:3000").gpu().build()?;  // future
+    let embedded_opts = EmbeddedOpts::default().minimal_memory();
+    let builder = ProverClient::embedded().with_embedded_opts(embedded_opts);
+    #[cfg(feature = "gpu")]
+    let builder = builder.gpu();
+    let client = builder.build()?;
 
     println!("Setting up first program...");
     client.upload(&PROGRAM1).run()?;
     client.setup(&PROGRAM1).run()?.await?;
-    
+
     println!("Setting up second program...");
     client.upload(&PROGRAM2).run()?;
     client.setup(&PROGRAM2).run()?.await?;
@@ -44,7 +36,7 @@ async fn main() -> Result<()> {
     let result = client.execute(&PROGRAM1, stdin.clone()).run()?.await?;
 
     println!(
-        "Program executed successfully: {} cycles in {:.2?} ms",
+        "Program executed successfully: {} cycles in {} ms",
         result.get_execution_steps(),
         result.get_execution_time()
     );
@@ -66,7 +58,7 @@ async fn main() -> Result<()> {
     let result2 = client.execute(&PROGRAM2, stdin2.clone()).run()?.await?;
 
     println!(
-        "Program executed successfully: {} cycles in {:.2?} ms",
+        "Program executed successfully: {} cycles in {} ms",
         result2.get_execution_steps(),
         result2.get_execution_time()
     );

--- a/examples/sha-hasher/host/Cargo.toml
+++ b/examples/sha-hasher/host/Cargo.toml
@@ -15,22 +15,42 @@ sha-hasher-common = { path = "../common" }
 [build-dependencies]
 zisk-sdk = { workspace = true }
 
+[features]
+default = []
+gpu = []
+
 [[bin]]
 name = "prove"
-path = "bin/prove.rs"
+path = "bin/embedded/prove.rs"
 
 [[bin]]
 name = "execute"
-path = "bin/execute.rs"
+path = "bin/embedded/execute.rs"
 
 [[bin]]
 name = "plonk"
-path = "bin/plonk.rs"
+path = "bin/embedded/plonk.rs"
 
 [[bin]]
 name = "minimal"
-path = "bin/minimal.rs"
+path = "bin/embedded/minimal.rs"
 
 [[bin]]
 name = "run"
 path = "bin/run.rs"
+
+[[bin]]
+name = "prove-remote"
+path = "bin/remote/prove.rs"
+
+[[bin]]
+name = "execute-remote"
+path = "bin/remote/execute.rs"
+
+[[bin]]
+name = "plonk-remote"
+path = "bin/remote/plonk.rs"
+
+[[bin]]
+name = "minimal-remote"
+path = "bin/remote/minimal.rs"

--- a/examples/sha-hasher/host/bin/embedded/execute.rs
+++ b/examples/sha-hasher/host/bin/embedded/execute.rs
@@ -16,10 +16,13 @@ async fn main() -> Result<()> {
 
     // Create a `ProverClient` method.
     println!("Building prover client...");
-    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
+    let builder = ProverClient::embedded();
+    #[cfg(feature = "gpu")]
+    let builder = builder.gpu();
+    let client = builder.build()?;
 
     println!("Setting up program...");
-    client.setup(&PROGRAM).run()?.await?; // S'ha de fer un must use
+    client.setup(&PROGRAM).run()?.await?;
     println!("Setup completed successfully");
 
     // Execute the program using the `ProverClient.execute` method, without generating a proof.
@@ -28,7 +31,7 @@ async fn main() -> Result<()> {
 
     println!("\u{2713} Execution completed successfully!");
     println!("Cycles: {}", result.get_execution_steps());
-    println!("Duration: {:?}", result.get_execution_time());
+    println!("Duration: {} ms", result.get_execution_time());
 
     println!("Reading public outputs...");
     let output: Output = result.get_public_values_abi()?;

--- a/examples/sha-hasher/host/bin/embedded/minimal.rs
+++ b/examples/sha-hasher/host/bin/embedded/minimal.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use zisk_sdk::{load_program, GuestProgram, ProofKind, ProverClient, ZiskStdin};
+use zisk_sdk::{load_program, ExecutorKind, GuestProgram, ProofKind, ProverClient, ZiskStdin};
 
 static PROGRAM: GuestProgram = load_program!("sha-hasher-guest");
 
@@ -15,22 +15,23 @@ async fn main() -> Result<()> {
 
     // Create a `ProverClient` method.
     println!("Building prover client...");
-    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
+    let builder = ProverClient::embedded().executor(ExecutorKind::Assembly);
+    #[cfg(feature = "gpu")]
+    let builder = builder.gpu();
+    let client = builder.build()?;
 
     println!("Setting up program...");
     client.setup(&PROGRAM).run()?.await?;
     println!("Setup completed successfully");
 
-    println!("Generating Vadcop proof...");
-    let vadcop_result = client.prove(&PROGRAM, stdin).run()?.await?;
-    println!("Vadcop proof generated in {:?}", vadcop_result.get_proving_time());
-
-    println!("Reducing proof (this may take a while)...");
-    let result =
-        client.wrap_proof(vadcop_result.get_proof(), ProofKind::VadcopFinalMinimal).run()?.await?;
-
-    // Alternatively, you can also call `minimal()` on the `ProverClient.prove` method to generate a minimal proof directly.
-    // let result = client.prove(&PROGRAM, stdin)?.with_prover_options(proof_opts).minimal().run()?;
+    println!("Generating minimal proof (this may take a while)...");
+    let result = client
+        .prove(&PROGRAM, stdin)
+        .executor(ExecutorKind::Assembly)
+        .wrap(ProofKind::VadcopFinalMinimal)
+        .run()?
+        .await?;
+    println!("Minimal proof generated in {} ms", result.get_proving_time());
 
     println!("Verifying minimal proof...");
     result.verify()?;

--- a/examples/sha-hasher/host/bin/embedded/plonk.rs
+++ b/examples/sha-hasher/host/bin/embedded/plonk.rs
@@ -15,7 +15,10 @@ async fn main() -> Result<()> {
 
     // Create a `ProverClient` method.
     println!("Building prover client with SNARK support...");
-    let client = ProverClient::embedded().gpu().plonk().build()?;
+    let builder = ProverClient::embedded().plonk();
+    #[cfg(feature = "gpu")]
+    let builder = builder.gpu();
+    let client = builder.build()?;
 
     println!("Setting up program and generating verification key...");
     client.setup(&PROGRAM).run()?.await?;
@@ -23,13 +26,8 @@ async fn main() -> Result<()> {
 
     println!("Generating PLONK proof (this may take a while)...");
     let snark_proof = client.prove(&PROGRAM, stdin).wrap(ProofKind::Plonk).run()?.await?;
-    println!("PLONK proof generated successfully in {:?}", snark_proof.get_proving_time());
+    println!("PLONK proof generated successfully in {} ms", snark_proof.get_proving_time());
     println!("Execution steps: {}", snark_proof.get_execution_steps());
-
-    // Alternatively, it can also be done in two steps
-    // let vadcop_result = client.prove(&PROGRAM, stdin)?.run()?;
-    // let vkey = PROGRAM.vk()?;
-    // let snark_proof = client.wrap_proof(vadcop_result.get_proof(), ProofMode::Plonk)?;
 
     println!("Verifying PLONK proof...");
     snark_proof.verify()?;

--- a/examples/sha-hasher/host/bin/embedded/prove.rs
+++ b/examples/sha-hasher/host/bin/embedded/prove.rs
@@ -1,0 +1,70 @@
+use anyhow::Result;
+use sha2::{Digest, Sha256};
+use sha_hasher_common::Output;
+use zisk_sdk::{
+    load_program, ExecutorKind, GuestProgram, Proof, ProverClient, PublicValues, ZiskStdin,
+};
+
+static PROGRAM: GuestProgram = load_program!("sha-hasher-guest");
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("Starting ZisK Prover Client...");
+
+    // Create an input stream and write '1000' to it.
+    let n = 1000u32;
+    let stdin = ZiskStdin::new();
+    stdin.write(&n);
+    println!("Input prepared: {} iterations", n);
+
+    // Create a `ProverClient` method.
+    println!("Building prover client...");
+    let builder = ProverClient::embedded().executor(ExecutorKind::Assembly);
+    #[cfg(feature = "gpu")]
+    let builder = builder.gpu();
+    let client = builder.build()?;
+
+    println!("Setting up program...");
+    client.setup(&PROGRAM).run()?.await?;
+    println!("Setup completed successfully");
+
+    println!("Generating proof (this may take a while)...");
+    let result = client.prove(&PROGRAM, stdin).executor(ExecutorKind::Assembly).run()?.await?;
+    println!("Proof generated successfully in {} ms", result.get_proving_time());
+    println!("Execution steps: {}", result.get_execution_steps());
+
+    println!("Verifying proof...");
+    result.verify()?;
+    println!("Proof verification successful!");
+
+    println!("Saving proof to disk...");
+    result.save_proof("tmp/sha_hasher_proof.bin")?;
+    println!("Proofs saved to tmp/ directory");
+
+    let mut hash = [0u8; 32];
+    for _ in 0..n {
+        let mut hasher = Sha256::new();
+        hasher.update(hash);
+        let digest = &hasher.finalize();
+        hash = Into::<[u8; 32]>::into(*digest);
+    }
+
+    let output = Output { hash: hash.into(), iterations: n, magic_number: 0xDEADBEEF };
+    println!("Expected output hash: {:02x?}", &hash[..8]);
+
+    println!("Verifying saved proofs from disk...");
+    let publics = PublicValues::write_abi(&output)?;
+    let vk = PROGRAM.vk()?;
+
+    println!("Loading proof with publics from disk...");
+    let proof = Proof::load("tmp/sha_hasher_proof.bin")?;
+
+    println!("Verifying proof with embedded publics...");
+    // Verify the proof with its embedded publics (from guest's commit)
+    proof.with_program_vk(&vk).with_publics(&publics).verify()?;
+    println!("Proof verification successful!");
+
+    println!("\u{2713} Successfully generated and verified all proofs!");
+
+    Ok(())
+}

--- a/examples/sha-hasher/host/bin/remote/execute.rs
+++ b/examples/sha-hasher/host/bin/remote/execute.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use sha_hasher_common::Output;
+use zisk_sdk::{load_program, GuestProgram, ProverClient, ZiskStdin};
+
+static PROGRAM: GuestProgram = load_program!("sha-hasher-guest");
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("Starting ZisK Prover Client...");
+
+    // Create an input stream and write '1000' to it.
+    let n = 1000u32;
+    let stdin = ZiskStdin::new();
+    stdin.write(&n);
+    println!("Input prepared: {} iterations", n);
+
+    // Create a `ProverClient` method.
+    println!("Building prover client...");
+    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
+
+    println!("Setting up program...");
+    client.upload(&PROGRAM).run()?;
+    client.setup(&PROGRAM).run()?.await?; // S'ha de fer un must use
+    println!("Setup completed successfully");
+
+    // Execute the program using the `ProverClient.execute` method, without generating a proof.
+    println!("Executing program (no proof generation)...");
+    let result = client.execute(&PROGRAM, stdin.clone()).run()?.await?;
+
+    println!("\u{2713} Execution completed successfully!");
+    println!("Cycles: {}", result.get_execution_steps());
+    println!("Duration: {} ms", result.get_execution_time());
+
+    println!("Reading public outputs...");
+    let output: Output = result.get_public_values_abi()?;
+    println!("Public outputs:");
+    println!("  Hash: {:02x?}", output.hash);
+    println!("  Iterations: {}", output.iterations);
+    println!("  Magic number: 0x{:08x}", output.magic_number);
+
+    Ok(())
+}

--- a/examples/sha-hasher/host/bin/remote/minimal.rs
+++ b/examples/sha-hasher/host/bin/remote/minimal.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use zisk_sdk::{load_program, GuestProgram, ProofKind, ProverClient, ZiskStdin};
+
+static PROGRAM: GuestProgram = load_program!("sha-hasher-guest");
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("Starting ZisK Prover Client (Minimal proof mode)...");
+
+    // Create an input stream and write '1000' to it.
+    let n = 1000u32;
+    let stdin = ZiskStdin::new();
+    stdin.write(&n);
+    println!("Input prepared: {} iterations", n);
+
+    // Create a `ProverClient` method.
+    println!("Building prover client...");
+    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
+
+    println!("Setting up program...");
+    client.upload(&PROGRAM).run()?;
+    client.setup(&PROGRAM).run()?.await?;
+    println!("Setup completed successfully");
+
+    println!("Generating Vadcop proof...");
+    let vadcop_result = client.prove(&PROGRAM, stdin).run()?.await?;
+    println!("Vadcop proof generated in {} ms", vadcop_result.get_proving_time());
+
+    println!("Reducing proof (this may take a while)...");
+    let result =
+        client.wrap_proof(vadcop_result.get_proof(), ProofKind::VadcopFinalMinimal).run()?.await?;
+
+    println!("Verifying minimal proof...");
+    result.verify()?;
+    println!("Minimal proof verification successful!");
+
+    println!("\u{2713} Successfully generated and verified minimal proof!");
+
+    Ok(())
+}

--- a/examples/sha-hasher/host/bin/remote/plonk.rs
+++ b/examples/sha-hasher/host/bin/remote/plonk.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use zisk_sdk::{load_program, GuestProgram, Proof, ProofKind, ProverClient, ZiskStdin};
+
+static PROGRAM: GuestProgram = load_program!("sha-hasher-guest");
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("Starting ZisK Prover Client (SNARK mode)...");
+
+    // Create an input stream and write '1000' to it.
+    let n = 1000u32;
+    let stdin = ZiskStdin::new();
+    stdin.write(&n);
+    println!("Input prepared: {} iterations", n);
+
+    // Create a `ProverClient` method.
+    println!("Building prover client with SNARK support...");
+    let client = ProverClient::remote("http://127.0.0.1:7000").build()?;
+
+    println!("Setting up program and generating verification key...");
+    client.upload(&PROGRAM).run()?;
+    client.setup(&PROGRAM).run()?.await?;
+    println!("Setup completed successfully");
+
+    println!("Generating Vadcop proof...");
+    let vadcop_result = client.prove(&PROGRAM, stdin).run()?.await?;
+    println!("Vadcop proof generated in {} ms", vadcop_result.get_proving_time());
+
+    println!("Wrapping into PLONK proof (this may take a while)...");
+    let snark_proof = client.wrap_proof(vadcop_result.get_proof(), ProofKind::Plonk).run()?.await?;
+    println!("PLONK proof wrapped successfully in {} ms", snark_proof.get_proving_time());
+    println!("Execution steps: {}", snark_proof.get_execution_steps());
+
+    println!("Verifying PLONK proof...");
+    snark_proof.verify()?;
+    println!("PLONK proof verification successful!");
+
+    println!("Saving PLONK proof to disk...");
+    snark_proof.save_proof("/tmp/sha_hasher_proof_snark.bin")?;
+    println!("Proof saved to /tmp/sha_hasher_proof_snark.bin");
+
+    println!("Loading and verifying saved PLONK proof...");
+    let proof = Proof::load("/tmp/sha_hasher_proof_snark.bin")?;
+    let vkey = PROGRAM.vk()?;
+    proof.with_program_vk(&vkey).verify()?;
+    println!("Saved PLONK proof verification successful!");
+
+    println!("\u{2713} Successfully generated and verified PLONK proof!");
+
+    Ok(())
+}

--- a/examples/sha-hasher/host/bin/remote/prove.rs
+++ b/examples/sha-hasher/host/bin/remote/prove.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
 
     println!("Generating proof (this may take a while)...");
     let result = client.prove(&PROGRAM, stdin).executor(ExecutorKind::Emulator).run()?.await?;
-    println!("Proof generated successfully in {:?}", result.get_proving_time());
+    println!("Proof generated successfully in {} ms", result.get_proving_time());
     println!("Execution steps: {}", result.get_execution_steps());
 
     println!("Verifying proof...");

--- a/examples/sha-hasher/host/src/main.rs
+++ b/examples/sha-hasher/host/src/main.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
     let setup_handle = client.setup(&PROGRAM).run()?;
     setup_handle.await?;
 
-    let input = ZiskStream::grpc();
+    let input = ZiskStream::unix();
 
     let handle = client.execute(&PROGRAM, input.clone()).executor(ExecutorKind::Assembly).run()?;
     input.write(&1000u32);
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     let result = handle.await?;
 
     println!(
-        "ZisK has executed program with {} cycles in {:?} ms",
+        "ZisK has executed program with {} cycles in {} ms",
         result.get_execution_steps(),
         result.get_execution_time()
     );


### PR DESCRIPTION
Rewrites the distributed_execution and hints_stream book chapters and refreshes examples/ to match the 0.17.0 SDK, where transport and hints sources are picked per-job from the SDK call instead of coordinator/worker CLI flags.
          
- quickstard and writing_programs.md: updates commands to match.                                                                                                                                                                                                            
- distributed_execution.md: new architecture, single-host quickstart, and systemd deployment path with full TOML reference.
                                                                                                  
- hints_stream.md: full chapter on the hints protocol, SDK usage, and distributed-mode transport selection via ZiskStream::unix()/grpc()/quic() and ZiskHints::from_file().

- Examples: sha-hasher/host split into embedded/ and remote/ bin trees; aggregation, big-program, hints, multiple-programs updated to the current SDK surface.  