### PR TITLE
Pad to word alignment instead of trimming in elf extraction

### DIFF
--- a/core/src/elf_extraction.rs
+++ b/core/src/elf_extraction.rs
@@ -73,9 +73,9 @@ pub fn collect_elf_payload_from_bytes(file_data: &[u8]) -> Result<ElfPayload, Bo
             let data = if sh.sh_type == SHT_PROGBITS {
                 let (raw, _) = elf.section_data(&sh)?;
                 let mut data = raw.to_vec();
-                // Word-align by trimming
+                // Word-align by padding with zeros (trimming would remove valid data)
                 while data.len() % 4 != 0 {
-                    data.pop();
+                    data.push(0);
                 }
                 data
             } else if sh.sh_type == SHT_NOBITS {


### PR DESCRIPTION
---

## Fix ELF section loading: pad to word alignment instead of trimming

### Problem

When loading `SHT_PROGBITS` sections (`.text`, `.rodata`, etc.) from an ELF file, `elf_extraction.rs` was trimming bytes from the end of a section to reach 4-byte alignment:

```rust
// Word-align by trimming
while data.len() % 4 != 0 {
    data.pop();
}
```

This is incorrect. Section data is authoritative up to the full size declared in the section header. Trimming silently discards the last 1–3 bytes of a section, making those addresses unavailable in the emulator's ROM map.

### Symptoms

When a program accessed any address in the trimmed tail of a section, the emulator panicked with:

```
Mem::read() section not found for addr: 0x8025d518 with width: 1
```

The failure was latent and only surfaced when the `.rodata` section size happened not to be a multiple of 4. Builds where all section sizes were already 4-byte-aligned were unaffected — which is why the bug did not appear consistently across different build configurations.

### Root cause

Different linker inputs (e.g. linking against a pre-built static library vs. compiling a crate directly) can produce slightly different section sizes. When `.rodata` was `0x1e029` bytes (1 mod 4), the old code trimmed the last byte — removing the byte at the highest address of the section. Any access to that address caused a fatal emulator crash.

### Fix

Pad with zeros instead of trimming:

```rust
// Word-align by padding with zeros (trimming would remove valid data)
while data.len() % 4 != 0 {
    data.push(0);
}
```

This preserves all section data and is consistent with how `SHT_NOBITS` (BSS) sections were already handled:

```rust
let aligned_size = (size + 3) & !3;
vec![0u8; aligned_size]
```

Zero-padding is safe: the bytes appended are in the gap between sections (the linker already aligned the *next* section to at least 4 bytes), so they will never be accessed by correct program code.

### Impact

Fixes emulator crashes that occurred when running guest programs whose `.rodata` section size was not a multiple of 4 bytes.