### PR TITLE
libziskos_standalone.a

### DIFF
--- a/.github/scripts/check-libziskos.sh
+++ b/.github/scripts/check-libziskos.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+. "$HOME/.cargo/env"
+
+FAIL=0
+TARGET=riscv64ima-zisk-zkvm-elf
+
+cargo +zisk build -p ziskos-staticlib --release \
+  --target "$TARGET" \
+  --config 'profile.release.lto="fat"'
+
+LIBZISKOS=$(find target -name "libziskos_staticlib.a" -path "*$TARGET*" | head -1)
+if [ -z "$LIBZISKOS" ]; then
+  echo "FAIL: libziskos_staticlib.a not found"
+  exit 1
+fi
+
+# Check that std is not bundled
+if ar t "$LIBZISKOS" | grep -q std; then
+  echo "FAIL: libziskos_staticlib.a contains std object files:"
+  ar t "$LIBZISKOS" | grep std
+  FAIL=1
+else
+  echo "OK: no std object files bundled"
+fi
+
+# Use llvm-nm to read symbols from the LLVM bitcode archive produced by lto=fat.
+# Use a herestring (<<<) instead of echo | grep to avoid a pipefail/SIGPIPE race
+# where grep -q exits early, echo receives SIGPIPE (141), and pipefail surfaces
+# the 141 rather than grep's 0, flipping the ! check.
+NM_OUTPUT=$(llvm-nm "$LIBZISKOS" 2>/dev/null)
+
+REQUIRED_SYMBOLS=(
+  _start
+  read_input
+  write_output
+  zkvm_init
+  zkvm_deinit
+  zkvm_keccak256
+  zkvm_sha256
+  zkvm_secp256k1_ecrecover
+  zkvm_secp256k1_verify
+  zkvm_secp256r1_verify
+  zkvm_bn254_g1_add
+  zkvm_bn254_g1_mul
+  zkvm_bn254_pairing
+  zkvm_bls12_g1_add
+  zkvm_bls12_g1_msm
+  zkvm_bls12_g2_add
+  zkvm_bls12_g2_msm
+  zkvm_bls12_pairing
+  zkvm_bls12_map_fp_to_g1
+  zkvm_bls12_map_fp2_to_g2
+  zkvm_blake2f
+  zkvm_ripemd160
+  zkvm_modexp
+  zkvm_kzg_point_eval
+)
+
+for SYM in "${REQUIRED_SYMBOLS[@]}"; do
+  if ! grep -qE " T $SYM$" <<< "$NM_OUTPUT"; then
+    echo "FAIL: missing symbol: $SYM"
+    FAIL=1
+  fi
+done
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "OK: libziskos_staticlib.a passes all checks"
+fi
+
+exit "$FAIL"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,20 +78,8 @@ jobs:
           cd "$GITHUB_WORKSPACE/tools/test-env"
           ./build_zisk.sh
 
-      - name: Check libziskos.a does not bundle std
-        run: |
-          . "$HOME/.cargo/env"
-          cargo +zisk build -p ziskos --release \
-            --target riscv64ima-zisk-zkvm-elf \
-            --config 'profile.release.lto="fat"' \
-            --features panic-handler
-          LIBZISKOS=$(find target -name "libziskos.a" -path "*riscv64ima*" | head -1)
-          if ar t "$LIBZISKOS" | grep -q std; then
-            echo "FAIL: libziskos.a contains std object files:"
-            ar t "$LIBZISKOS" | grep std
-            exit 1
-          fi
-          echo "OK: libziskos.a contains no std object files"
+      - name: Check libziskos.a does not bundle std and contains required symbols
+        run: .github/scripts/check-libziskos.sh
 
       - name: Build setup
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7810,6 +7810,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ziskos-staticlib"
+version = "0.17.1"
+dependencies = [
+ "ziskos",
+]
+
+[[package]]
 name = "zkvm-interface"
 version = "0.17.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "state-machines/mem-cpp",
     "state-machines/rom",
     "ziskos/entrypoint",
+    "ziskos-staticlib",
     "ziskos-hints",
     "precompiles/arith_eq",
     "precompiles/arith_eq_384",

--- a/ziskos-staticlib/Cargo.toml
+++ b/ziskos-staticlib/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["staticlib"]
 default = ["panic-handler"]
 panic-handler = []
 
-[target.'cfg(all(target_os = "zkvm", target_vendor = "zisk"))'.dependencies]
+[dependencies]
 ziskos = { path = "../ziskos/entrypoint", default-features = false }

--- a/ziskos-staticlib/Cargo.toml
+++ b/ziskos-staticlib/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ziskos-staticlib"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+crate-type = ["staticlib"]
+
+[features]
+default = ["panic-handler"]
+panic-handler = []
+
+[target.'cfg(all(target_os = "zkvm", target_vendor = "zisk"))'.dependencies]
+ziskos = { path = "../ziskos/entrypoint", default-features = false }

--- a/ziskos-staticlib/src/lib.rs
+++ b/ziskos-staticlib/src/lib.rs
@@ -6,18 +6,13 @@
 // Re-exporting the public interface ensures those symbols are bundled into the
 // archive.  The #[panic_handler] is required by staticlib but not rlib targets.
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
-pub use ziskos::zkvm_init;
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
-pub use ziskos::zkvm_deinit;
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
-pub use ziskos::zisklib::zkvm_io::read_input;
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
-pub use ziskos::zisklib::zkvm_io::write_output;
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
 pub use ziskos::zisklib::zkvm_accelerators::*;
+pub use ziskos::zisklib::zkvm_io::read_input;
+pub use ziskos::zisklib::zkvm_io::write_output;
+pub use ziskos::zkvm_deinit;
+pub use ziskos::zkvm_init;
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk", feature = "panic-handler"))]
+#[cfg(all(feature = "panic-handler", target_os = "zkvm", target_vendor = "zisk"))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     core::intrinsics::abort()

--- a/ziskos-staticlib/src/lib.rs
+++ b/ziskos-staticlib/src/lib.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(all(target_os = "zkvm", target_vendor = "zisk"), no_std)]
+#![cfg_attr(all(target_os = "zkvm", target_vendor = "zisk"), feature(core_intrinsics))]
+#![cfg_attr(all(target_os = "zkvm", target_vendor = "zisk"), allow(internal_features))]
+
+// This crate produces libziskos.a for linking by C programs.
+// Re-exporting the public interface ensures those symbols are bundled into the
+// archive.  The #[panic_handler] is required by staticlib but not rlib targets.
+
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+pub use ziskos::zkvm_init;
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+pub use ziskos::zkvm_deinit;
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+pub use ziskos::zisklib::zkvm_io::read_input;
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+pub use ziskos::zisklib::zkvm_io::write_output;
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+pub use ziskos::zisklib::zkvm_accelerators::*;
+
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk", feature = "panic-handler"))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    core::intrinsics::abort()
+}

--- a/ziskos/entrypoint/Cargo.toml
+++ b/ziskos/entrypoint/Cargo.toml
@@ -8,7 +8,7 @@ repository = { workspace = true }
 categories = { workspace = true }
 
 [lib]
-crate-type = ["rlib", "staticlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 zkvm-interface = { workspace = true }
@@ -66,7 +66,6 @@ ctor = { version = "0.2", optional = true }
 
 [features]
 default = ["user-hints", "inputcpy"]
-panic-handler = []
 user-hints = [
     "dep:zisk-common",
     "dep:bytes",

--- a/ziskos/entrypoint/src/lib.rs
+++ b/ziskos/entrypoint/src/lib.rs
@@ -459,14 +459,4 @@ pub mod ziskos {
     core::arch::global_asm!(include_str!("dma/memcmp.s"));
     //core::arch::global_asm!(include_str!("dma/inputcpy.s"));
     core::arch::global_asm!(include_str!("dma/memset.s"));
-
-    #[cfg(feature = "panic-handler")]
-    #[panic_handler]
-    fn panic(info: &core::panic::PanicInfo) -> ! {
-        if let Some(msg) = info.message().as_str() {
-            sys_write(1, msg.as_ptr(), msg.len());
-            sys_write(1, b"\n".as_ptr(), 1);
-        }
-        core::intrinsics::abort()
-    }
 }


### PR DESCRIPTION
Separates the `libziskos.a` static library into a dedicated `ziskos-staticlib` workspace crate, and adds a CI check to verify the archive is correct. I think that a separate crate is even better because it allows fine grained export of functions/symbols and the resulting archive is smaller.

### Changes

- `ziskos/entrypoint` is now `crate-type = ["rlib"]` only, with no `#[panic_handler]`.
- A new `ziskos-staticlib` crate (alongside `ziskos-hints` at the workspace root) is `crate-type = ["staticlib"]`. It:
  - Explicitly re-exports the public interface of `ziskos` (`read_input`, `write_output`, `zkvm_init`, `zkvm_deinit`, all `zkvm_*` precompiles) to guarantee those symbols are bundled into the archive.
  - Provides the `#[panic_handler]` behind a `panic-handler` feature flag (enabled by default, disableable for consumers that supply their own).

### CI check

A new script `.github/scripts/check-libziskos.sh` is added and called from `pr.yml`. It builds `ziskos-staticlib` with `lto="fat"`, then verifies:

- No `std` object files are bundled in the archive.
- All required symbols are present: `_start`, `read_input`, `write_output`, `zkvm_init`, `zkvm_deinit`, and all 18 `zkvm_*` precompile accelerators.
