### PR TITLE
fix: accept all spec-permitted FENCE encodings in the decoder

### DIFF
--- a/riscv/src/riscv_interpreter.rs
+++ b/riscv/src/riscv_interpreter.rs
@@ -258,14 +258,11 @@ fn riscv_get_instruction_32(inst: u32, root_address: u64, code_index: usize) -> 
     } else if i.t == *"F" {
         i.funct3 = (inst & 0x7000) >> 12;
         if i.funct3 == 0 {
-            if (inst & 0xF00F8F80) != 0 {
-                //panic!("Invalid F funct3=0 inst=0x{inst:x} at index={code_index} addr=0x{rom_address:x}");
-                i.inst = "reserved".to_string();
-            } else {
-                i.pred = (inst & 0x0F000000) >> 24;
-                i.succ = (inst & 0x00F00000) >> 20;
-                i.inst = "fence".to_string();
-            }
+            // Per the unprivileged spec, base impls shall ignore FENCE rs1/rd
+            // and treat reserved fm/pred/succ as a regular FENCE (fm=0000).
+            i.pred = (inst & 0x0F000000) >> 24;
+            i.succ = (inst & 0x00F00000) >> 20;
+            i.inst = "fence".to_string();
         } else if i.funct3 == 1 {
             if (inst & 0xFFFF8F80) != 0 {
                 //panic!("Invalid F funct3=1 inst=0x{inst:x} at index={code_index} addr=0x{rom_address:x}");


### PR DESCRIPTION
## Summary

`riscv_get_instruction_32` currently reclassifies any FENCE with a non-zero `fm`, `rs1`, or `rd` field as `"reserved"`, after which ziskemu aborts with `Emu::run() finished with error` when the offending instruction is reached. The unprivileged spec is explicit that this is [wrong](https://github.com/riscv/riscv-isa-manual/blob/f685667d68de587aa5cb44c1e22c3c5b577d4511/src/unpriv/rv32.adoc?plain=1#L857):

> The unused fields in the FENCE instructions—`rs1` and `rd`—are reserved for finer-grain fences in future extensions. **For forward compatibility, base implementations shall ignore these fields**, and standard software shall zero these fields. Likewise, many `fm` and predecessor/successor set settings are also reserved for future use. **Base implementations shall treat all such reserved configurations as FENCE instructions** (with `fm`=0000), and standard software shall use only non-reserved configurations.
> — *RISC-V Unprivileged ISA, "Memory Ordering Instructions"*

The opcode (`MISC-MEM` = `0001111`) plus `funct3 = 000` already uniquely identifies the FENCE encoding space (the surrounding `i.t == "F"` and `funct3 == 0` checks enforce that). Nothing else inside that space should be rejected. The mask we drop (`0xF00F8F80`) covered exactly the three fields the spec mandates be ignored — `fm[31:28]`, `rs1[19:15]`, `rd[11:7]` — so removing it is precise and minimal: `pred[27:24]`, `succ[23:20]`, `funct3`, and `opcode` are still being read/checked as before, and the existing `"fence" -> nop` mapping in `core/src/riscv2zisk_context.rs:233` handles execution unchanged. **No executor or proving-circuit change.**

## Testing
This was tested locally based on [this branch of the ZKEVM Test Monitor](https://github.com/eth-act/zkevm-test-monitor/tree/zisk-misalign-update) and was shown to make all of the FENCE tests pass. When v0.18.0 lands, a proper update to the test monitor will be pushed.