### PR TITLE
Fix: NativeAOT alignment processing issues

### DIFF
--- a/core/src/zisk_rom_2_asm.rs
+++ b/core/src/zisk_rom_2_asm.rs
@@ -1999,6 +1999,14 @@ impl ZiskRom2Asm {
                                 *code += &format!("pc_{:x}_b_address_check_done:\n", ctx.pc);
                             }
                             4 | 2 => {
+                                // Save original addr to AUX before &~7 destroys it
+                                *code += &format!(
+                                    "\tmov {}, {} {}\n",
+                                    REG_AUX,
+                                    reg_address,
+                                    ctx.comment_str("aux = original address")
+                                );
+
                                 // Calculate previous aligned address
                                 *code += &format!(
                                     "\tand {}, 0xFFFFFFFFFFFFFFF8 {}\n",
@@ -2021,30 +2029,25 @@ impl ZiskRom2Asm {
                                     ctx.comment_str("mem_reads[@+size*8] = prev_b")
                                 );
 
-                                // Calculate next aligned address, keeping a copy of previous aligned
-                                // address in value
-                                *code += &format!(
-                                    "\tmov {}, {} {}\n",
-                                    REG_VALUE,
-                                    reg_address,
-                                    ctx.comment_str("value = copy of prev_address")
-                                );
+                                // Compute next_aligned from ORIGINAL addr (in AUX), not prev_aligned
                                 let address_increment = instruction.ind_width - 1;
                                 *code += &format!(
                                     "\tadd {}, {} {}\n",
-                                    reg_address,
+                                    REG_AUX,
                                     address_increment,
-                                    ctx.comment(format!("address += {address_increment}"))
+                                    ctx.comment(format!(
+                                        "aux += {address_increment} (= addr + width-1)"
+                                    ))
                                 );
                                 *code += &format!(
                                     "\tand {}, 0xFFFFFFFFFFFFFFF8 {}\n",
-                                    reg_address,
-                                    ctx.comment_str("address = next aligned address")
+                                    REG_AUX,
+                                    ctx.comment_str("aux = next aligned address")
                                 );
                                 *code += &format!(
                                     "\tcmp {}, {} {}\n",
-                                    REG_VALUE,
                                     reg_address,
+                                    REG_AUX,
                                     ctx.comment_str("prev_address = next_address ?")
                                 );
                                 *code +=
@@ -2066,11 +2069,11 @@ impl ZiskRom2Asm {
                                 unusual_code +=
                                     &format!("pc_{:x}_b_ind_different_address:\n", ctx.pc);
 
-                                // Store next aligned address value in mem_reads
+                                // Read mem[next_address] from REG_AUX (which now holds next_aligned)
                                 unusual_code += &format!(
                                     "\tmov {}, [{}] {}\n",
                                     REG_VALUE,
-                                    reg_address,
+                                    REG_AUX,
                                     ctx.comment_str("value = mem[next_address]")
                                 );
 
@@ -2882,11 +2885,11 @@ impl ZiskRom2Asm {
                                     ctx.comment_str("aux = address")
                                 );
 
-                                // Calculate previous aligned address
+                                // Calculate previous aligned address (in AUX)
                                 *code += &format!(
                                     "\tand {}, 0xFFFFFFFFFFFFFFF8 {}\n",
                                     REG_AUX,
-                                    ctx.comment_str("address = previous aligned address")
+                                    ctx.comment_str("aux = previous aligned address")
                                 );
 
                                 // Store previous aligned address value in mem_reads, advancing address
@@ -2904,30 +2907,31 @@ impl ZiskRom2Asm {
                                     ctx.comment_str("mem_reads[@+size*8] = prev_c")
                                 );
 
-                                // Calculate next aligned address, keeping a copy of previous aligned
-                                // address in value
+                                // FIX: compute next_aligned from ORIGINAL addr (REG_ADDRESS), not prev_aligned
                                 *code += &format!(
                                     "\tmov {}, {} {}\n",
                                     REG_VALUE,
-                                    REG_AUX,
-                                    ctx.comment_str("value = copy of prev_address")
+                                    REG_ADDRESS,
+                                    ctx.comment_str("value = original address")
                                 );
                                 let address_increment = instruction.ind_width - 1;
                                 *code += &format!(
                                     "\tadd {}, {} {}\n",
-                                    REG_AUX,
+                                    REG_VALUE,
                                     address_increment,
-                                    ctx.comment(format!("address += {address_increment}"))
+                                    ctx.comment(format!(
+                                        "value += {address_increment} (= addr + width-1)"
+                                    ))
                                 );
                                 *code += &format!(
                                     "\tand {}, 0xFFFFFFFFFFFFFFF8 {}\n",
-                                    REG_AUX,
-                                    ctx.comment_str("address = next aligned address")
+                                    REG_VALUE,
+                                    ctx.comment_str("value = next aligned address")
                                 );
                                 *code += &format!(
                                     "\tcmp {}, {} {}\n",
-                                    REG_VALUE,
                                     REG_AUX,
+                                    REG_VALUE,
                                     ctx.comment_str("prev_address = next_address ?")
                                 );
                                 *code +=
@@ -2947,11 +2951,11 @@ impl ZiskRom2Asm {
                                 unusual_code +=
                                     &format!("pc_{:x}_c_ind_different_address:\n", ctx.pc);
 
-                                // Store next aligned address value in mem_reads
+                                // FIX: REG_VALUE holds next_aligned address — read mem at it
                                 unusual_code += &format!(
                                     "\tmov {}, [{}] {}\n",
                                     REG_VALUE,
-                                    REG_AUX,
+                                    REG_VALUE,
                                     ctx.comment_str("value = mem[next_address]")
                                 );
 

--- a/state-machines/mem-cpp/cpp/mem_counter.cpp
+++ b/state-machines/mem-cpp/cpp/mem_counter.cpp
@@ -172,7 +172,7 @@ void MemCounter::execute_chunk(uint32_t chunk_id, const MemCountersBusData *chun
                     if ((aligned_addr & ADDR_MASK) == addr_mask) {
                         incr_counter(aligned_addr, chunk_id, false, chunk_data->flags & MOPS_WRITE_FLAG);
                     }
-                    else if (((aligned_addr + 7) & ADDR_MASK) == addr_mask) {
+                    else if (((addr + 7) & ADDR_MASK) == addr_mask) {
                         incr_counter(aligned_addr + 8 , chunk_id, false, chunk_data->flags & MOPS_WRITE_FLAG);
                     }
                 }


### PR DESCRIPTION
# Summary
While investigating operation of NativeAOT applications, like [Nethermind](https://github.com/nethermindeth/nethermind), we found several issues while proving the execution.

## Issue 1 (f9998a87f48ed825b6b703ea4730e7f89e7e33d1)

Patch fixes usage of invalid value, causing global constraints to fail.

## Issue 2 (5db4e39c4d1e15dca9bab063e5a1b0acce2fc0be)

Patch fixes spontaneous loss of the second word during unaligned 8-byte access.

More information in particular commits.

The correct operation of NativeAOT also needs @juanfranblanco patches from the PR #941. For ease of check, I suggest to verify branch [feature/nethermind_test](https://github.com/NethermindEth/zisk/tree/feature/nethermind_test) in our Zisk fork. It already contains cherry-picked patches from @juanfranblanco. The particular binary and the super small test block we used is attached.
[nethermind.zip](https://github.com/user-attachments/files/27566589/nethermind.zip)
[150026.bin.zip](https://github.com/user-attachments/files/27566599/150026.bin.zip)

## Results
These patches, along with other mentioned ones, allow full end-to-end proving for Nethermind NativeAOT client on both emulator and GPU.

## cla
Confirming that I have read cla and agree to that.
