### PR TITLE
Resilience when hints fail

### DIFF
--- a/distributed/crates/cluster-api/proto/zisk_cluster_api.proto
+++ b/distributed/crates/cluster-api/proto/zisk_cluster_api.proto
@@ -47,7 +47,12 @@ message WorkerMessage {
     ExecuteTaskResponse execute_task_response = 5;
     JobCancelledAck job_cancelled_ack = 6;
     SetupProgramAck setup_program_ack = 7;
+    WorkerRecoveryComplete recovery_complete = 8;
   }
+}
+
+message WorkerRecoveryComplete {
+  string worker_id = 1;
 }
 
 message SetupProgram {
@@ -208,6 +213,7 @@ message ExecuteTaskResponse {
     FinalProof final_proof = 9;
     WrapResult wrap_result = 10;
   }
+  bool worker_in_recovery = 11;
 }
 
 message WitnessExecInfo {

--- a/distributed/crates/cluster-api/src/conversions.rs
+++ b/distributed/crates/cluster-api/src/conversions.rs
@@ -381,6 +381,7 @@ impl From<ExecuteTaskResponse> for ExecuteTaskResponseDto {
                 Some(response.error_message)
             },
             result_data: result_data.unwrap(),
+            worker_in_recovery: response.worker_in_recovery,
         }
     }
 }

--- a/distributed/crates/cluster-common/src/dto.rs
+++ b/distributed/crates/cluster-common/src/dto.rs
@@ -268,6 +268,7 @@ pub struct ExecuteTaskResponseDto {
     pub success: bool,
     pub error_message: Option<String>,
     pub result_data: ExecuteTaskResponseResultDataDto,
+    pub worker_in_recovery: bool,
 }
 
 pub struct ContributionsResultDataDto {

--- a/distributed/crates/coordinator-server/src/backend/coordinator.rs
+++ b/distributed/crates/coordinator-server/src/backend/coordinator.rs
@@ -324,7 +324,7 @@ impl BackendService for CoordinatorBackend {
             .coordinator
             .subscribe_job_events(&job_id_internal)
             .await
-            .ok_or_else(|| internal(format!("job {} not found", job_id)))?;
+            .ok_or(ApiError::JobNotFound(job_id))?;
 
         let result = timeout(timeout_dur, async {
             loop {
@@ -373,7 +373,7 @@ impl BackendService for CoordinatorBackend {
             .coordinator
             .subscribe_job_events(&job_id_internal)
             .await
-            .ok_or_else(|| internal(format!("job {} not found", job_id)))?;
+            .ok_or(ApiError::JobNotFound(job_id))?;
 
         // Synthesize events the client missed between job submission and now.
         // Clone the Arc first so we can drop the jobs map lock before awaiting the job lock.

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -738,6 +738,19 @@ impl Coordinator {
     /// * `job_id` - Identifier of the failing job
     /// * `reason` - Human-readable description of the failure cause
     pub async fn fail_job(&self, job_id: &JobId, reason: impl AsRef<str>) -> CoordinatorResult<()> {
+        self.fail_job_with_recovery(job_id, reason, None).await
+    }
+
+    /// Same as [`Self::fail_job`] but parks `recovering_worker` in
+    /// `SettingUp` instead of `Ready` so the dispatcher won't pick it
+    /// while it does post-failure maintenance. The worker becomes
+    /// `Ready` again on the next `WorkerRecoveryComplete`.
+    pub async fn fail_job_with_recovery(
+        &self,
+        job_id: &JobId,
+        reason: impl AsRef<str>,
+        recovering_worker: Option<&WorkerId>,
+    ) -> CoordinatorResult<()> {
         let jobs_map = self.jobs.read().await;
         let job_entry =
             jobs_map.get(job_id).cloned().ok_or(CoordinatorError::NotFoundOrInaccessible)?;
@@ -758,7 +771,10 @@ impl Coordinator {
 
         // These operations only need the worker IDs, not the job lock.
         self.cancel_job_workers(&worker_ids, job_id, reason.as_ref()).await;
-        self.ensure_workers_ready(&worker_ids).await;
+        match recovering_worker {
+            Some(rec) => self.ensure_workers_ready_except(&worker_ids, rec).await,
+            None => self.ensure_workers_ready(&worker_ids).await,
+        }
 
         self.fire_job_event(job_id, CoordinatorJobEvent::Failed(reason.as_ref().to_string())).await;
 
@@ -1272,6 +1288,7 @@ mod tests {
                 },
                 publics: vec![],
             }),
+            worker_in_recovery: false,
         };
 
         // Should succeed (not error) — the late response is silently discarded

--- a/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
+++ b/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
@@ -104,6 +104,22 @@ impl Coordinator {
         Ok(())
     }
 
+    pub(crate) async fn handle_stream_recovery_complete(
+        &self,
+        worker_id: &WorkerId,
+    ) -> CoordinatorResult<()> {
+        if self.workers_pool.worker_state(worker_id).await == Some(WorkerState::SettingUp) {
+            let _ = self.workers_pool.mark_worker_with_state(worker_id, WorkerState::Ready).await;
+            info!("[Recovery] Worker {} finished recovery, now Ready", worker_id);
+        } else {
+            warn!(
+                "[Recovery] Worker {} sent RecoveryComplete but is not in SettingUp; ignoring",
+                worker_id
+            );
+        }
+        Ok(())
+    }
+
     /// Sends cancellation messages to all workers assigned to a job.
     /// Best-effort: logs warnings on failure but continues.
     pub(crate) async fn cancel_job_workers(
@@ -126,6 +142,21 @@ impl Coordinator {
     /// Marks all Computing workers in the list as Ready.
     pub(super) async fn ensure_workers_ready(&self, worker_ids: &[WorkerId]) {
         self.workers_pool.mark_computing_workers_ready(worker_ids).await;
+    }
+
+    pub(super) async fn ensure_workers_ready_except(
+        &self,
+        worker_ids: &[WorkerId],
+        recovering: &WorkerId,
+    ) {
+        let others: Vec<WorkerId> =
+            worker_ids.iter().filter(|w| *w != recovering).cloned().collect();
+        self.workers_pool.mark_computing_workers_ready(&others).await;
+        if self.workers_pool.worker_state(recovering).await.is_some() {
+            let _ =
+                self.workers_pool.mark_worker_with_state(recovering, WorkerState::SettingUp).await;
+            info!("[Recovery] Worker {} entered SettingUp pending recovery completion", recovering);
+        }
     }
 
     /// Handles new worker registration. Returns `(accepted, message)`.
@@ -527,7 +558,8 @@ impl Coordinator {
     ///
     /// * `message` - Task response containing failure details and context
     async fn handle_task_failure(&self, message: ExecuteTaskResponseDto) -> CoordinatorResult<()> {
-        self.fail_job(&message.job_id, "Task execution failed").await?;
+        let recovering = if message.worker_in_recovery { Some(&message.worker_id) } else { None };
+        self.fail_job_with_recovery(&message.job_id, "Task execution failed", recovering).await?;
 
         Err(CoordinatorError::WorkerError(format!(
             "Worker {} failed to execute task for {}: {}",

--- a/distributed/crates/coordinator/src/coordinator_grpc.rs
+++ b/distributed/crates/coordinator/src/coordinator_grpc.rs
@@ -198,6 +198,10 @@ impl CoordinatorGrpc {
                         })
                         .await
                 }
+                worker_message::Payload::RecoveryComplete(rc) => {
+                    Self::validate_same_worker_id(worker_id, &rc.worker_id)?;
+                    coordinator.handle_stream_recovery_complete(worker_id).await
+                }
             },
             None => Err(CoordinatorError::InvalidRequest("Invalid message format".to_string())),
         }

--- a/distributed/crates/worker/src/cli/main.rs
+++ b/distributed/crates/worker/src/cli/main.rs
@@ -140,11 +140,27 @@ async fn main() -> Result<()> {
 
     if prover_config.emulator {
         let mut worker = WorkerNode::<Emu>::new_emu(worker_config, prover_config).await?;
-        return worker.run().await;
+        run_with_signals(worker.run()).await
     } else {
         let mut worker = WorkerNode::<Asm>::new_asm(worker_config, prover_config).await?;
-        return worker.run().await;
-    };
+        run_with_signals(worker.run()).await
+    }
+}
+
+async fn run_with_signals(fut: impl std::future::Future<Output = Result<()>>) -> Result<()> {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut sigterm = signal(SignalKind::terminate())?;
+    tokio::select! {
+        res = fut => res,
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!("Received SIGINT, shutting down gracefully");
+            Ok(())
+        }
+        _ = sigterm.recv() => {
+            tracing::info!("Received SIGTERM, shutting down gracefully");
+            Ok(())
+        }
+    }
 }
 
 fn print_command_info(

--- a/distributed/crates/worker/src/worker.rs
+++ b/distributed/crates/worker/src/worker.rs
@@ -412,6 +412,12 @@ impl<T: ZiskBackend + 'static> Worker<T> {
         self.prover.clone()
     }
 
+    /// Returns a clone of the cached `Arc<GuestProgram>` for `hash_id`,
+    /// or `None` if the program isn't set up on this worker.
+    pub fn guest_program(&self, hash_id: &str) -> Option<Arc<GuestProgram>> {
+        self.guest_programs.get(hash_id).cloned()
+    }
+
     pub async fn cancel_current_computation(&mut self) {
         self.prover.cancel();
 
@@ -842,7 +848,7 @@ impl<T: ZiskBackend + 'static> Worker<T> {
             }
             Err(err) => {
                 error!("Failed to generate proof for {job_id}: {:?}", err);
-                return Err(anyhow::anyhow!("Failed to generate proof"));
+                return Err(err.context("Failed to generate proof"));
             }
         };
 
@@ -1239,6 +1245,8 @@ impl<T: ZiskBackend + 'static> Worker<T> {
 
                 let guest_programs = self.guest_programs.clone();
                 let is_execution = matches!(tag, WorkerMpiTag::Execution);
+                let world_rank = self.world_rank();
+                let hash_id = message.hash_id.clone();
                 tokio::task::spawn_blocking(move || {
                     let run = || -> Result<()> {
                         if is_execution {
@@ -1274,6 +1282,23 @@ impl<T: ZiskBackend + 'static> Worker<T> {
 
                     if let Err(e) = run() {
                         error!("MPI broadcast task failed: {}. Waiting for new job...", e);
+                        // Soft-reset on peer ranks: rank 0 signals reset off the
+                        // dispatch path via worker_node, but peer ranks have no
+                        // coordinator channel, so they signal here. The next collective
+                        // broadcast acts as the synchronization point with rank 0.
+                        match guest_programs.get(&hash_id).cloned() {
+                            Some(elf) => {
+                                warn!("[Recovery] rank {world_rank}: signalling ASM soft reset");
+                                if let Err(e) = prover.restart_asm_resources(&elf, with_hints) {
+                                    error!(
+                                        "[Recovery] rank {world_rank}: soft reset failed: {e:#}"
+                                    );
+                                }
+                            }
+                            None => error!(
+                                "[Recovery] rank {world_rank}: guest program missing for hash_id={hash_id}"
+                            ),
+                        }
                     }
                 });
             }

--- a/distributed/crates/worker/src/worker_node.rs
+++ b/distributed/crates/worker/src/worker_node.rs
@@ -197,10 +197,12 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
             // On panic/cancel, the handle branch fires and we report the error.
             let mut computation_handle = self.worker.take_current_computation();
 
-            // biased: computation_rx must be checked before the JoinHandle branch.
-            // When a task completes normally, both become ready simultaneously.
-            // Without biased, select! picks non-deterministically and the JoinHandle
-            // branch could win, discarding the actual result.
+            // Branches are polled in declaration order. This is a soft preference,
+            // not a correctness guarantee — a cross-thread wakeup race can still let
+            // the JoinHandle resolve before the channel poll observes a just-sent
+            // message, so the JoinHandle Ok(()) arm re-drains the channel via try_recv.
+            // The ordering still matters for branch priority: compute results >
+            // coordinator messages > task health > heartbeat.
             tokio::select! {
                 biased;
 
@@ -227,7 +229,16 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                             if let Err(e) = self.handle_coordinator_message(message, &message_sender, computation_tx).await {
                                 error!("Error handling coordinator message: {}", e);
                                 self.report_computation_error(&message_sender, &e.to_string()).await;
-                                break;
+                                // Only truly fatal errors (e.g. registration rejected) set state
+                                // to Error inside the handler — those break the loop and trigger
+                                // reconnect. Recoverable errors (task dispatch failures, unknown
+                                // task types, etc.) just reset the worker to Ready and keep the
+                                // stream alive.
+                                if matches!(self.worker.state(), WorkerState::Error) {
+                                    break;
+                                }
+                                self.worker.set_current_job(None);
+                                self.worker.set_state(WorkerState::Ready);
                             }
                         }
                         Err(e) => {
@@ -236,11 +247,11 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                         }
                     }
                 }
-                // Monitor the computation task handle directly. This branch only
-                // fires when the task finishes WITHOUT sending a ComputationResult
-                // (panic, cancellation, or unexpected silent exit).
-                // Because of biased, computation_rx is checked first — so this only
-                // fires when the channel is empty (i.e., the task truly didn't send).
+                // Monitor the computation task handle directly. Fires on panic,
+                // cancellation, or silent exit. `biased` checks computation_rx first,
+                // but a cross-thread wakeup race can let the JoinHandle resolve before
+                // the channel poll observes a just-sent message — so on `Ok(())` we
+                // re-drain the channel before declaring a silent exit.
                 join_result = async { computation_handle.as_mut().unwrap().await }, if computation_handle.is_some() => {
                     match join_result {
                         Err(join_error) => {
@@ -250,11 +261,20 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                             self.worker.set_state(WorkerState::Ready);
                         }
                         Ok(()) => {
-                            // Task completed without sending a ComputationResult — shouldn't
-                            // happen in normal operation, but handle it defensively.
-                            warn!("Computation task exited without sending a result");
-                            self.worker.set_current_job(None);
-                            self.worker.set_state(WorkerState::Ready);
+                            match computation_rx.try_recv() {
+                                Ok(result) => {
+                                    if let Err(e) = self.handle_computation_result(result, &message_sender).await {
+                                        error!("Error handling computation result: {}", e);
+                                        self.report_computation_error(&message_sender, &e.to_string()).await;
+                                        break;
+                                    }
+                                }
+                                Err(_) => {
+                                    warn!("Computation task exited without sending a result");
+                                    self.worker.set_current_job(None);
+                                    self.worker.set_state(WorkerState::Ready);
+                                }
+                            }
                         }
                     }
                 }
@@ -428,6 +448,11 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
             zisk_execution_time: Some(zisk_execution_time),
         }));
 
+        // On failure with poisoned ASM: park ourselves in `SettingUp` via
+        // the response flag, then run the respawn off-task.
+        let recovery_ctx = if success { None } else { self.collect_recovery_context().await };
+        let worker_in_recovery = recovery_ctx.is_some();
+
         let message = WorkerMessage {
             payload: Some(worker_message::Payload::ExecuteTaskResponse(ExecuteTaskResponse {
                 worker_id: self.worker_config.worker.worker_id.as_string(),
@@ -436,10 +461,15 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                 success,
                 result_data: result_data_msg,
                 error_message,
+                worker_in_recovery,
             })),
         };
 
         message_sender.send(message)?;
+
+        if let Some((guest_program, with_hints)) = recovery_ctx {
+            self.spawn_post_failure_recovery(guest_program, with_hints, message_sender.clone());
+        }
 
         Ok(())
     }
@@ -506,6 +536,10 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
             witness_info: Some(witness_info_msg),
         }));
 
+        // Same recovery handshake as the contribution path.
+        let recovery_ctx = if success { None } else { self.collect_recovery_context().await };
+        let worker_in_recovery = recovery_ctx.is_some();
+
         let message = WorkerMessage {
             payload: Some(worker_message::Payload::ExecuteTaskResponse(ExecuteTaskResponse {
                 worker_id: self.worker_config.worker.worker_id.as_string(),
@@ -514,10 +548,15 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                 success,
                 result_data: result_data_msg,
                 error_message,
+                worker_in_recovery,
             })),
         };
 
         message_sender.send(message)?;
+
+        if let Some((guest_program, with_hints)) = recovery_ctx {
+            self.spawn_post_failure_recovery(guest_program, with_hints, message_sender.clone());
+        }
 
         Ok(())
     }
@@ -572,6 +611,7 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                 success,
                 result_data: Some(ResultData::Proofs(ProofList { proofs: result_data })),
                 error_message,
+                worker_in_recovery: false,
             })),
         };
 
@@ -681,6 +721,7 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                 success,
                 result_data,
                 error_message,
+                worker_in_recovery: false,
             })),
         };
 
@@ -694,6 +735,56 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
         }
 
         Ok(())
+    }
+
+    /// Returns `(elf, with_hints)` for the failed job, used to drive the
+    /// soft-reset signal in `spawn_post_failure_recovery`.
+    async fn collect_recovery_context(
+        &self,
+    ) -> Option<(std::sync::Arc<zisk_prover_backend::GuestProgram>, bool)> {
+        let job = self.worker.current_job()?;
+        let (hash_id, with_hints) = {
+            let g = job.lock().await;
+            let with_hints = !matches!(g.data_ctx.hints_source, HintsSourceDto::HintsNull);
+            (g.hash_id.clone(), with_hints)
+        };
+        Some((self.worker.guest_program(&hash_id)?, with_hints))
+    }
+
+    /// Soft-reset the ASM children off-task, then send `WorkerRecoveryComplete`
+    /// so the coordinator flips us from `SettingUp` back to `Ready`.
+    fn spawn_post_failure_recovery(
+        &self,
+        guest_program: std::sync::Arc<zisk_prover_backend::GuestProgram>,
+        with_hints: bool,
+        message_sender: mpsc::UnboundedSender<WorkerMessage>,
+    ) {
+        let prover = self.worker.prover_arc();
+        let worker_id = self.worker_config.worker.worker_id.as_string();
+        tokio::spawn(async move {
+            warn!("[Recovery] {worker_id}: signalling ASM soft reset");
+            let join = tokio::task::spawn_blocking(move || {
+                prover.restart_asm_resources(&guest_program, with_hints)
+            })
+            .await;
+            match join {
+                Ok(Ok(())) => {
+                    info!("[Recovery] {worker_id}: soft reset done; signalling Ready");
+                    let msg = WorkerMessage {
+                        payload: Some(worker_message::Payload::RecoveryComplete(
+                            WorkerRecoveryComplete { worker_id: worker_id.clone() },
+                        )),
+                    };
+                    if let Err(e) = message_sender.send(msg) {
+                        error!("[Recovery] {worker_id}: send RecoveryComplete failed: {e}");
+                    }
+                }
+                Ok(Err(e)) => error!(
+                    "[Recovery] {worker_id}: soft reset failed: {e:#}; worker stays in SettingUp"
+                ),
+                Err(e) => error!("[Recovery] {worker_id}: recovery task panicked: {e}"),
+            }
+        });
     }
 
     async fn send_heartbeat_ack(
@@ -788,30 +879,49 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                 } else {
                     self.worker.set_state(WorkerState::Error);
                     error!("Registration rejected: {}", response.message);
-                    std::process::exit(1);
+                    return Err(anyhow!("Registration rejected: {}", response.message));
                 }
             }
             coordinator_message::Payload::ExecuteTask(request) => {
-                match TaskType::try_from(request.task_type) {
-                    Ok(TaskType::Execution) => {
-                        self.execute_only(request, computation_tx).await?;
-                    }
+                let job_id = request.job_id.clone();
+                let task_type_int = request.task_type;
+                let dispatch = match TaskType::try_from(task_type_int) {
+                    Ok(TaskType::Execution) => self.execute_only(request, computation_tx).await,
                     Ok(TaskType::PartialContribution) => {
-                        self.partial_contribution(request, computation_tx).await?;
+                        self.partial_contribution(request, computation_tx).await
                     }
-                    Ok(TaskType::Prove) => {
-                        self.prove(request, computation_tx).await?;
+                    Ok(TaskType::Prove) => self.prove(request, computation_tx).await,
+                    Ok(TaskType::Aggregate) => self.aggregate(request, computation_tx).await,
+                    Ok(TaskType::Wrap) => self.handle_wrap_task(request, message_sender).await,
+                    Err(_) => Err(anyhow!("Unknown task type: {task_type_int}")),
+                };
+
+                // Dispatch failures (cache miss, unknown task type, etc.) happen
+                // before any computation starts, so `current_job` may not be set
+                // and `report_computation_error` would silently drop the report.
+                // Send a proper `ExecuteTaskResponse` failure here using the
+                // request's `job_id` so the coordinator can fail the job and
+                // route work elsewhere instead of waiting on a phantom worker.
+                if let Err(e) = dispatch {
+                    error!("Failed to dispatch task {job_id}: {e:#}");
+                    let response = WorkerMessage {
+                        payload: Some(worker_message::Payload::ExecuteTaskResponse(
+                            ExecuteTaskResponse {
+                                worker_id: self.worker_config.worker.worker_id.as_string(),
+                                job_id,
+                                task_type: task_type_int,
+                                success: false,
+                                result_data: None,
+                                error_message: e.to_string(),
+                                worker_in_recovery: false,
+                            },
+                        )),
+                    };
+                    if let Err(send_err) = message_sender.send(response) {
+                        warn!("Failed to send dispatch-failure response: {send_err}");
                     }
-                    Ok(TaskType::Aggregate) => {
-                        self.aggregate(request, computation_tx).await?;
-                    }
-                    Ok(TaskType::Wrap) => {
-                        self.handle_wrap_task(request, message_sender).await?;
-                    }
-                    Err(_) => {
-                        error!("Unknown task type: {}", request.task_type);
-                        return Err(anyhow!("Unknown task type: {}", request.task_type));
-                    }
+                    self.worker.set_current_job(None);
+                    self.worker.set_state(WorkerState::Ready);
                 }
             }
             coordinator_message::Payload::StreamData(stream_data) => {
@@ -1328,6 +1438,7 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                 success,
                 result_data,
                 error_message,
+                worker_in_recovery: false,
             })),
         };
 

--- a/emulator-asm/asm-runner/src/asm_mo_runner.rs
+++ b/emulator-asm/asm-runner/src/asm_mo_runner.rs
@@ -195,54 +195,61 @@ impl AsmRunnerMO {
             }
         };
 
-        if exit_code != 0 {
-            return Err(AsmRunError::ExitCode(exit_code as u32))
-                .context("Child process returned error");
-        }
-
-        // Wait for the assembly emulator to complete writing the trace
-        let response = handle
-            .join()
-            .map_err(|_| AsmRunError::JoinPanic)?
-            .map_err(AsmRunError::ServiceError)?;
-
-        if response.result != 0 {
-            return Err(anyhow::anyhow!(
-                "ASM MO service returned non-zero result: {}",
-                response.result
-            ));
-        }
-        if response.trace_len == 0 {
-            return Err(anyhow::anyhow!("ASM MO service returned empty trace"));
-        }
-        if response.trace_len > response.allocated_len {
-            return Err(anyhow::anyhow!(
-                "ASM MO service trace_len ({}) exceeds allocated_len ({})",
-                response.trace_len,
-                response.allocated_len
-            ));
-        }
-
+        // Wind the C++ planner down before any further work. Without this,
+        // its background threads stay parked waiting for more chunks, and
+        // the C++ destructor blocks on `Drop`, holding the `MOShMemReader`
+        // Mutex and hanging the next job's MO thread on lock acquisition.
         mem_planner.set_completed();
-        // Wait for mem_align_plans, this mem_align_plans are calculated in rust from
-        // counters calculated in C++
-        let mut mem_align_plans = mem_planner.wait_mem_align_plans();
         mem_planner.wait();
 
-        stats_end!(_stats, &_process_scope);
-        stats_begin!(_stats, &_runner_scope, _collect_scope, "MO_COLLECT_PLANS", 0);
+        // Compute the result; on any error we still fall through to the
+        // single re-stash point below so the next job has a planner ready.
+        let result: Result<Vec<Plan>> = (|| -> Result<Vec<Plan>> {
+            if exit_code != 0 {
+                return Err(AsmRunError::ExitCode(exit_code as u32))
+                    .context("Child process returned error");
+            }
 
-        let plans = mem_planner.collect_plans(&mut mem_align_plans);
+            let response = handle
+                .join()
+                .map_err(|_| AsmRunError::JoinPanic)?
+                .map_err(AsmRunError::ServiceError)?;
 
-        #[cfg(feature = "save_mem_plans")]
-        save_plans(&plans, "mem_plans_cpp.txt");
+            if response.result != 0 {
+                return Err(anyhow::anyhow!(
+                    "ASM MO service returned non-zero result: {}",
+                    response.result
+                ));
+            }
+            if response.trace_len == 0 {
+                return Err(anyhow::anyhow!("ASM MO service returned empty trace"));
+            }
+            if response.trace_len > response.allocated_len {
+                return Err(anyhow::anyhow!(
+                    "ASM MO service trace_len ({}) exceeds allocated_len ({})",
+                    response.trace_len,
+                    response.allocated_len
+                ));
+            }
 
-        stats_end!(_stats, &_collect_scope);
+            let mut mem_align_plans = mem_planner.wait_mem_align_plans();
+            stats_end!(_stats, &_process_scope);
+            stats_begin!(_stats, &_runner_scope, _collect_scope, "MO_COLLECT_PLANS", 0);
+            let plans = mem_planner.collect_plans(&mut mem_align_plans);
+            stats_end!(_stats, &_collect_scope);
+            Ok(plans)
+        })();
 
+        // Always re-stash the planner so the next call has one to take.
         preloaded.handle_mo = Some(std::thread::spawn(move || {
             drop(mem_planner);
             MemPlanner::new()
         }));
+
+        let plans = result?;
+
+        #[cfg(feature = "save_mem_plans")]
+        save_plans(&plans, "mem_plans_cpp.txt");
 
         stats_end!(_stats, &_runner_scope);
         Ok(AsmRunnerMO::new(plans))

--- a/emulator-asm/asm-runner/src/asm_services/services.rs
+++ b/emulator-asm/asm-runner/src/asm_services/services.rs
@@ -64,6 +64,7 @@ impl AsmService {
             unsafe {
                 command.pre_exec(|| {
                     libc::setpriority(libc::PRIO_PROCESS, 0, -5);
+                    libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
                     Ok(())
                 });
             }
@@ -392,6 +393,37 @@ impl AsmServices {
     #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
     pub fn send_shutdown_and_wait(&self, _: &AsmService) -> Result<()> {
         Ok(())
+    }
+
+    /// Unlink every `/dev/shm/{shm_prefix}*` shmem segment and
+    /// `/dev/shm/sem.{sem_prefix}*` semaphore. The C-side `server_cleanup`
+    /// only unlinks if `delete_input_shm`/`delete_output_shm` flags are
+    /// set — which the long-running ASM service children don't have — so
+    /// the parent has to do it. Call after `stop_asm_services` so the
+    /// children are already detached from the segments.
+    pub fn cleanup_my_shmem(&self) {
+        let dev_shm = std::path::Path::new("/dev/shm");
+        let entries = match std::fs::read_dir(dev_shm) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!("Cannot scan /dev/shm for cleanup: {e}");
+                return;
+            }
+        };
+        let sem_marker = format!("sem.{}", self.sem_prefix);
+        for entry in entries.flatten() {
+            let Some(name) = entry.file_name().to_str().map(str::to_string) else { continue };
+            if name.starts_with(&self.shm_prefix) {
+                let _ = shm_unlink_by_name(&name);
+            } else if let Some(rest) = name.strip_prefix("sem.") {
+                if name.starts_with(&sem_marker) {
+                    let sem_name = format!("/{rest}");
+                    if let Ok(cstr) = std::ffi::CString::new(sem_name) {
+                        unsafe { libc::sem_unlink(cstr.as_ptr()) };
+                    }
+                }
+            }
+        }
     }
 
     pub(super) fn encode_request(request: RequestData) -> [u8; 40] {

--- a/emulator-asm/asm-runner/src/control_shmem.rs
+++ b/emulator-asm/asm-runner/src/control_shmem.rs
@@ -6,11 +6,14 @@ pub struct ControlShmem {
     writers: Vec<SharedMemoryWriter>,
 }
 
+/// Byte offsets into the C-side `shmem_control_input_address` array.
+/// Each slot is a `u64`; the C wait functions read these on every iteration.
 #[derive(Copy, Clone)]
-pub enum ControlShmemOffsets {
+enum ControlShmemOffsets {
     PrecompilesSize = 0,
     ShutdownFlag = 8,
     InputsSize = 16,
+    ResetFlag = 24,
 }
 
 impl ControlShmem {
@@ -32,21 +35,12 @@ impl ControlShmem {
         Ok(Self { writers })
     }
 
-    pub fn read_u64_at(&self, offset: ControlShmemOffsets) -> u64 {
-        self.writers[0].read_u64_at(offset as usize)
-    }
-
-    pub fn write_u64_at(&self, offset: ControlShmemOffsets, size: u64) {
-        for writer in &self.writers {
-            writer.write_u64_at(offset as usize, size);
-        }
-    }
-
     pub fn reset(&self) {
         for writer in &self.writers {
             writer.write_u64_at(ControlShmemOffsets::PrecompilesSize as usize, 0);
             writer.write_u64_at(ControlShmemOffsets::ShutdownFlag as usize, 0);
             writer.write_u64_at(ControlShmemOffsets::InputsSize as usize, 0);
+            writer.write_u64_at(ControlShmemOffsets::ResetFlag as usize, 0);
         }
     }
 
@@ -60,15 +54,9 @@ impl ControlShmem {
         self.writers[0].read_u64_at(ControlShmemOffsets::PrecompilesSize as usize)
     }
 
-    pub fn set_shutdown_flag(&self) {
+    pub fn set_reset_flag(&self) {
         for writer in &self.writers {
-            writer.write_u64_at(ControlShmemOffsets::ShutdownFlag as usize, 1);
-        }
-    }
-
-    pub fn set_inputs_size(&self, size: u64) {
-        for writer in &self.writers {
-            writer.write_u64_at(ControlShmemOffsets::InputsSize as usize, size);
+            writer.write_u64_at(ControlShmemOffsets::ResetFlag as usize, 1);
         }
     }
 
@@ -78,9 +66,5 @@ impl ControlShmem {
         for writer in &self.writers {
             writer.write_u64_at(ControlShmemOffsets::InputsSize as usize, new_size);
         }
-    }
-
-    pub fn inputs_size(&self) -> u64 {
-        self.writers[0].read_u64_at(ControlShmemOffsets::InputsSize as usize)
     }
 }

--- a/emulator-asm/asm-runner/src/hints_shmem.rs
+++ b/emulator-asm/asm-runner/src/hints_shmem.rs
@@ -5,33 +5,37 @@
 
 use crate::{
     sem_available_name, sem_read_name, shmem_control_reader_name, shmem_precompile_name,
-    AsmService, AsmServices, ControlShmem, SharedMemoryReader, SharedMemoryWriter,
+    AsmService, AsmServices, ControlShmem, SharedMemoryWriter,
 };
 use anyhow::Result;
 use named_sem::NamedSemaphore;
-use std::{
-    cell::RefCell,
-    sync::{
-        atomic::{fence, AtomicUsize, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{fence, AtomicUsize, Ordering},
+    Arc, Mutex,
 };
 use tracing::debug;
 use zisk_common::io::StreamSink;
 
-/// Per-service shmem resources
+/// Per-service control-output shmem (the C side's
+/// `precompile_read_address`). Read by the parent for flow control in
+/// `submit` (slowest-consumer wait); the C side resets it to 0 itself
+/// in `server_reset_fast()` after every emulation.
 struct SeparateShm {
-    /// Consumer's read-position control shmem.
-    control_reader: SharedMemoryReader,
+    control_output: SharedMemoryWriter,
 }
 
+// SAFETY: serialised by the enclosing `Mutex<Vec<SeparateShm>>`.
+unsafe impl Send for SeparateShm {}
+unsafe impl Sync for SeparateShm {}
+
 impl SeparateShm {
-    pub fn new(shm_prefix: &str, service: AsmService) -> Result<Self> {
+    pub fn new(shm_prefix: &str, unlock_mapped_memory: bool, service: AsmService) -> Result<Self> {
         let name = shmem_control_reader_name(shm_prefix, service);
         Ok(Self {
-            control_reader: SharedMemoryReader::new(
+            control_output: SharedMemoryWriter::new(
                 &name,
                 HintsShmem::CONTROL_PRECOMPILE_SIZE as usize,
+                unlock_mapped_memory,
             )?,
         })
     }
@@ -45,6 +49,10 @@ struct SeparateSem {
     sem_read: NamedSemaphore,
 }
 
+// SAFETY: POSIX named semaphores are thread- and process-safe by spec.
+unsafe impl Send for SeparateSem {}
+unsafe impl Sync for SeparateSem {}
+
 /// Unified resources shared across all asm services.
 struct UnifiedResources {
     /// Control shared memory writer (single write_pos)
@@ -54,20 +62,21 @@ struct UnifiedResources {
     data_writers: Vec<SharedMemoryWriter>,
 }
 
+// SAFETY: writes are serialized by the enclosing `Mutex<UnifiedResources>`.
+unsafe impl Send for UnifiedResources {}
+unsafe impl Sync for UnifiedResources {}
+
 /// HintsShmem struct manages the writing of processed precompile hints to shared memory.
 pub struct HintsShmem {
     /// Number of active ASM services to notify on submit.
     active_count: AtomicUsize,
     /// Unified resources (single data buffer and control writer)
-    unified: RefCell<UnifiedResources>,
+    unified: Mutex<UnifiedResources>,
     /// Per-service shmem.
-    separate_shm: RefCell<Vec<SeparateShm>>,
+    separate_shm: Mutex<Vec<SeparateShm>>,
     /// Per-program semaphores.
-    separate_sem: RefCell<Option<Vec<SeparateSem>>>,
+    separate_sem: Mutex<Option<Vec<SeparateSem>>>,
 }
-
-unsafe impl Send for HintsShmem {}
-unsafe impl Sync for HintsShmem {}
 
 impl HintsShmem {
     const CONTROL_PRECOMPILE_SIZE: u64 = 0x1000; // 4KB
@@ -88,13 +97,13 @@ impl HintsShmem {
         // Create separate resources
         let separate_shm = AsmServices::SERVICES
             .iter()
-            .map(|service| SeparateShm::new(shm_prefix, *service))
+            .map(|service| SeparateShm::new(shm_prefix, unlock_mapped_memory, *service))
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Self {
-            unified: RefCell::new(unified),
-            separate_shm: RefCell::new(separate_shm),
-            separate_sem: RefCell::new(None),
+            unified: Mutex::new(unified),
+            separate_shm: Mutex::new(separate_shm),
+            separate_sem: Mutex::new(None),
             active_count: AtomicUsize::new(active_services.len()),
         })
     }
@@ -117,13 +126,31 @@ impl HintsShmem {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        *self.separate_sem.borrow_mut() = Some(sems);
+        *self.separate_sem.lock().expect("separate_sem mutex poisoned") = Some(sems);
+        Ok(())
+    }
+
+    /// Soft-reset signal: write `1` to the `ResetFlag` slot and post
+    /// `sem_prec_avail` to wake any child sleeping in `_wait_for_prec_avail`.
+    /// The C side returns non-zero from the wait function, the assembly
+    /// unwinds cleanly out of `emulator_start()`, and the child stays alive
+    /// for the next request — no respawn.
+    pub fn signal_children_reset(&self) -> Result<()> {
+        self.unified.lock().expect("unified mutex poisoned").control_writer.set_reset_flag();
+        if let Some(sems) = self.separate_sem.lock().expect("separate_sem mutex poisoned").as_mut()
+        {
+            for sem in sems.iter_mut() {
+                if let Err(e) = sem.sem_available.post() {
+                    tracing::warn!("signal_children_reset: sem_available.post failed: {e}");
+                }
+            }
+        }
         Ok(())
     }
 
     /// Drop the semaphore handles (does not unlink — the binary owns the names).
     pub fn unbind_semaphores(&self) {
-        *self.separate_sem.borrow_mut() = None;
+        *self.separate_sem.lock().expect("separate_sem mutex poisoned") = None;
     }
 
     /// Update the number of active ASM services notified on each submit.
@@ -190,9 +217,9 @@ impl StreamSink for HintsShmem {
             ));
         }
 
-        let mut unified = self.unified.borrow_mut();
-        let separate_shm = self.separate_shm.borrow();
-        let mut separate_sem_guard = self.separate_sem.borrow_mut();
+        let mut unified = self.unified.lock().expect("unified mutex poisoned");
+        let separate_shm = self.separate_shm.lock().expect("separate_shm mutex poisoned");
+        let mut separate_sem_guard = self.separate_sem.lock().expect("separate_sem mutex poisoned");
         debug_assert!(separate_sem_guard.is_some(), "submit called before bind_semaphores");
 
         let active = self.active_count.load(Ordering::SeqCst);
@@ -214,7 +241,7 @@ impl StreamSink for HintsShmem {
             let (slowest_idx, min_read_pos) = separate_shm[0..active]
                 .iter()
                 .enumerate()
-                .map(|(i, res)| (i, res.control_reader.read_u64_at(0)))
+                .map(|(i, res)| (i, res.control_output.read_u64_at(0)))
                 .min_by_key(|(_, pos)| *pos)
                 .unwrap();
 
@@ -267,30 +294,18 @@ impl StreamSink for HintsShmem {
     }
 
     fn reset(&self) {
-        // Reset control writer and all data writers to initial state for next stream
-        let mut unified = self.unified.borrow_mut();
+        let mut unified = self.unified.lock().expect("unified mutex poisoned");
         unified.control_writer.reset();
         for writer in &mut unified.data_writers {
             writer.reset();
         }
 
-        // Drain stale semaphore signals from previous execution
-        if let Some(separate_sem) = self.separate_sem.borrow_mut().as_mut() {
-            for res in separate_sem.iter_mut() {
+        // Drain any leftover semaphore counts from the previous run.
+        if let Some(sems) = self.separate_sem.lock().expect("separate_sem mutex poisoned").as_mut()
+        {
+            for res in sems.iter_mut() {
                 while res.sem_available.try_wait().is_ok() {}
                 while res.sem_read.try_wait().is_ok() {}
-            }
-        }
-
-        for (idx, res) in self.separate_shm.borrow().iter().enumerate() {
-            let read_pos = res.control_reader.read_u64_at(0);
-            if read_pos != 0 {
-                tracing::warn!(
-                    "HintsShmem::reset: control_reader[{}] read position is {} (expected 0). \
-                     Previous emulation may not have completed cleanly.",
-                    idx,
-                    read_pos
-                );
             }
         }
     }

--- a/emulator-asm/asm-runner/src/hints_shmem.rs
+++ b/emulator-asm/asm-runner/src/hints_shmem.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     sem_available_name, sem_read_name, shmem_control_reader_name, shmem_precompile_name,
-    AsmService, AsmServices, ControlShmem, SharedMemoryWriter,
+    AsmService, AsmServices, ControlShmem, SharedMemoryReader, SharedMemoryWriter,
 };
 use anyhow::Result;
 use named_sem::NamedSemaphore;
@@ -21,7 +21,7 @@ use zisk_common::io::StreamSink;
 /// `submit` (slowest-consumer wait); the C side resets it to 0 itself
 /// in `server_reset_fast()` after every emulation.
 struct SeparateShm {
-    control_output: SharedMemoryWriter,
+    control_reader: SharedMemoryReader,
 }
 
 // SAFETY: serialised by the enclosing `Mutex<Vec<SeparateShm>>`.
@@ -29,13 +29,12 @@ unsafe impl Send for SeparateShm {}
 unsafe impl Sync for SeparateShm {}
 
 impl SeparateShm {
-    pub fn new(shm_prefix: &str, unlock_mapped_memory: bool, service: AsmService) -> Result<Self> {
+    pub fn new(shm_prefix: &str, service: AsmService) -> Result<Self> {
         let name = shmem_control_reader_name(shm_prefix, service);
         Ok(Self {
-            control_output: SharedMemoryWriter::new(
+            control_reader: SharedMemoryReader::new(
                 &name,
                 HintsShmem::CONTROL_PRECOMPILE_SIZE as usize,
-                unlock_mapped_memory,
             )?,
         })
     }
@@ -97,7 +96,7 @@ impl HintsShmem {
         // Create separate resources
         let separate_shm = AsmServices::SERVICES
             .iter()
-            .map(|service| SeparateShm::new(shm_prefix, unlock_mapped_memory, *service))
+            .map(|service| SeparateShm::new(shm_prefix, *service))
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Self {
@@ -241,7 +240,7 @@ impl StreamSink for HintsShmem {
             let (slowest_idx, min_read_pos) = separate_shm[0..active]
                 .iter()
                 .enumerate()
-                .map(|(i, res)| (i, res.control_output.read_u64_at(0)))
+                .map(|(i, res)| (i, res.control_reader.read_u64_at(0)))
                 .min_by_key(|(_, pos)| *pos)
                 .unwrap();
 

--- a/emulator-asm/asm-runner/src/hints_shmem_stub.rs
+++ b/emulator-asm/asm-runner/src/hints_shmem_stub.rs
@@ -34,6 +34,12 @@ impl HintsShmem {
             "HintsShmem::set_active_services() is not supported on this platform. Only Linux x86_64 is supported."
         );
     }
+
+    pub fn signal_children_reset(&self) -> Result<()> {
+        unreachable!(
+            "HintsShmem::signal_children_reset() is not supported on this platform. Only Linux x86_64 is supported."
+        );
+    }
 }
 
 impl StreamSink for HintsShmem {

--- a/emulator-asm/asm-runner/src/inputs_shmem.rs
+++ b/emulator-asm/asm-runner/src/inputs_shmem.rs
@@ -88,7 +88,7 @@ impl InputsShmemWriter {
         Ok(())
     }
 
-    fn notify_all_services(&self) -> Result<()> {
+    pub fn notify_all_services(&self) -> Result<()> {
         if let Some(sems) = self.sem_avails.lock().unwrap().as_mut() {
             for sem in sems.iter_mut() {
                 sem.post()?;

--- a/emulator-asm/asm-runner/src/inputs_shmem_stub.rs
+++ b/emulator-asm/asm-runner/src/inputs_shmem_stub.rs
@@ -43,6 +43,12 @@ impl InputsShmemWriter {
         );
     }
 
+    pub fn notify_all_services(&self) -> Result<()> {
+        unreachable!(
+            "InputsShmemWriter::notify_all_services() is not supported on this platform. Only Linux x86_64 is supported."
+        );
+    }
+
     pub fn reset(&self) {
         unreachable!(
             "InputsShmemWriter::reset() is not supported on this platform. Only Linux x86_64 is supported."

--- a/emulator-asm/src/c_provided.c
+++ b/emulator-asm/src/c_provided.c
@@ -333,6 +333,11 @@ int _wait_for_prec_avail (void)
             asm_printf("ERROR: wait_for_prec_avail() found precompile_exit_address=%lu\n", *precompile_exit_address);
             exit(-1);
         }
+        if (*precompile_reset_address != 0)
+        {
+            asm_printf("INFO: wait_for_prec_avail() found precompile_reset_address=%lu, aborting emulation\n", *precompile_reset_address);
+            return 1;
+        }
         if (*precompile_written_address > *precompile_read_address)
         {
             // Sync precompile shared memory
@@ -417,6 +422,11 @@ int _wait_for_input_avail (uint64_t required_input_bytes)
         {
             asm_printf("ERROR: wait_for_input_avail() found precompile_exit_address=%lu\n", *precompile_exit_address);
             exit(-1);
+        }
+        if (*precompile_reset_address != 0)
+        {
+            asm_printf("INFO: wait_for_input_avail() found precompile_reset_address=%lu, aborting emulation\n", *precompile_reset_address);
+            return 1;
         }
         if (*input_written_address >= required_input_bytes)
         {

--- a/emulator-asm/src/globals.c
+++ b/emulator-asm/src/globals.c
@@ -113,6 +113,7 @@ uint64_t * shmem_control_input_address = NULL;
 volatile uint64_t * precompile_written_address = NULL;
 volatile uint64_t * precompile_exit_address = NULL;
 volatile uint64_t * input_written_address = NULL;
+volatile uint64_t * precompile_reset_address = NULL;
 
 // Control output shared memory
 int shmem_control_output_fd = -1;

--- a/emulator-asm/src/globals.hpp
+++ b/emulator-asm/src/globals.hpp
@@ -142,6 +142,7 @@ extern uint64_t * shmem_control_input_address;
 extern volatile uint64_t * precompile_written_address;
 extern volatile uint64_t * precompile_exit_address;
 extern volatile uint64_t * input_written_address;
+extern volatile uint64_t * precompile_reset_address;
 
 // Control output shared memory
 extern int shmem_control_output_fd;

--- a/emulator-asm/src/server.c
+++ b/emulator-asm/src/server.c
@@ -395,6 +395,7 @@ void server_setup (void)
     precompile_written_address = &shmem_control_input_address[0];
     precompile_exit_address = &shmem_control_input_address[1];
     input_written_address = &shmem_control_input_address[2];
+    precompile_reset_address = &shmem_control_input_address[3];
 
     // Report duration
     if (verbose)

--- a/executor/src/asm_resources.rs
+++ b/executor/src/asm_resources.rs
@@ -233,13 +233,26 @@ impl AsmResources {
             .unwrap_or(false)
     }
 
+    /// Soft-reset the C children: write `1` to the `ResetFlag` slot and
+    /// post both `sem_prec_avail` and `sem_input_avail` so any child
+    /// sleeping in either wait function wakes up and aborts the in-flight
+    /// emulation cleanly. Children stay alive — no respawn needed.
+    pub fn signal_children_reset(&self) -> Result<()> {
+        if let Some(s) = &self.shared.hints_stream {
+            let processor = s
+                .lock()
+                .map_err(|e| anyhow::anyhow!("hints_stream mutex poisoned: {e}"))?
+                .get_processor();
+            processor.hints_sink().signal_children_reset()?;
+        }
+        self.shared.inputs_shmem_writer.notify_all_services()?;
+        Ok(())
+    }
+
     pub fn reset(&self) {
         if let Some(s) = &self.shared.hints_stream {
-            s.lock().unwrap().reset();
+            s.lock().expect("hints_stream mutex poisoned").reset();
         }
-
-        // Full reset: clear shmem data and size.  Every job re-streams its
-        // input via the relay, so there is nothing to preserve.
         self.shared.inputs_shmem_writer.reset();
     }
 
@@ -304,5 +317,11 @@ impl Drop for AsmResources {
                 e
             );
         }
+        // The ASM service children don't unlink shmem on exit (the
+        // `delete_*_shm` flags aren't set for them), so the parent must
+        // unlink the `/dev/shm/{shm_prefix}*` and `sem.{sem_prefix}*`
+        // entries here. Otherwise GBs of `_input`, `_ram`, `_rom` files
+        // leak until the next worker startup runs `cleanup_stale_shmem`.
+        self.asm_services.cleanup_my_shmem();
     }
 }

--- a/precompiles/hints/src/hints_processor.rs
+++ b/precompiles/hints/src/hints_processor.rs
@@ -568,50 +568,53 @@ impl<S: StreamSink> HintsProcessor<S> {
                 break;
             }
 
-            // Drain all consecutive ready results from the front
+            // Drain all consecutive ready results from the front. Once the
+            // error flag is set, items are popped without submitting — the
+            // wire protocol with the C children is sequenced (each hint is
+            // delivered at a specific buffer offset), so submitting hint
+            // #N+1 after #N failed would feed the C side data it doesn't
+            // expect and crash it. The drainer stays alive across the
+            // failure so the next job's `reset_state` finds it ready.
             let mut drained_any = false;
             while let Some(Some(res)) = queue.buffer.front() {
                 drained_any = true;
+                let error_set = state.error_flag.load(Ordering::Acquire);
                 match res {
-                    Ok(data) => {
-                        // Clone data before dropping lock
+                    Ok(data) if !error_set => {
                         let data_to_submit = data.clone();
                         queue.buffer.pop_front();
                         queue.next_drain_seq += 1;
-
-                        // Drop lock before submitting to avoid blocking workers
                         drop(queue);
 
-                        // Submit to sink
                         if let Err(e) = hints_sink.submit(&data_to_submit) {
-                            eprintln!("Error submitting to sink: {}", e);
+                            tracing::error!("Error submitting to sink: {e}");
                             state.error_flag.store(true, Ordering::Release);
                             state.drain_signal.notify_all();
-                            return;
-                        }
-
-                        if let Some(broadcast_fn) = &mpi_broadcast_fn {
+                        } else if let Some(broadcast_fn) = &mpi_broadcast_fn {
                             let mut serialized = borsh::to_vec(&(
                                 JobPhase::ContributionsHintsStream,
                                 StreamMessage { data: data_to_submit.clone() },
                             ))
                             .unwrap();
-
                             broadcast_fn(&mut serialized)
                                 .expect("MPI broadcast failed in drainer thread");
                         }
 
-                        // Re-acquire lock for next iteration
                         queue = state.queue.lock().unwrap();
                     }
-                    Err(e) => {
-                        // Error found - signal to stop
-                        state.error_flag.store(true, Ordering::Release);
-                        eprintln!("[seq={}] Error: {}", queue.next_drain_seq, e);
+                    Ok(_) => {
+                        // Error flag already set — drop without submitting.
                         queue.buffer.pop_front();
                         queue.next_drain_seq += 1;
-                        state.drain_signal.notify_all();
-                        return;
+                    }
+                    Err(e) => {
+                        if !error_set {
+                            tracing::error!("[seq={}] Error: {}", queue.next_drain_seq, e);
+                            state.error_flag.store(true, Ordering::Release);
+                            state.drain_signal.notify_all();
+                        }
+                        queue.buffer.pop_front();
+                        queue.next_drain_seq += 1;
                     }
                 }
             }

--- a/prover-backend/src/prover/asm.rs
+++ b/prover-backend/src/prover/asm.rs
@@ -499,6 +499,36 @@ impl ProverEngine for AsmProver {
         self.core_prover.backend.reset_resources()
     }
 
+    fn restart_asm_resources(&self, elf: &GuestProgram, with_hints: bool) -> Result<()> {
+        let key = SetupKey::new(&*elf.program_id.hash_id, with_hints);
+        let world_rank = self.core_prover.rank_info.world_rank;
+
+        tracing::warn!(
+            ">>> [{world_rank}] Soft-resetting ASM children for program {} (with_hints={with_hints})",
+            elf.name(),
+        );
+
+        let resources = {
+            let cache = self.program_cache.read().unwrap();
+            cache
+                .get(&key)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "restart_asm_resources: program '{}' (with_hints={with_hints}) not in cache",
+                        elf.name()
+                    )
+                })?
+                .resources
+                .clone()
+        };
+
+        self.core_prover.backend.cancel();
+        resources.signal_children_reset()?;
+
+        tracing::info!(">>> [{world_rank}] Soft-reset signal sent for program {}", elf.name());
+        Ok(())
+    }
+
     fn cancel(&self) {
         self.core_prover.backend.cancel();
     }

--- a/prover-backend/src/prover/mod.rs
+++ b/prover-backend/src/prover/mod.rs
@@ -395,6 +395,10 @@ pub trait ProverEngine {
         Ok(())
     }
 
+    fn restart_asm_resources(&self, _elf: &GuestProgram, _with_hints: bool) -> Result<()> {
+        Ok(())
+    }
+
     fn cancel(&self);
 }
 
@@ -621,6 +625,10 @@ impl<C: ZiskBackend> ZiskProver<C> {
 
     pub fn reset_resources(&self) -> Result<()> {
         self.prover.reset_resources()
+    }
+
+    pub fn restart_asm_resources(&self, elf: &GuestProgram, with_hints: bool) -> Result<()> {
+        self.prover.restart_asm_resources(elf, with_hints)
     }
 
     pub fn cancel(&self) {


### PR DESCRIPTION
**Problem**

When a hint result exceeded the 4 MiB sink buffer, submit returned an error that propagated up, panicking the hints-stream thread, leaving C children deadlocked on sem_read.wait(), and forcing a full ASM child respawn (~5 s) on the next job. Worker disconnects also leaked /dev/shm/ZISK_* files (multi-GB) and orphaned ASM child processes. Dispatch-time errors (cache miss, unknown task type) caused reconnect storms.

**Solution**

C-side soft-reset signal: parent sets a flag, children abort the in-flight emulation cleanly and stay alive. Worker reports failure with worker_in_recovery=true; coordinator parks the worker in SettingUp until the worker emits WorkerRecoveryComplete. Recoverable dispatch errors send a proper ExecuteTaskResponse failure instead of disconnecting.

**Changes**
**C-side soft-reset signal (5 files)**
[emulator-asm/src/c_provided.c]: _wait_for_prec_avail and _wait_for_input_avail check *precompile_reset_address after each sem_timedwait; return 1 to unwind out of emulator_start() cleanly.

[emulator-asm/src/server.c], [emulator-asm/src/globals.c], [emulator-asm/src/globals.hpp]: new precompile_reset_address pointer at shmem_control_input_address[3] (read-only mapping; parent zeros it via ControlShmem::reset()).

**Rust shmem control (3 files)**
[emulator-asm/asm-runner/src/control_shmem.rs]: added ResetFlag = 24 slot + set_reset_flag(). reset() zeros all 4 slots. Pruned dead helpers (set_shutdown_flag, set_inputs_size, etc.).

[emulator-asm/asm-runner/src/hints_shmem.rs]: new signal_children_reset() (set flag + post sem_prec_avail). RefCell → Mutex (soundness — RefCell borrow counter isn't atomic). Removed unused parent-side control_output[0] = 0 mirror in reset() (C side already does it).

[emulator-asm/asm-runner/src/inputs_shmem.rs]: notify_all_services() made pub so input-waiting children can be woken too.

**Process lifecycle / cleanup (3 files)**
[emulator-asm/asm-runner/src/asm_services/services.rs]: prctl(PR_SET_PDEATHSIG, SIGKILL) so kernel kills children if parent dies. New cleanup_my_shmem() scans /dev/shm and unlinks {shm_prefix}* + sem.{sem_prefix}* (long-running children don't have delete_*_shm flags, so the parent must clean up).

[executor/src/asm_resources.rs]: new signal_children_reset() ties together hints + inputs wakes. Drop calls cleanup_my_shmem() to prevent shmem leaks on graceful shutdown.

[distributed/crates/worker/src/cli/main.rs]: wrap worker.run() in tokio::select! on SIGINT/SIGTERM so signals run the Drop chain instead of bypassing it.

**Wire-protocol consistency (2 files)**
[emulator-asm/asm-runner/src/asm_mo_runner.rs]: always run mem_planner.set_completed() + wait() + re-stash regardless of error path. Without this, an error return left C++ MemPlanner threads parked, blocking Drop, holding MOShMemReader mutex, deadlocking the next job's MO thread.

[precompiles/hints/src/hints_processor.rs](vscode-webview://1vb5821r57lcutr50mfdsdf1ruhe1anmvdmm78vnagclespvps2r/precompiles/hints/src/hints_processor.rs#L568-L620): drainer thread no longer dies on submit error. After error_flag is set, it pops queue items without submitting — submitting hint #N+1 after #N failed would feed C children out-of-sequence data and SIGSEGV them. Drainer survives for the next job's reset_state.
Prover-backend recovery API (2 files)
[prover-backend/src/prover/asm.rs], [prover-backend/src/prover/mod.rs] new restart_asm_resources(elf, with_hints) on ProverEngine — looks up cached resources by (hash_id, with_hints) and calls signal_children_reset(). ~30 lines, no respawn.

**Coordinator/worker handshake (5 files)**

[distributed/crates/cluster-api/proto/zisk_cluster_api.proto]: new WorkerRecoveryComplete { worker_id } oneof variant + bool worker_in_recovery on ExecuteTaskResponse.

[distributed/crates/cluster-api/src/conversions.rs], [distributed/crates/cluster-common/src/dto.rs]: mirror DTOs.

[distributed/crates/coordinator/src/coordinator.rs]: new fail_job_with_recovery parks the recovering worker in SettingUp instead of Ready.

[distributed/crates/coordinator/src/coordinator/worker_handlers.rs], [distributed/crates/coordinator/src/coordinator_grpc.rs]"  handle_stream_recovery_complete flips SettingUp → Ready. ensure_workers_ready_except splits the post-fail mass-mark.

**Worker (2 files)**

[distributed/crates/worker/src/worker.rs]:
- New guest_program(hash_id) accessor for worker_node.rs::collect_recovery_context.
- Peer-rank MPI broadcast handler calls restart_asm_resources inline on error (peers have no gRPC channel; next collective broadcast acts as the sync point with rank 0).
- Registration-rejected returns Err instead of process::exit(1).
- Drop generic anyhow context wrapper that swallowed the inner error message.

[distributed/crates/worker/src/worker_node.rs]:
- On task failure: collect (GuestProgram, with_hints), set worker_in_recovery=true, spawn background restart_asm_resources task that emits WorkerRecoveryComplete on success.
- Recoverable dispatch errors (cache miss, unknown task type) now send an ExecuteTaskResponse with success=false using the request's job_id, then reset to Ready — instead of breaking the gRPC stream and triggering reconnect/re-setup. Only state-transitioned-to-Error (registration rejection) disconnects.
- JoinHandle race: on Ok(()) from the join branch, try_recv the channel before declaring a silent exit.

**Misc (1 file)**
[distributed/crates/coordinator-server/src/backend/coordinator.rs](vscode-webview://1vb5821r57lcutr50mfdsdf1ruhe1anmvdmm78vnagclespvps2r/distributed/crates/coordinator-server/src/backend/coordinator.rs): two internal(...) errors → typed ApiError::JobNotFound (404 instead of 500).

**Recovery sequences**

**Sink overflow:**

1. submit returns Err → drainer sets error_flag, drops further items without submitting.
2. Worker reports task failure with worker_in_recovery=true; coordinator parks worker in SettingUp.
3. Background task writes ResetFlag=1, posts sem_prec_avail + sem_input_avail.
4. C children wake, return 1 from wait fn, ASM unwinds out of emulator_start(), children stay alive.
5. Worker sends WorkerRecoveryComplete → coordinator flips SettingUp → Ready. Next dispatch lands without the 5s respawn delay.

**Dispatch-time error (cache miss, unknown task type):**

1. Handler returns Err.
2. Wrapper sends ExecuteTaskResponse { success: false, ... } with the request's job_id.
3. Coordinator fails the job, frees the worker.
4. Worker resets to Ready, gRPC stream stays alive.