### PR TITLE
fix: fill only from ROM_ADDR

### DIFF
--- a/core/src/zisk_rom_2_asm.rs
+++ b/core/src/zisk_rom_2_asm.rs
@@ -3691,7 +3691,9 @@ impl ZiskRom2Asm {
                 //   4N + 3
                 // 4(N+1)
                 //   ...
-                if (*key > ROM_ADDR) && (*key != (previous_key + 1) && (*key != FLOAT_LIB_ROM_ADDR))
+                if (previous_key >= ROM_ADDR)
+                    && (*key > ROM_ADDR)
+                    && (*key != (previous_key + 1) && (*key != FLOAT_LIB_ROM_ADDR))
                 {
                     for _ in previous_key + 1..*key {
                         *code += "\t.quad 0\n";


### PR DESCRIPTION
Go's linker always reserves one 4 KB page at the start of the first `PT_LOAD` for `PT_PHDR + NOTE`, so for a Go guest, we have to use `-T 0x80001000` and accept `.text` one page above `ROM_ADDR`. The resulting `min_program_pc = ROM_ADDR + 0x1000` makes the branch table gap-fill loop to fill gap between end of BIOS and `ROM_ADDR + 0x1000`, that creates huge `.rodata` in the generated assembly.

This PR fixes it by adding `previous_key >= ROM_ADDR` to the predicate so the gap-fill only happens when both endpoints sit inside the user-code region.
