### PR TITLE
feat: bls verification

### DIFF
--- a/test-artifacts/programs/Cargo.lock
+++ b/test-artifacts/programs/Cargo.lock
@@ -5470,6 +5470,7 @@ dependencies = [
 name = "uint256"
 version = "0.1.0"
 dependencies = [
+ "ruint",
  "ziskos",
 ]
 

--- a/test-artifacts/programs/Cargo.toml
+++ b/test-artifacts/programs/Cargo.toml
@@ -28,6 +28,7 @@ zisk-sdk = { path = "../../sdk" }
 precompiles-helpers = { path = "../../precompiles/helpers" }
 
 rand = "0.8.1"
+ruint = { version = "1", default-features = false }
 
 # [workspace.lints.rust]
 # unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_vendor, values("zisk"))', 'cfg(zisk_hints)'] }

--- a/test-artifacts/programs/bls12_381/src/hash_to_curve.rs
+++ b/test-artifacts/programs/bls12_381/src/hash_to_curve.rs
@@ -1,0 +1,115 @@
+use ziskos::zisklib::{hash_to_curve_g2_bls12_381, is_on_curve_twist_bls12_381};
+
+use crate::constants::IDENTITY_G2;
+
+// DST used by the IETF test vectors (RFC 9380 §J.10.1)
+const DST: &[u8] = b"QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_";
+
+pub fn hash_to_curve_tests() {
+    // RFC 9380 §J.10.1 test vectors
+
+    // msg = ""
+    let msg = b"";
+    let expected = g2_from_hex(
+        "0141ebfbdca40eb85b87142e130ab689c673cf60f1a3e98d69335266f30d9b8d4ac44c1038e9dcdd5393faf5c41fb78a",
+        "05cb8437535e20ecffaef7752baddf98034139c38452458baeefab379ba13dff5bf5dd71b72418717047f5b0f37da03d",
+        "0503921d7f6a12805e72940b963c0cf3471c7b2a524950ca195d11062ee75ec076daf2d4bc358c4b190c0c98064fdd92",
+        "12424ac32561493f3fe3c260708a12b7c620e7be00099a974e259ddc7d1f6395c3c811cdd19f1e8dbf3e9ecfdcbab8d6",
+    );
+    let p = hash_to_curve_g2_bls12_381(msg, DST);
+    assert_eq!(p, expected, "hash_to_curve_g2_bls12_381 test vector 1 mismatch");
+
+    // msg = "abc"
+    let msg = b"abc";
+    let expected = g2_from_hex(
+        "02c2d18e033b960562aae3cab37a27ce00d80ccd5ba4b7fe0e7a210245129dbec7780ccc7954725f4168aff2787776e6",
+        "139cddbccdc5e91b9623efd38c49f81a6f83f175e80b06fc374de9eb4b41dfe4ca3a230ed250fbe3a2acf73a41177fd8",
+        "1787327b68159716a37440985269cf584bcb1e621d3a7202be6ea05c4cfe244aeb197642555a0645fb87bf7466b2ba48",
+        "00aa65dae3c8d732d10ecd2c50f8a1baf3001578f71c694e03866e9f3d49ac1e1ce70dd94a733534f106d4cec0eddd16",
+    );
+    let p = hash_to_curve_g2_bls12_381(msg, DST);
+    assert_eq!(p, expected, "hash_to_curve_g2_bls12_381 test vector 2 mismatch");
+
+    // msg = "abcdef0123456789"
+    let msg = b"abcdef0123456789";
+    let expected = g2_from_hex(
+        "121982811d2491fde9ba7ed31ef9ca474f0e1501297f68c298e9f4c0028add35aea8bb83d53c08cfc007c1e005723cd0",
+        "190d119345b94fbd15497bcba94ecf7db2cbfd1e1fe7da034d26cbba169fb3968288b3fafb265f9ebd380512a71c3f2c",
+        "05571a0f8d3c08d094576981f4a3b8eda0a8e771fcdcc8ecceaf1356a6acf17574518acb506e435b639353c2e14827c8",
+        "0bb5e7572275c567462d91807de765611490205a941a5a6af3b1691bfe596c31225d3aabdf15faff860cb4ef17c7c3be",
+    );
+    let p = hash_to_curve_g2_bls12_381(msg, DST);
+    assert_eq!(p, expected, "hash_to_curve_g2_bls12_381 test vector 3 mismatch");
+
+    // msg = "q128_" + 'q' * 128  (133 bytes)
+    let mut msg = [b'q'; 133];
+    msg[..5].copy_from_slice(b"q128_");
+    let expected = g2_from_hex(
+        "19a84dd7248a1066f737cc34502ee5555bd3c19f2ecdb3c7d9e24dc65d4e25e50d83f0f77105e955d78f4762d33c17da",
+        "0934aba516a52d8ae479939a91998299c76d39cc0c035cd18813bec433f587e2d7a4fef038260eef0cef4d02aae3eb91",
+        "14f81cd421617428bc3b9fe25afbb751d934a00493524bc4e065635b0555084dd54679df1536101b2c979c0152d09192",
+        "09bcccfa036b4847c9950780733633f13619994394c23ff0b32fa6b795844f4a0673e20282d07bc69641cee04f5e5662",
+    );
+    let p = hash_to_curve_g2_bls12_381(&msg, DST);
+    assert_eq!(p, expected, "hash_to_curve_g2_bls12_381 test vector 4 mismatch");
+
+    // msg = "a512_" + 'a' * 512  (517 bytes)
+    let mut msg = [b'a'; 517];
+    msg[..5].copy_from_slice(b"a512_");
+    let expected = g2_from_hex(
+        "01a6ba2f9a11fa5598b2d8ace0fbe0a0eacb65deceb476fbbcb64fd24557c2f4b18ecfc5663e54ae16a84f5ab7f62534",
+        "11fca2ff525572795a801eed17eb12785887c7b63fb77a42be46ce4a34131d71f7a73e95fee3f812aea3de78b4d01569",
+        "0b6798718c8aed24bc19cb27f866f1c9effcdbf92397ad6448b5c9db90d2b9da6cbabf48adc1adf59a1a28344e79d57e",
+        "03a47f8e6d1763ba0cad63d6114c0accbef65707825a511b251a660a9b3994249ae4e63fac38b23da0c398689ee2ab52",
+    );
+    let p = hash_to_curve_g2_bls12_381(&msg, DST);
+    assert_eq!(p, expected, "hash_to_curve_g2_bls12_381 test vector 5 mismatch");
+}
+
+/// Parse a 96-char big-endian hex string into 6 little-endian u64 limbs.
+const fn fp_from_be_hex(hex: &str) -> [u64; 6] {
+    let bytes = hex.as_bytes();
+    assert!(bytes.len() == 96, "Fp hex must be exactly 96 chars (no 0x prefix)");
+
+    let mut limbs = [0u64; 6];
+    let mut i = 0;
+    while i < 6 {
+        let start = i * 16;
+        let mut limb = 0u64;
+        let mut j = 0;
+        while j < 16 {
+            let c = bytes[start + j];
+            let nibble = match c {
+                b'0'..=b'9' => c - b'0',
+                b'a'..=b'f' => c - b'a' + 10,
+                b'A'..=b'F' => c - b'A' + 10,
+                _ => panic!("invalid hex digit"),
+            };
+            limb = (limb << 4) | nibble as u64;
+            j += 1;
+        }
+        // BE hex's most-significant limb is at hex[0..16], stored at the LE index 5.
+        limbs[5 - i] = limb;
+        i += 1;
+    }
+    limbs
+}
+
+/// Build a G2 point `[u64; 24]` from four BE hex Fp values: x.c0, x.c1, y.c0, y.c1.
+const fn g2_from_hex(x_c0: &str, x_c1: &str, y_c0: &str, y_c1: &str) -> [u64; 24] {
+    let xc0 = fp_from_be_hex(x_c0);
+    let xc1 = fp_from_be_hex(x_c1);
+    let yc0 = fp_from_be_hex(y_c0);
+    let yc1 = fp_from_be_hex(y_c1);
+
+    let mut p = [0u64; 24];
+    let mut i = 0;
+    while i < 6 {
+        p[i] = xc0[i];
+        p[6 + i] = xc1[i];
+        p[12 + i] = yc0[i];
+        p[18 + i] = yc1[i];
+        i += 1;
+    }
+    p
+}

--- a/test-artifacts/programs/bls12_381/src/hash_to_curve.rs
+++ b/test-artifacts/programs/bls12_381/src/hash_to_curve.rs
@@ -1,6 +1,4 @@
-use ziskos::zisklib::{hash_to_curve_g2_bls12_381, is_on_curve_twist_bls12_381};
-
-use crate::constants::IDENTITY_G2;
+use ziskos::zisklib::hash_to_curve_g2_bls12_381;
 
 // DST used by the IETF test vectors (RFC 9380 §J.10.1)
 const DST: &[u8] = b"QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_";

--- a/test-artifacts/programs/bls12_381/src/main.rs
+++ b/test-artifacts/programs/bls12_381/src/main.rs
@@ -8,6 +8,7 @@ mod fp;
 mod fp12;
 mod fp2;
 mod fp6;
+mod hash_to_curve;
 mod pairing;
 mod twist;
 
@@ -17,6 +18,7 @@ use fp::fp_tests;
 use fp12::fp12_tests;
 use fp2::fp2_tests;
 use fp6::fp6_tests;
+use hash_to_curve::hash_to_curve_tests;
 use pairing::pairing_valid_tests;
 use twist::twist_tests;
 
@@ -41,6 +43,9 @@ fn main() {
 
     // Final exponentiation
     final_exp_tests();
+
+    // Hash to curve
+    hash_to_curve_tests();
 
     // Pairing
     pairing_valid_tests();

--- a/test-artifacts/programs/syscalls/arith384_mod/src/main.rs
+++ b/test-artifacts/programs/syscalls/arith384_mod/src/main.rs
@@ -4,7 +4,7 @@ ziskos::entrypoint!(main);
 use ziskos::syscalls::{syscall_arith384_mod, SyscallArith384ModParams};
 
 fn main() {
-let a: [u64; 6] = [0, 0, 0, 0, 0, 0];
+    let a: [u64; 6] = [0, 0, 0, 0, 0, 0];
     let b: [u64; 6] = [0, 0, 0, 0, 0, 0];
     let c: [u64; 6] = [0, 0, 0, 0, 0, 0];
     let module: [u64; 6] = [0, 0, 0, 0, 0, 0];

--- a/test-artifacts/programs/syscalls/bls12_381_add/src/main.rs
+++ b/test-artifacts/programs/syscalls/bls12_381_add/src/main.rs
@@ -1,7 +1,9 @@
 #![no_main]
 ziskos::entrypoint!(main);
 
-use ziskos::syscalls::{syscall_bls12_381_curve_add, SyscallBls12_381CurveAddParams, SyscallPoint384};
+use ziskos::syscalls::{
+    syscall_bls12_381_curve_add, SyscallBls12_381CurveAddParams, SyscallPoint384,
+};
 
 fn main() {
     let mut p1 = SyscallPoint384 { x: [0, 0, 0, 0, 0, 0], y: [0, 0, 0, 0, 0, 0] };

--- a/test-artifacts/programs/syscalls/bls12_381_complex_add/src/main.rs
+++ b/test-artifacts/programs/syscalls/bls12_381_complex_add/src/main.rs
@@ -1,7 +1,9 @@
 #![no_main]
 ziskos::entrypoint!(main);
 
-use ziskos::syscalls::{syscall_bls12_381_complex_add, SyscallBls12_381ComplexAddParams, SyscallComplex384};
+use ziskos::syscalls::{
+    syscall_bls12_381_complex_add, SyscallBls12_381ComplexAddParams, SyscallComplex384,
+};
 
 fn main() {
     let mut f1 = SyscallComplex384 { x: [0, 0, 0, 0, 0, 0], y: [0, 0, 0, 0, 0, 0] };

--- a/test-artifacts/programs/syscalls/bls12_381_complex_mul/src/main.rs
+++ b/test-artifacts/programs/syscalls/bls12_381_complex_mul/src/main.rs
@@ -1,7 +1,9 @@
 #![no_main]
 ziskos::entrypoint!(main);
 
-use ziskos::syscalls::{syscall_bls12_381_complex_mul, SyscallBls12_381ComplexMulParams, SyscallComplex384};
+use ziskos::syscalls::{
+    syscall_bls12_381_complex_mul, SyscallBls12_381ComplexMulParams, SyscallComplex384,
+};
 
 fn main() {
     let mut f1 = SyscallComplex384 { x: [0, 0, 0, 0, 0, 0], y: [0, 0, 0, 0, 0, 0] };

--- a/test-artifacts/programs/syscalls/bls12_381_complex_sub/src/main.rs
+++ b/test-artifacts/programs/syscalls/bls12_381_complex_sub/src/main.rs
@@ -1,7 +1,9 @@
 #![no_main]
 ziskos::entrypoint!(main);
 
-use ziskos::syscalls::{syscall_bls12_381_complex_sub, SyscallBls12_381ComplexSubParams, SyscallComplex384};
+use ziskos::syscalls::{
+    syscall_bls12_381_complex_sub, SyscallBls12_381ComplexSubParams, SyscallComplex384,
+};
 
 fn main() {
     let mut f1 = SyscallComplex384 { x: [0, 0, 0, 0, 0, 0], y: [0, 0, 0, 0, 0, 0] };

--- a/test-artifacts/programs/syscalls/bn254_complex_add/src/main.rs
+++ b/test-artifacts/programs/syscalls/bn254_complex_add/src/main.rs
@@ -1,7 +1,9 @@
 #![no_main]
 ziskos::entrypoint!(main);
 
-use ziskos::syscalls::{syscall_bn254_complex_add, SyscallBn254ComplexAddParams, SyscallComplex256};
+use ziskos::syscalls::{
+    syscall_bn254_complex_add, SyscallBn254ComplexAddParams, SyscallComplex256,
+};
 
 fn main() {
     let mut f1 = SyscallComplex256 { x: [0, 0, 0, 0], y: [0, 0, 0, 0] };

--- a/test-artifacts/programs/syscalls/bn254_complex_mul/src/main.rs
+++ b/test-artifacts/programs/syscalls/bn254_complex_mul/src/main.rs
@@ -1,7 +1,9 @@
 #![no_main]
 ziskos::entrypoint!(main);
 
-use ziskos::syscalls::{syscall_bn254_complex_mul, SyscallBn254ComplexMulParams, SyscallComplex256};
+use ziskos::syscalls::{
+    syscall_bn254_complex_mul, SyscallBn254ComplexMulParams, SyscallComplex256,
+};
 
 fn main() {
     let mut f1 = SyscallComplex256 { x: [0, 0, 0, 0], y: [0, 0, 0, 0] };

--- a/test-artifacts/programs/syscalls/bn254_complex_sub/src/main.rs
+++ b/test-artifacts/programs/syscalls/bn254_complex_sub/src/main.rs
@@ -1,7 +1,9 @@
 #![no_main]
 ziskos::entrypoint!(main);
 
-use ziskos::syscalls::{syscall_bn254_complex_sub, SyscallBn254ComplexSubParams, SyscallComplex256};
+use ziskos::syscalls::{
+    syscall_bn254_complex_sub, SyscallBn254ComplexSubParams, SyscallComplex256,
+};
 
 fn main() {
     let mut f1 = SyscallComplex256 { x: [0, 0, 0, 0], y: [0, 0, 0, 0] };

--- a/test-artifacts/programs/syscalls/secp256k1_add/src/main.rs
+++ b/test-artifacts/programs/syscalls/secp256k1_add/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 ziskos::entrypoint!(main);
 
-use ziskos::syscalls::{syscall_secp256k1_add, SyscallSecp256k1AddParams, SyscallPoint256};
+use ziskos::syscalls::{syscall_secp256k1_add, SyscallPoint256, SyscallSecp256k1AddParams};
 
 fn main() {
     let mut p1 = SyscallPoint256 { x: [0, 0, 0, 0], y: [0, 0, 0, 0] };

--- a/test-artifacts/programs/syscalls/secp256r1_add/src/main.rs
+++ b/test-artifacts/programs/syscalls/secp256r1_add/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 ziskos::entrypoint!(main);
 
-use ziskos::syscalls::{syscall_secp256r1_add, SyscallSecp256r1AddParams, SyscallPoint256};
+use ziskos::syscalls::{syscall_secp256r1_add, SyscallPoint256, SyscallSecp256r1AddParams};
 
 fn main() {
     let mut p1 = SyscallPoint256 { x: [0, 0, 0, 0], y: [0, 0, 0, 0] };

--- a/test-artifacts/programs/uint256/Cargo.toml
+++ b/test-artifacts/programs/uint256/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 ziskos.workspace = true
+ruint.workspace = true
 
 [features]
 # Force the u256 wrappers to use the ruint fallback even when targeting zisk

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/bls.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/bls.rs
@@ -1,0 +1,276 @@
+//! BLS signature verification over BLS12-381 (IETF [draft-irtf-cfrg-bls-signature-06](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-06.html)).
+//!
+//! Implements the minimal-pubkey-size **Basic** ciphersuite variant.
+//!
+
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+use crate::alloc_extern::vec::Vec;
+
+use crate::zisklib::{lib::utils::eq, mul_fp12_bls12_381};
+
+use super::{
+    constants::{G1_GENERATOR, G1_IDENTITY},
+    curve::{
+        add_complete_bls12_381, decompress_bls12_381, is_on_subgroup_bls12_381, neg_bls12_381,
+    },
+    hash_to_curve::hash_to_curve_g2_bls12_381,
+    pairing::{pairing_bls12_381, pairing_check_bls12_381},
+    twist::{decompress_twist_bls12_381, is_on_subgroup_twist_bls12_381},
+};
+
+/// Domain separation tag for the basic scheme minimal-pubkey-size ciphersuite
+pub const BLS_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
+
+/// Single BLS signature verification (CoreVerify, IETF draft §2.7).
+pub fn bls_verify_bls12_381(
+    pk_compressed: &[u8; 48],
+    msg: &[u8],
+    sig_compressed: &[u8; 96],
+    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
+) -> Result<bool, &'static str> {
+    // Signature decompression and validation
+    let r = decompress_and_validate_sig(
+        sig_compressed,
+        #[cfg(feature = "hints")]
+        hints,
+    )?;
+
+    // Public key decompression and validation
+    let pk = decompress_and_validate_pk(
+        pk_compressed,
+        #[cfg(feature = "hints")]
+        hints,
+    )?;
+
+    // Hash the message to a curve point in G2
+    let q = hash_to_curve_g2_bls12_381(
+        msg,
+        BLS_DST,
+        #[cfg(feature = "hints")]
+        hints,
+    );
+
+    // Compute e(PK, H(msg)) and e(G1, sig) and compare
+    let c1 = pairing_bls12_381(
+        &pk,
+        &q,
+        #[cfg(feature = "hints")]
+        hints,
+    );
+    let c2 = pairing_bls12_381(
+        &G1_GENERATOR,
+        &r,
+        #[cfg(feature = "hints")]
+        hints,
+    );
+
+    if eq(&c1, &c2) {
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Aggregate verification, Basic scheme (AggregateVerify, IETF draft §3.1.1).
+pub fn bls_aggregate_verify_bls12_381(
+    pks_compressed: &[[u8; 48]],
+    msgs: &[&[u8]],
+    sig_compressed: &[u8; 96],
+    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
+) -> Result<bool, &'static str> {
+    // To avoid rogue key attacks, we ensure that all messages are distinct
+    for i in 0..msgs.len() {
+        for j in (i + 1)..msgs.len() {
+            if msgs[i] == msgs[j] {
+                return Err("Duplicate messages are not allowed in aggregate verification");
+            }
+        }
+    }
+
+    bls_core_aggregate_verify_bls12_381(
+        pks_compressed,
+        msgs,
+        sig_compressed,
+        #[cfg(feature = "hints")]
+        hints,
+    )
+}
+
+/// Aggregate verification (CoreAggregateVerify, IETF draft §2.9).
+/// Verifies one aggregate signature against `n` (PK, msg) pairs.
+pub fn bls_core_aggregate_verify_bls12_381(
+    pks_compressed: &[[u8; 48]],
+    msgs: &[&[u8]],
+    sig_compressed: &[u8; 96],
+    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
+) -> Result<bool, &'static str> {
+    // Preconditions
+    if pks_compressed.is_empty() {
+        return Err("Empty input");
+    }
+    if pks_compressed.len() != msgs.len() {
+        return Err("Length mismatch between public keys and messages");
+    }
+
+    // Signature decompression and validation
+    let r = decompress_and_validate_sig(
+        sig_compressed,
+        #[cfg(feature = "hints")]
+        hints,
+    )?;
+
+    // Group the n input messages into l distinct messages
+    // Aggregate the pks of the same message to l sets of pks
+    // Compute the pairings and accumulate the result in c1
+    let n = pks_compressed.len();
+    let mut c1: [u64; 72] = [0; 72];
+    for i in 0..n {
+        // Find a non-seen message
+        let mut seen_earlier = false;
+        for k in 0..i {
+            if msgs[i] == msgs[k] {
+                seen_earlier = true;
+                break;
+            }
+        }
+        if seen_earlier {
+            continue;
+        }
+
+        // Public key decompression and validation
+        let mut aggregate = decompress_and_validate_pk(
+            &pks_compressed[i],
+            #[cfg(feature = "hints")]
+            hints,
+        )?;
+
+        // Scan for duplicate messages and aggregate their pks
+        let mut group_size: usize = 1;
+        for j in (i + 1)..n {
+            if msgs[j] == msgs[i] {
+                // Public key decompression and validation
+                let next = decompress_and_validate_pk(
+                    &pks_compressed[j],
+                    #[cfg(feature = "hints")]
+                    hints,
+                )?;
+
+                // Aggregate the pk
+                aggregate = add_complete_bls12_381(
+                    &aggregate,
+                    &next,
+                    #[cfg(feature = "hints")]
+                    hints,
+                )
+                .map_err(|_| "Error during public key aggregation")?;
+                group_size += 1;
+            }
+        }
+
+        // If the group has more than one PK, check that the aggregate is not the
+        // point at infinity
+        if group_size > 1 && eq(&aggregate, &G1_IDENTITY) {
+            return Err("Aggregate public key is the point at infinity");
+        }
+
+        // Hash the message to a curve point in G2
+        let q = hash_to_curve_g2_bls12_381(
+            msgs[i],
+            BLS_DST,
+            #[cfg(feature = "hints")]
+            hints,
+        );
+
+        // Compute the pairing:
+        //      e(agg_i, H(m_i)) = e(Σ_{k ∈ group_i} pk_k, H(m_i)) = ∏_{k ∈ group_i} e(pk_k, H(m_i))
+        // and accumulate the result in c1
+        let pairing_result = pairing_bls12_381(
+            &aggregate,
+            &q,
+            #[cfg(feature = "hints")]
+            hints,
+        );
+        c1 = mul_fp12_bls12_381(
+            &c1,
+            &pairing_result,
+            #[cfg(feature = "hints")]
+            hints,
+        );
+    }
+
+    // Compute e(G1, sig)
+    let c2 = pairing_bls12_381(
+        &G1_GENERATOR,
+        &r,
+        #[cfg(feature = "hints")]
+        hints,
+    );
+
+    if eq(&c1, &c2) {
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Decompresses a signature and checks that it belongs to the correct subgroup.
+fn decompress_and_validate_sig(
+    sig_compressed: &[u8; 96],
+    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
+) -> Result<[u64; 24], &'static str> {
+    // Decompress the signature
+    let (sig, is_inf) = decompress_twist_bls12_381(
+        sig_compressed,
+        #[cfg(feature = "hints")]
+        hints,
+    )
+    .map_err(|_| "Failed to decompress signature")?;
+
+    // Check that it belongs to the correct subgroup
+    if !is_inf
+        && !is_on_subgroup_twist_bls12_381(
+            &sig,
+            #[cfg(feature = "hints")]
+            hints,
+        )
+    {
+        return Err("Signature is not in the correct subgroup");
+    }
+
+    Ok(sig)
+}
+
+/// Decompresses a public key and runs KeyValidate: rejects identity and points
+/// outside the prime-order G1 subgroup.
+fn decompress_and_validate_pk(
+    pk_compressed: &[u8; 48],
+    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
+) -> Result<[u64; 12], &'static str> {
+    // Decompress the public key
+    let (pk, pk_is_inf) = decompress_bls12_381(
+        pk_compressed,
+        #[cfg(feature = "hints")]
+        hints,
+    )
+    .map_err(|_| "Failed to decompress public key")?;
+
+    // Reject the point at infinity
+    if pk_is_inf {
+        return Err("Public key is the point at infinity");
+    }
+
+    // Check that it belongs to the correct subgroup
+    if !is_on_subgroup_bls12_381(
+        &pk,
+        #[cfg(feature = "hints")]
+        hints,
+    ) {
+        return Err("Public key is not in the correct subgroup");
+    }
+
+    Ok(pk)
+}

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/bls.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/bls.rs
@@ -3,7 +3,7 @@
 //! Implements the minimal-pubkey-size **Basic** ciphersuite variant.
 //!
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(zisk_guest)]
 use crate::alloc_extern::vec::Vec;
 
 use crate::zisklib::{lib::utils::eq, mul_fp12_bls12_381};

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
@@ -46,7 +46,7 @@ const G1_MSM_ERR_NOT_IN_SUBGROUP: u8 = 4;
 pub fn decompress_bls12_381(
     input: &[u8; 48],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
-) -> Result<[u64; 12], &'static str> {
+) -> Result<([u64; 12], bool), &'static str> {
     let flags = input[0];
 
     // Check compression bit
@@ -65,7 +65,7 @@ pub fn decompress_bls12_381(
                 return Err("Invalid infinity encoding");
             }
         }
-        return Ok(G1_IDENTITY);
+        return Ok((G1_IDENTITY, true));
     }
 
     // Extract sign bit
@@ -132,7 +132,7 @@ pub fn decompress_bls12_381(
     let mut result = [0u64; 12];
     result[0..6].copy_from_slice(&x);
     result[6..12].copy_from_slice(&final_y);
-    Ok(result)
+    Ok((result, false))
 }
 
 /// Check if a non-zero point `p` is on the BLS12-381 curve
@@ -853,10 +853,10 @@ pub unsafe extern "C" fn decompress_bls12_381_c(
         #[cfg(feature = "hints")]
         hints,
     ) {
-        Ok(p) => {
+        Ok((p, is_infinity)) => {
             let result = &mut *(result_ptr as *mut [u64; 12]);
             *result = p;
-            if eq(&p, &G1_IDENTITY) {
+            if is_infinity {
                 1
             } else {
                 0

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/hash_to_curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/hash_to_curve.rs
@@ -1,0 +1,198 @@
+//! Hash-to-curve for BLS12-381 G2
+
+#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+use crate::alloc_extern::vec::Vec;
+
+use crate::zisklib::lib::sha256::sha256;
+
+use super::{
+    fp::{add_fp_bls12_381, mul_fp_bls12_381},
+    map_to_curve::map_to_curve_g2_no_cofactor_bls12_381,
+    twist::{add_complete_twist_bls12_381, clear_cofactor_twist_bls12_381},
+};
+
+/// Hash an arbitrary byte string to a point in the BLS12-381 G2 prime-order
+pub fn hash_to_curve_g2_bls12_381(
+    msg: &[u8],
+    dst: &[u8],
+    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
+) -> [u64; 24] {
+    // Hash to field to get 2 Fp2 elements (u0, u1)
+    let u = hash_to_field_fp2_count2_bls12_381(
+        msg,
+        dst,
+        #[cfg(feature = "hints")]
+        hints,
+    );
+
+    // Map u0 to a point on the curve Q0
+    let q0 = map_to_curve_g2_no_cofactor_bls12_381(
+        &u[0],
+        #[cfg(feature = "hints")]
+        hints,
+    )
+    .expect("hash_to_field output is reduced mod p");
+
+    // Map u1 to a point on the curve Q1
+    let q1 = map_to_curve_g2_no_cofactor_bls12_381(
+        &u[1],
+        #[cfg(feature = "hints")]
+        hints,
+    )
+    .expect("hash_to_field output is reduced mod p");
+
+    // R = Q0 + Q1
+    let r = add_complete_twist_bls12_381(
+        &q0,
+        &q1,
+        #[cfg(feature = "hints")]
+        hints,
+    )
+    .expect("Q0 and Q1 are on the curve by construction");
+
+    // Clear cofactor
+    clear_cofactor_twist_bls12_381(
+        &r,
+        #[cfg(feature = "hints")]
+        hints,
+    )
+}
+
+/// Expand a message to `len_in_bytes` uniformly random bytes
+fn expand_message_xmd_sha256(
+    msg: &[u8],
+    dst: &[u8],
+    len_in_bytes: usize,
+    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
+) -> Vec<u8> {
+    const B_IN_BYTES: usize = 32; // SHA-256 output length in bytes
+    const S_IN_BYTES: usize = 64; // SHA-256 input block length in bytes
+
+    assert!(dst.len() <= 255, "DST too long for expand_message_xmd");
+    assert!(len_in_bytes <= 0xFFFF, "len_in_bytes exceeds its limit");
+
+    let ell = len_in_bytes.div_ceil(B_IN_BYTES);
+    assert!(ell <= 255, "expand_message_xmd requires ell <= 255");
+
+    // DST_prime = DST || I2OSP(len(DST), 1)
+    let mut dst_prime = Vec::with_capacity(dst.len() + 1);
+    dst_prime.extend_from_slice(dst);
+    dst_prime.push(dst.len() as u8);
+
+    // msg_prime = I2OSP(0, s_in_bytes) || msg || I2OSP(len_in_bytes, 2) || I2OSP(0, 1) || DST_prime
+    let mut msg_prime = Vec::with_capacity(S_IN_BYTES + msg.len() + 3 + dst_prime.len());
+    msg_prime.extend(core::iter::repeat(0u8).take(S_IN_BYTES));
+    msg_prime.extend_from_slice(msg);
+    msg_prime.push((len_in_bytes >> 8) as u8);
+    msg_prime.push((len_in_bytes & 0xff) as u8);
+    msg_prime.push(0);
+    msg_prime.extend_from_slice(&dst_prime);
+
+    // b_0 = H(msg_prime)
+    let b_0 = sha256(
+        &msg_prime,
+        #[cfg(feature = "hints")]
+        hints,
+    );
+
+    // b_1 = H(b_0 || I2OSP(1, 1) || DST_prime)
+    let mut buf: Vec<u8> = Vec::with_capacity(B_IN_BYTES + 1 + dst_prime.len());
+    buf.extend_from_slice(&b_0);
+    buf.push(1);
+    buf.extend_from_slice(&dst_prime);
+    let mut b_prev = sha256(
+        &buf,
+        #[cfg(feature = "hints")]
+        hints,
+    );
+
+    // b_i = H(strxor(b_0, b_{i-1}) || I2OSP(i, 1) || DST_prime), for i in 2..=ell
+    let mut uniform_bytes = Vec::with_capacity(B_IN_BYTES * ell);
+    uniform_bytes.extend_from_slice(&b_prev);
+    for i in 2..=ell {
+        let mut xored = [0u8; B_IN_BYTES];
+        for j in 0..B_IN_BYTES {
+            xored[j] = b_0[j] ^ b_prev[j];
+        }
+        buf.clear();
+        buf.extend_from_slice(&xored);
+        buf.push(i as u8);
+        buf.extend_from_slice(&dst_prime);
+        b_prev = sha256(
+            &buf,
+            #[cfg(feature = "hints")]
+            hints,
+        );
+        uniform_bytes.extend_from_slice(&b_prev);
+    }
+
+    uniform_bytes.truncate(len_in_bytes);
+    uniform_bytes
+}
+
+/// Reduces a 64-byte big-endian integer to an Fp element via the
+/// split-and-shift trick: each 32-byte half is already < 2^256 < p, so we just
+/// compute `hi * 2^256 + lo (mod p)` with one Fp multiplication and one Fp add.
+fn os2ip_64_be_mod_p(bytes: &[u8; 64], #[cfg(feature = "hints")] hints: &mut Vec<u64>) -> [u64; 6] {
+    const R256_FP: [u64; 6] = [0, 0, 0, 0, 1, 0]; // 2^256 mod p
+
+    let mut d_hi = [0u64; 6];
+    let mut d_lo = [0u64; 6];
+    for i in 0..4 {
+        for j in 0..8 {
+            d_hi[3 - i] |= (bytes[i * 8 + j] as u64) << (8 * (7 - j));
+            d_lo[3 - i] |= (bytes[32 + i * 8 + j] as u64) << (8 * (7 - j));
+        }
+    }
+    let shifted = mul_fp_bls12_381(
+        &d_hi,
+        &R256_FP,
+        #[cfg(feature = "hints")]
+        hints,
+    );
+    add_fp_bls12_381(
+        &shifted,
+        &d_lo,
+        #[cfg(feature = "hints")]
+        hints,
+    )
+}
+
+/// Hash an arbitrary-length byte string to two Fp2 elements
+fn hash_to_field_fp2_count2_bls12_381(
+    msg: &[u8],
+    dst: &[u8],
+    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
+) -> [[u64; 12]; 2] {
+    const L: usize = 64; // ceil((ceil(log2(p)) + k) / 8) = ceil((381 + 128) / 8)
+    const M: usize = 2; // Fp2 has degree 2 over Fp
+    const COUNT: usize = 2; // Output 2 Fp2 elements for the G2 suite
+
+    // Expand the message to 256 uniformly random bytes
+    let uniform = expand_message_xmd_sha256(
+        msg,
+        dst,
+        L * M * COUNT,
+        #[cfg(feature = "hints")]
+        hints,
+    );
+
+    // Parse the output as 4 big-endian 64-byte integers,
+    // reduce each mod p to get 4 Fp elements,
+    // and pack those into 2 Fp2 elements
+    let mut result = [[0u64; 12]; COUNT];
+    for (i, fp2) in result.iter_mut().enumerate() {
+        for j in 0..M {
+            let off = L * (j + i * M);
+            let chunk: &[u8; L] = uniform[off..off + L].try_into().unwrap();
+            let e_j = os2ip_64_be_mod_p(
+                chunk,
+                #[cfg(feature = "hints")]
+                hints,
+            );
+            let limb_off = j * 6;
+            fp2[limb_off..limb_off + 6].copy_from_slice(&e_j);
+        }
+    }
+    result
+}

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/hash_to_curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/hash_to_curve.rs
@@ -1,6 +1,6 @@
 //! Hash-to-curve for BLS12-381 G2
 
-#[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
+#[cfg(zisk_guest)]
 use crate::alloc_extern::vec::Vec;
 
 use crate::zisklib::lib::sha256::sha256;

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/kzg.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/kzg.rs
@@ -5,12 +5,9 @@ use crate::zisklib::{
 
 use super::{
     constants::{G1_GENERATOR, G1_IDENTITY, G2_GENERATOR, G2_IDENTITY, R, TRUSTED_SETUP_TAU_G2},
-    curve::{decompress_bls12_381, scalar_mul_bls12_381, sub_bls12_381, sub_complete_bls12_381},
+    curve::{decompress_bls12_381, scalar_mul_bls12_381, sub_complete_bls12_381},
     pairing::pairing_batch_bls12_381,
-    twist::{
-        decompress_twist_bls12_381, neg_twist_bls12_381, scalar_mul_twist_bls12_381,
-        sub_complete_twist_bls12_381, sub_twist_bls12_381,
-    },
+    twist::{neg_twist_bls12_381, scalar_mul_twist_bls12_381, sub_complete_twist_bls12_381},
 };
 
 /// Verify KZG proof using BLS12-381 implementation.
@@ -22,15 +19,15 @@ pub fn verify_kzg_proof(
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> bool {
     // Parse the commitment
-    let commitment = match decompress_bls12_381(
+    let (commitment, commitment_is_inf) = match decompress_bls12_381(
         commitment_bytes,
         #[cfg(feature = "hints")]
         hints,
     ) {
-        Ok(result) => result,
+        Ok((result, is_infinity)) => (result, is_infinity),
         Err(_) => return false,
     };
-    if !eq(&commitment, &G1_IDENTITY)
+    if !commitment_is_inf
         && !is_on_subgroup_bls12_381(
             &commitment,
             #[cfg(feature = "hints")]
@@ -41,15 +38,15 @@ pub fn verify_kzg_proof(
     }
 
     // Parse the proof
-    let proof = match decompress_bls12_381(
+    let (proof, proof_is_inf) = match decompress_bls12_381(
         proof_bytes,
         #[cfg(feature = "hints")]
         hints,
     ) {
-        Ok(result) => result,
+        Ok((result, is_infinity)) => (result, is_infinity),
         Err(_) => return false,
     };
-    if !eq(&proof, &G1_IDENTITY)
+    if !proof_is_inf
         && !is_on_subgroup_bls12_381(
             &proof,
             #[cfg(feature = "hints")]

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/map_to_curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/map_to_curve.rs
@@ -1,3 +1,5 @@
+//! Map-to-curve for BLS12-381 G1 and G2
+
 use crate::zisklib::{eq, is_zero, lt};
 
 use super::{
@@ -68,30 +70,42 @@ pub fn map_to_curve_g2_bls12_381(
     u: &[u64; 12],
     #[cfg(feature = "hints")] hints: &mut Vec<u64>,
 ) -> Result<[u64; 24], u8> {
-    // Verify input is in field
+    let p = map_to_curve_g2_no_cofactor_bls12_381(
+        u,
+        #[cfg(feature = "hints")]
+        hints,
+    )?;
+
+    // Clear cofactor
+    Ok(clear_cofactor_twist_bls12_381(
+        &p,
+        #[cfg(feature = "hints")]
+        hints,
+    ))
+}
+
+/// Maps a field element in Fp2 to a point on the BLS12-381 G2 curve
+/// without clearing the cofactor.
+pub(super) fn map_to_curve_g2_no_cofactor_bls12_381(
+    u: &[u64; 12],
+    #[cfg(feature = "hints")] hints: &mut Vec<u64>,
+) -> Result<[u64; 24], u8> {
     let u_0: [u64; 6] = u[0..6].try_into().unwrap();
     let u_1: [u64; 6] = u[6..12].try_into().unwrap();
     if !lt(&u_0, &P) || !lt(&u_1, &P) {
         return Err(G2_MAP_TO_CURVE_ERR_NOT_IN_FIELD);
     }
 
-    // Step 1: Map to isogenous curve E' using simplified SWU
+    // Map to isogenous curve E' using simplified SWU
     let p_prime = map_to_curve_simple_swu_g2_bls12_381(
         u,
         #[cfg(feature = "hints")]
         hints,
     );
 
-    // Step 2: Apply isogeny map from E' to E
-    let p = isogeny_map_g2_bls12_381(
+    // Apply isogeny map from E' to E
+    Ok(isogeny_map_g2_bls12_381(
         &p_prime,
-        #[cfg(feature = "hints")]
-        hints,
-    );
-
-    // Step 3: Clear cofactor
-    Ok(clear_cofactor_twist_bls12_381(
-        &p,
         #[cfg(feature = "hints")]
         hints,
     ))

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/mod.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/mod.rs
@@ -17,10 +17,13 @@
 //! - [`cyclotomic`] — Cyclotomic subgroup arithmetic.
 //! - [`pairing`] — Optimal Ate pairing and batch pairing check.
 //!
-//! ## KZG and hash-to-curve
+//! ## KZG, BLS and hash-to-curve
 //! - [`kzg`] — KZG polynomial commitment proof verification.
-//! - [`map_to_curve`] — Hash-to-curve for G1 and G2.
+//! - [`bls`] — BLS signature verification.
+//! - [`map_to_curve`] — Map-to-curve for G1 and G2.
+//! - [`hash_to_curve`] — Hash-to-curve for G2.
 
+mod bls;
 mod constants;
 mod curve;
 mod cyclotomic;
@@ -30,12 +33,14 @@ mod fp12;
 mod fp2;
 mod fp6;
 mod fr;
+mod hash_to_curve;
 mod kzg;
 mod map_to_curve;
 mod miller_loop;
 mod pairing;
 mod twist;
 
+pub use bls::*;
 pub use curve::*;
 pub use cyclotomic::*;
 pub use final_exp::*;
@@ -44,6 +49,7 @@ pub use fp12::*;
 pub use fp2::*;
 pub use fp6::*;
 pub use fr::*;
+pub use hash_to_curve::*;
 pub use kzg::*;
 pub use map_to_curve::*;
 pub use pairing::*;

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
@@ -1150,10 +1150,10 @@ pub unsafe extern "C" fn decompress_twist_bls12_381_c(
         #[cfg(feature = "hints")]
         hints,
     ) {
-        Ok((p, _)) => {
+        Ok((p, is_infinity)) => {
             let result = &mut *(result_ptr as *mut [u64; 24]);
             *result = p;
-            if eq(&p, &G2_IDENTITY) {
+            if is_infinity {
                 1
             } else {
                 0


### PR DESCRIPTION
This pull request introduces new BLS signature verification functionality for the BLS12-381 curve and adds comprehensive hash-to-curve RFC test vectors. The most significant changes include the implementation of BLS verification conforming IETF [draft-irtf-cfrg-bls-signature-06](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-06.html) (including aggregate verification) , the addition of hash-to-curve test coverage, and important adjustments to point decompression APIs to correctly handle the point at infinity. There are also minor dependency and formatting improvements.