### PR TITLE
Enable `ziskos-staticlib` `riscv64im-unknown-none-elf` compilation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,24 @@ jobs:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
 
+  build-riscv64im:
+    name: Build ziskos-staticlib (riscv64im-unknown-none-elf)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly with rust-src
+        # riscv64im-unknown-none-elf is a Tier 3 target — no pre-built std is available.
+        # rust-src is required so that -Z build-std can compile core/alloc from source.
+        # No cross-compiler is needed; Rust uses its bundled rust-lld linker.
+        run: rustup toolchain install nightly --component rust-src --no-self-update
+
+      - name: Build ziskos-staticlib for riscv64im-unknown-none-elf
+        run: cargo +nightly build -p ziskos-staticlib --release --target riscv64im-unknown-none-elf -Z build-std=core,alloc --config 'profile.release.lto="fat"'
+
   test-x86_64:
     name: Test on Ubuntu x86_64
     runs-on: gpu-hosted

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,7 +63,9 @@ jobs:
         run: rustup toolchain install nightly --component rust-src --no-self-update
 
       - name: Build ziskos-staticlib for riscv64im-unknown-none-elf
-        run: cargo +nightly build -p ziskos-staticlib --release --target riscv64im-unknown-none-elf -Z build-std=core,alloc --config 'profile.release.lto="fat"'
+        run: cargo +nightly build -p ziskos-staticlib --release --target riscv64im-unknown-none-elf -Z build-std=core,alloc --config 'profile.release.lto="fat"' --features panic-handler
+        env:
+          RUSTFLAGS: "-D warnings"
 
   test-x86_64:
     name: Test on Ubuntu x86_64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5455,15 +5455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7672,7 +7663,6 @@ dependencies = [
  "secp256k1",
  "serde",
  "sha2",
- "spin",
  "talc",
  "tiny-keccak",
  "tokio",

--- a/ziskos/entrypoint/Cargo.toml
+++ b/ziskos/entrypoint/Cargo.toml
@@ -24,10 +24,10 @@ dlmalloc = { version = "0.2", default-features = false, optional = true }
 zisk-verifier = { workspace = true }
 
 [target.'cfg(any(all(target_os = "zkvm", target_vendor = "zisk"), all(target_arch = "riscv64", target_os = "none")))'.dependencies]
-spin = "0.9"
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 bincode = { version = "2", default-features = false, features = ["alloc", "serde"] }
+
 
 [target.'cfg(not(any(all(target_os = "zkvm", target_vendor = "zisk"), all(target_arch = "riscv64", target_os = "none"))))'.dependencies]
 lib-c = { workspace = true }

--- a/ziskos/entrypoint/src/lib.rs
+++ b/ziskos/entrypoint/src/lib.rs
@@ -383,22 +383,21 @@ pub mod ziskos {
             }
         }
     }
-    use core::sync::atomic::{AtomicBool, Ordering};
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
-    use spin::Mutex;
 
-    static RNG: Mutex<Option<SmallRng>> = Mutex::new(None);
-    static SYS_RAND_WARNING: AtomicBool = AtomicBool::new(false);
+    // riscv64 guest targets are single-core — sys_rand uses static mut, no atomics needed
+    static mut RNG: Option<SmallRng> = None;
+    static mut SYS_RAND_WARNING: bool = false;
 
     #[no_mangle]
     unsafe extern "C" fn sys_rand(recv_buf: *mut u8, words: usize) {
-        if !SYS_RAND_WARNING.swap(true, Ordering::Relaxed) {
+        if !SYS_RAND_WARNING {
+            SYS_RAND_WARNING = true;
             let msg = b"WARNING: Using insecure random number generator.\n";
             sys_write(1, msg.as_ptr(), msg.len());
         }
-        let mut rng_guard = RNG.lock();
-        let rng = rng_guard.get_or_insert_with(|| SmallRng::seed_from_u64(0x123456789abcdef0));
+        let rng = RNG.get_or_insert_with(|| SmallRng::seed_from_u64(0x123456789abcdef0));
         for i in 0..words {
             let element = recv_buf.add(i);
             *element = rng.gen();

--- a/ziskos/entrypoint/src/lib.rs
+++ b/ziskos/entrypoint/src/lib.rs
@@ -1,6 +1,4 @@
 #![cfg_attr(zisk_guest, no_std)]
-#![cfg_attr(zisk_guest, feature(core_intrinsics))]
-#![cfg_attr(zisk_guest, allow(internal_features))]
 #![allow(unexpected_cfgs)]
 #![allow(unused_imports)]
 
@@ -390,6 +388,7 @@ pub mod ziskos {
     static mut RNG: Option<SmallRng> = None;
     static mut SYS_RAND_WARNING: bool = false;
 
+    #[allow(static_mut_refs)]
     #[no_mangle]
     unsafe extern "C" fn sys_rand(recv_buf: *mut u8, words: usize) {
         if !SYS_RAND_WARNING {


### PR DESCRIPTION
These two commits prepare `ziskos` for a second guest target (`riscv64im-unknown-none-elf`) alongside the existing `riscv64ima-zisk-zkvm-elf`. The `riscv64im` target is bare-metal and lacks the RISC-V 'A' (atomic) extension, which made the previous `sys_rand` implementation — built on `spin::Mutex` and `AtomicBool` — fail to compile for it.

### Commit 1 — Get rid of `spin` crate dependency

`sys_rand` is called on a single-core guest; it has no concurrent callers at any point, so a mutex and atomic flag are unnecessary overhead. The implementation is replaced with plain `static mut`:

```rust
static mut RNG: Option<SmallRng> = None;
static mut SYS_RAND_WARNING: bool = false;
```

This removes the `spin` crate from the dependency tree entirely and makes the code compile on any RISC-V guest target, regardless of whether the 'A' extension is present.

### Commit 2 — CI check for `riscv64im-unknown-none-elf`

Adds a new `build-riscv64im` job to the PR workflow that compiles `ziskos-staticlib` against the new target:

```
cargo +nightly build -p ziskos-staticlib --release \
  --target riscv64im-unknown-none-elf \
  -Z build-std=core,alloc \
  --config 'profile.release.lto="fat"'
```

**Toolchain setup:** `riscv64im-unknown-none-elf` is a Tier 3 target — there is no pre-built `std` to download, so `rustup target add` is not applicable. Instead, `-Z build-std` compiles `core` and `alloc` from source using the `rust-src` component. No external cross-compiler is needed; Rust's bundled `rust-lld` handles RISC-V linking. The toolchain setup reduces to a single `rustup` call:

```
rustup toolchain install nightly --component rust-src --no-self-update
```

The job runs on `ubuntu-latest` and has no dependencies on the GPU runner or any heavy native libraries.