### PR TITLE
feat: new RC API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1237,7 +1237,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "fields 1.0.0-beta",
  "num-bigint",
@@ -1860,7 +1860,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1882,7 +1882,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2037,7 +2037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2939,7 +2939,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2959,27 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3511,7 +3493,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3917,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "colored",
  "fields 1.0.0-beta",
@@ -3937,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "pil2-stark-setup"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3962,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "pilout"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bytes",
  "prost 0.13.5",
@@ -4343,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "blake3",
@@ -4377,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "borsh",
@@ -4408,7 +4390,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "fields 1.0.0-beta",
  "itoa",
@@ -4421,7 +4403,7 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4431,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -4440,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "colored",
@@ -4463,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "fields 1.0.0-beta",
@@ -4519,7 +4501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -4539,7 +4521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4560,7 +4542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4573,7 +4555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4692,7 +4674,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5175,7 +5157,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5234,7 +5216,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5821,7 +5803,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stark-recurser"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "anyhow",
  "fields 1.0.0-beta",
@@ -6009,7 +5991,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6970,7 +6952,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7189,15 +7171,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -7229,28 +7202,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -7284,12 +7240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7300,12 +7250,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7320,22 +7264,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7350,12 +7282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7366,12 +7292,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7386,12 +7306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7402,12 +7316,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -7530,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "colored",
  "fields 1.0.0-beta",

--- a/precompiles/arith_eq/src/arith_eq.rs
+++ b/precompiles/arith_eq/src/arith_eq.rs
@@ -379,7 +379,7 @@ impl<F: PrimeField64> ArithEqSM<F> {
 
     #[inline(always)]
     fn to_ranged_field(&self, value: i64, range_id: usize) -> u64 {
-        self.std.range_check(range_id, value, 1);
+        self.std.range_check_one(range_id, value);
         if value >= 0 {
             value as u64
         } else {
@@ -456,7 +456,7 @@ impl<F: PrimeField64> ArithEqSM<F> {
                         data.x3[i] - data.y2[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_x3_lt = x3_lt;
 
                     trace[i].set_y3_lt(false);
@@ -471,7 +471,7 @@ impl<F: PrimeField64> ArithEqSM<F> {
                         data.x3[i] - SECP256K1_PRIME_CHUNKS[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_x3_lt = x3_lt;
 
                     let y3_lt = data.y3[i] < SECP256K1_PRIME_CHUNKS[i]
@@ -483,7 +483,7 @@ impl<F: PrimeField64> ArithEqSM<F> {
                         data.y3[i] - SECP256K1_PRIME_CHUNKS[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_y3_lt = y3_lt;
                 }
                 SEL_OP_BN254_CURVE_ADD
@@ -500,7 +500,7 @@ impl<F: PrimeField64> ArithEqSM<F> {
                         data.x3[i] - BN254_PRIME_CHUNKS[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_x3_lt = x3_lt;
 
                     let y3_lt = data.y3[i] < BN254_PRIME_CHUNKS[i]
@@ -512,7 +512,7 @@ impl<F: PrimeField64> ArithEqSM<F> {
                         data.y3[i] - BN254_PRIME_CHUNKS[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_y3_lt = y3_lt;
                 }
                 SEL_OP_SECP256R1_ADD | SEL_OP_SECP256R1_DBL => {
@@ -525,7 +525,7 @@ impl<F: PrimeField64> ArithEqSM<F> {
                         data.x3[i] - SECP256R1_PRIME_CHUNKS[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_x3_lt = x3_lt;
 
                     let y3_lt = data.y3[i] < SECP256R1_PRIME_CHUNKS[i]
@@ -537,7 +537,7 @@ impl<F: PrimeField64> ArithEqSM<F> {
                         data.y3[i] - SECP256R1_PRIME_CHUNKS[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_y3_lt = y3_lt;
                 }
                 _ => {

--- a/precompiles/arith_eq_384/src/arith_eq_384.rs
+++ b/precompiles/arith_eq_384/src/arith_eq_384.rs
@@ -262,7 +262,7 @@ impl<F: PrimeField64> ArithEq384SM<F> {
 
     #[inline(always)]
     fn to_ranged_field(&self, value: i64, range_id: usize) -> u64 {
-        self.std.range_check(range_id, value, 1);
+        self.std.range_check_one(range_id, value);
         if value >= 0 {
             value as u64
         } else {
@@ -337,7 +337,7 @@ impl<F: PrimeField64> ArithEq384SM<F> {
                         data.x3[i] - data.y2[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_x3_lt = x3_lt;
 
                     trace[i].set_y3_lt(false);
@@ -356,7 +356,7 @@ impl<F: PrimeField64> ArithEq384SM<F> {
                         data.x3[i] - BLS12_381_PRIME_CHUNKS[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_x3_lt = x3_lt;
 
                     let y3_lt = data.y3[i] < BLS12_381_PRIME_CHUNKS[i]
@@ -368,7 +368,7 @@ impl<F: PrimeField64> ArithEq384SM<F> {
                         data.y3[i] - BLS12_381_PRIME_CHUNKS[i],
                         iclock,
                     );
-                    self.std.inc_virtual_row(self.table_id, row as u64, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                     prev_y3_lt = y3_lt;
                 }
                 _ => {

--- a/precompiles/big_int/src/add256.rs
+++ b/precompiles/big_int/src/add256.rs
@@ -202,7 +202,7 @@ impl<F: PrimeField64> Add256SM<F> {
         }
 
         // Send final result to std
-        self.std.range_checks(self.range_id, global_multiplicities);
+        self.std.range_check_ranged(self.range_id, None, &global_multiplicities);
 
         timer_stop_and_log_trace!(ADD256_TRACE);
 

--- a/precompiles/blake2/src/blake2.rs
+++ b/precompiles/blake2/src/blake2.rs
@@ -379,7 +379,7 @@ impl<F: PrimeField64> Blake2SM<F> {
                                            // and there are 8 g functions per blake2
         range_checks[0] += count_zeros as u32;
 
-        self.std.range_checks(self.range_id, range_checks);
+        self.std.range_check_ranged(self.range_id, None, &range_checks);
 
         Ok(AirInstance::new_from_trace(FromTrace::new(&mut trace)))
     }

--- a/precompiles/dma/src/dma/dma.rs
+++ b/precompiles/dma/src/dma/dma.rs
@@ -307,17 +307,20 @@ impl<F: PrimeField64> DmaSM<F> {
         // ] {
         //     println!("TRACE[{i}]={:?}", trace_rows[i]);
         // }
-        self.std
-            .inc_virtual_rows_ranged(self.dual_range_7_bits_id, &global_dual_7_bits_multiplicities);
-        self.std.range_checks(self.range_24_bits_id, global_24_bits_low_values);
-        self.std.inc_virtual_rows_ranged(self.rom_table_id, &global_rom_multiplicities);
-        self.std.range_checks(self.range_16_bits_id, global_16_bits_multiplicities);
+        self.std.inc_virtual_rows_ranged(
+            self.dual_range_7_bits_id,
+            None,
+            &global_dual_7_bits_multiplicities,
+        );
+        self.std.range_check_ranged(self.range_24_bits_id, None, &global_24_bits_low_values);
+        self.std.inc_virtual_rows_ranged(self.rom_table_id, None, &global_rom_multiplicities);
+        self.std.range_check_ranged(self.range_16_bits_id, None, &global_16_bits_multiplicities);
 
         for value in global_22_bits_values {
-            self.std.range_check(self.range_22_bits_id, value as i64, 1);
+            self.std.range_check_one(self.range_22_bits_id, value);
         }
         for value in global_24_bits_values {
-            self.std.range_check(self.range_24_bits_id, value as i64, 1);
+            self.std.range_check_one(self.range_24_bits_id, value);
         }
 
         if total_inputs < num_rows {

--- a/precompiles/dma/src/dma/dma_inputcpy.rs
+++ b/precompiles/dma/src/dma/dma_inputcpy.rs
@@ -210,15 +210,15 @@ impl<F: PrimeField64> DmaInputCpySM<F> {
                 },
             );
 
-        self.std.range_checks(self.range_7_bits_id, global_7_bits_multiplicities);
-        self.std.range_checks(self.range_24_bits_id, global_24_bits_low_values);
-        self.std.inc_virtual_rows_ranged(self.rom_table_id, &global_rom_multiplicities);
+        self.std.range_check_ranged(self.range_7_bits_id, None, &global_7_bits_multiplicities);
+        self.std.range_check_ranged(self.range_24_bits_id, None, &global_24_bits_low_values);
+        self.std.inc_virtual_rows_ranged(self.rom_table_id, None, &global_rom_multiplicities);
 
         for value in global_22_bits_values {
-            self.std.range_check(self.range_22_bits_id, value as i64, 1);
+            self.std.range_check_one(self.range_22_bits_id, value);
         }
         for value in global_24_bits_values {
-            self.std.range_check(self.range_24_bits_id, value as i64, 1);
+            self.std.range_check_one(self.range_24_bits_id, value);
         }
 
         if total_inputs < num_rows {

--- a/precompiles/dma/src/dma/dma_memcpy.rs
+++ b/precompiles/dma/src/dma/dma_memcpy.rs
@@ -242,16 +242,19 @@ impl<F: PrimeField64> DmaMemCpySM<F> {
         //         println!("DUAL_7_BITS[{index}]={value}")
         //     }
         // }
-        self.std
-            .inc_virtual_rows_ranged(self.dual_range_7_bits_id, &global_dual_7_bits_multiplicities);
-        self.std.range_checks(self.range_24_bits_id, global_24_bits_low_values);
-        self.std.inc_virtual_rows_ranged(self.rom_table_id, &global_rom_multiplicities);
+        self.std.inc_virtual_rows_ranged(
+            self.dual_range_7_bits_id,
+            None,
+            &global_dual_7_bits_multiplicities,
+        );
+        self.std.range_check_ranged(self.range_24_bits_id, None, &global_24_bits_low_values);
+        self.std.inc_virtual_rows_ranged(self.rom_table_id, None, &global_rom_multiplicities);
 
         for value in global_22_bits_values {
-            self.std.range_check(self.range_22_bits_id, value as i64, 1);
+            self.std.range_check_one(self.range_22_bits_id, value);
         }
         for value in global_24_bits_values {
-            self.std.range_check(self.range_24_bits_id, value as i64, 1);
+            self.std.range_check_one(self.range_24_bits_id, value);
         }
 
         if total_inputs < num_rows {

--- a/precompiles/dma/src/dma_64_aligned/dma_64_aligned.rs
+++ b/precompiles/dma/src/dma_64_aligned/dma_64_aligned.rs
@@ -274,18 +274,18 @@ impl<F: PrimeField64> Dma64AlignedSM<F> {
 
         // add range check of count to check that it's a positive 32-bits number
         let last_count = air_values.segment_last_count64.as_canonical_u64();
-        self.std.range_check(self.range_16_bits_id, (last_count & 0xFFFF) as i64, 1);
-        self.std.range_check(self.range_16_bits_id, ((last_count >> 16) & 0xFFFF) as i64, 1);
+        self.std.range_check_one(self.range_16_bits_id, last_count & 0xFFFF);
+        self.std.range_check_one(self.range_16_bits_id, (last_count >> 16) & 0xFFFF);
 
         // range check of 24 must be multiplied by 2 because there are two values, but dual range check
         // it's dual, no need to multiply by 2.
-        self.std.inc_virtual_row(self.dual_range_byte_id, 0u64, range_check_non_used_ops);
+        self.std.inc_virtual_row(self.dual_range_byte_id, 0, range_check_non_used_ops);
         self.std.range_check(self.range_24_bits_id, 0, range_check_non_used_ops * 2);
         for value in dual_byte_range_check_values {
-            self.std.inc_virtual_row(self.dual_range_byte_id, value as u64, 1);
+            self.std.inc_virtual_row_one(self.dual_range_byte_id, value);
         }
         for value in range_check_24b_values {
-            self.std.range_check(self.range_24_bits_id, value as i64, 1);
+            self.std.range_check_one(self.range_24_bits_id, value);
         }
 
         let segment_id = segment_id.into();

--- a/precompiles/dma/src/dma_64_aligned/dma_64_aligned_inputcpy.rs
+++ b/precompiles/dma/src/dma_64_aligned/dma_64_aligned_inputcpy.rs
@@ -225,11 +225,11 @@ impl<F: PrimeField64> Dma64AlignedInputCpySM<F> {
         // add range check of count to check that it's a positive 32-bits number
         let last_count = air_values.segment_last_count64.as_canonical_u64();
 
-        self.std.range_check(self.range_16_bits_id, (last_count & 0xFFFF) as i64, 1);
-        self.std.range_check(self.range_16_bits_id, ((last_count >> 16) & 0xFFFF) as i64, 1);
-        self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, &local_dual_byte);
+        self.std.range_check_one(self.range_16_bits_id, last_count & 0xFFFF);
+        self.std.range_check_one(self.range_16_bits_id, (last_count >> 16) & 0xFFFF);
+        self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, None, &local_dual_byte);
         for value in values_24_bits.iter() {
-            self.std.range_check(self.range_24_bits_id, *value as i64, 1);
+            self.std.range_check_one(self.range_24_bits_id, *value);
         }
 
         let segment_id = segment_id.into();

--- a/precompiles/dma/src/dma_64_aligned/dma_64_aligned_mem.rs
+++ b/precompiles/dma/src/dma_64_aligned/dma_64_aligned_mem.rs
@@ -247,7 +247,7 @@ impl<F: PrimeField64> Dma64AlignedMemSM<F> {
         local_16_bits_table[(last_count & 0xFFFF) as usize] += 1;
         local_16_bits_table[((last_count >> 16) & 0xFFFF) as usize] += 1;
 
-        self.std.range_checks(self.range_16_bits_id, local_16_bits_table);
+        self.std.range_check_ranged(self.range_16_bits_id, None, &local_16_bits_table);
 
         let segment_id = segment_id.into();
         air_values.segment_id = F::from_usize(segment_id);

--- a/precompiles/dma/src/dma_64_aligned/dma_64_aligned_memcpy.rs
+++ b/precompiles/dma/src/dma_64_aligned/dma_64_aligned_memcpy.rs
@@ -217,7 +217,7 @@ impl<F: PrimeField64> Dma64AlignedMemCpySM<F> {
         local_16_bits_table[(last_count & 0xFFFF) as usize] += 1;
         local_16_bits_table[((last_count >> 16) & 0xFFFF) as usize] += 1;
 
-        self.std.range_checks(self.range_16_bits_id, local_16_bits_table);
+        self.std.range_check_ranged(self.range_16_bits_id, None, &local_16_bits_table);
 
         let segment_id = segment_id.into();
         air_values.segment_id = F::from_usize(segment_id);

--- a/precompiles/dma/src/dma_64_aligned/dma_64_aligned_memset.rs
+++ b/precompiles/dma/src/dma_64_aligned/dma_64_aligned_memset.rs
@@ -205,7 +205,7 @@ impl<F: PrimeField64> Dma64AlignedMemSetSM<F> {
         local_16_bits_table[(last_count & 0xFFFF) as usize] += 1;
         local_16_bits_table[((last_count >> 16) & 0xFFFF) as usize] += 1;
 
-        self.std.range_checks(self.range_16_bits_id, local_16_bits_table);
+        self.std.range_check_ranged(self.range_16_bits_id, None, &local_16_bits_table);
 
         let segment_id = segment_id.into();
         air_values.segment_id = F::from_usize(segment_id);

--- a/precompiles/dma/src/dma_pre_post/dma_pre_post.rs
+++ b/precompiles/dma/src/dma_pre_post/dma_pre_post.rs
@@ -348,16 +348,16 @@ impl<F: PrimeField64> DmaPrePostSM<F> {
             .unzip();
         for pre_post_table_mul in global_pre_post_table_mul.iter() {
             // println!("PRE_POST_TABLE_MUL {:?}", pre_post_table_mul);
-            self.std.inc_virtual_rows_ranged(self.pre_post_table_id, pre_post_table_mul);
+            self.std.inc_virtual_rows_ranged(self.pre_post_table_id, None, pre_post_table_mul);
         }
 
         for byte_cmp_table_mul in global_byte_cmp_table_mul.iter() {
             // println!("PRE_POST_TABLE_MUL {:?}", pre_post_table_mul);
-            self.std.inc_virtual_rows_ranged(self.byte_cmp_table_id, byte_cmp_table_mul);
+            self.std.inc_virtual_rows_ranged(self.byte_cmp_table_id, None, byte_cmp_table_mul);
         }
 
         for dual_range_byte_mul in global_dual_range_byte_mul.iter() {
-            self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, dual_range_byte_mul);
+            self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, None, dual_range_byte_mul);
         }
         // for i in [
         //     4538, 4541, 4542, 4544, 4545, 4546, 4549, 4550, 4551, 4739, 147059, 147215, 147258,

--- a/precompiles/dma/src/dma_pre_post/dma_pre_post_inputcpy.rs
+++ b/precompiles/dma/src/dma_pre_post/dma_pre_post_inputcpy.rs
@@ -206,11 +206,11 @@ impl<F: PrimeField64> DmaPrePostInputCpySM<F> {
 
         for pre_post_table_mul in global_pre_post_table_mul.iter() {
             // println!("PRE_POST_TABLE_MUL {:?}", pre_post_table_mul);
-            self.std.inc_virtual_rows_ranged(self.pre_post_table_id, pre_post_table_mul);
+            self.std.inc_virtual_rows_ranged(self.pre_post_table_id, None, pre_post_table_mul);
         }
 
         for dual_range_byte_mul in global_dual_range_byte_mul.iter() {
-            self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, dual_range_byte_mul);
+            self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, None, dual_range_byte_mul);
         }
 
         if total_inputs < num_rows {

--- a/precompiles/dma/src/dma_pre_post/dma_pre_post_memcpy.rs
+++ b/precompiles/dma/src/dma_pre_post/dma_pre_post_memcpy.rs
@@ -254,11 +254,11 @@ impl<F: PrimeField64> DmaPrePostMemCpySM<F> {
 
         for pre_post_table_mul in global_pre_post_table_mul.iter() {
             // println!("PRE_POST_TABLE_MUL {:?}", pre_post_table_mul);
-            self.std.inc_virtual_rows_ranged(self.pre_post_table_id, pre_post_table_mul);
+            self.std.inc_virtual_rows_ranged(self.pre_post_table_id, None, pre_post_table_mul);
         }
 
         for dual_range_byte_mul in global_dual_range_byte_mul.iter() {
-            self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, dual_range_byte_mul);
+            self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, None, dual_range_byte_mul);
         }
 
         /*

--- a/precompiles/dma/src/dma_unaligned/dma_unaligned.rs
+++ b/precompiles/dma/src/dma_unaligned/dma_unaligned.rs
@@ -236,11 +236,11 @@ impl<F: PrimeField64> DmaUnalignedSM<F> {
         } else {
             0
         };
-        self.std.range_check(self.range_16_bits_id, (last_count & 0xFFFF) as i64, 1);
-        self.std.range_check(self.range_16_bits_id, ((last_count >> 16) & 0xFFFF) as i64, 1);
+        self.std.range_check_one(self.range_16_bits_id, last_count & 0xFFFF);
+        self.std.range_check_one(self.range_16_bits_id, (last_count >> 16) & 0xFFFF);
 
         local_dual_byte_table[0] += (padding_size * 4) as u64;
-        self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, &local_dual_byte_table);
+        self.std.inc_virtual_rows_ranged(self.dual_range_byte_id, None, &local_dual_byte_table);
 
         air_values.segment_id = F::from_usize(segment_id.into());
         air_values.is_last_segment = F::from_bool(is_last_segment);

--- a/precompiles/keccakf/src/keccakf.rs
+++ b/precompiles/keccakf/src/keccakf.rs
@@ -223,7 +223,7 @@ impl<F: PrimeField64> KeccakfSM<F> {
         }
         table.into_par_iter().enumerate().for_each(|(row, value)| {
             if value > 0 {
-                self.std.inc_virtual_row(self.table_id, row as u64, value as u64);
+                self.std.inc_virtual_row(self.table_id, row as u32, value);
             }
         });
         timer_stop_and_log_trace!(KECCAKF_TRACE);

--- a/precompiles/sha256f/src/sha256f.rs
+++ b/precompiles/sha256f/src/sha256f.rs
@@ -496,8 +496,8 @@ impl<F: PrimeField64> Sha256fSM<F> {
         a_range_checks[0] += count_zeros as u32;
         e_range_checks[0] += count_zeros as u32;
 
-        self.std.range_checks(self.a_range_id, a_range_checks);
-        self.std.range_checks(self.e_range_id, e_range_checks);
+        self.std.range_check_ranged(self.a_range_id, None, &a_range_checks);
+        self.std.range_check_ranged(self.e_range_id, None, &e_range_checks);
 
         timer_stop_and_log_trace!(SHA256F_PADDING);
 

--- a/state-machines/arith/src/arith_full_instance.rs
+++ b/state-machines/arith/src/arith_full_instance.rs
@@ -238,7 +238,7 @@ impl<F: PrimeField64> ArithInstanceCollector<F> {
         }
 
         if frops_row != ArithFrops::NO_FROPS {
-            self.std.inc_virtual_row(self.frops_table_id, frops_row as u64, 1);
+            self.std.inc_virtual_row_one(self.frops_table_id, frops_row);
             return true;
         }
 

--- a/state-machines/binary/src/binary_add.rs
+++ b/state-machines/binary/src/binary_add.rs
@@ -140,7 +140,7 @@ impl<F: PrimeField64> BinaryAddSM<F> {
         }
         multiplicities[0] += 4 * (num_rows - total_inputs) as u32;
 
-        self.std.range_checks(self.range_id, multiplicities);
+        self.std.range_check_ranged(self.range_id, None, &multiplicities);
 
         // Set 0 + 0 as the padding row
         let padding_size = num_rows - total_inputs;

--- a/state-machines/binary/src/binary_add_collector.rs
+++ b/state-machines/binary/src/binary_add_collector.rs
@@ -92,7 +92,7 @@ impl<F: PrimeField64> BinaryAddCollector<F> {
         }
 
         if frops_row != BinaryBasicFrops::NO_FROPS {
-            self.std.inc_virtual_row(self.frops_table_id, frops_row as u64, 1);
+            self.std.inc_virtual_row_one(self.frops_table_id, frops_row);
             return true;
         }
 

--- a/state-machines/binary/src/binary_basic.rs
+++ b/state-machines/binary/src/binary_basic.rs
@@ -248,7 +248,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -315,7 +315,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -367,7 +367,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         if i == 0 { 2 * pfirst[i] } else { plast[i] },
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -419,7 +419,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         if i == 0 { 2 * pfirst[i] } else { plast[i] },
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -483,7 +483,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -536,7 +536,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -585,7 +585,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -631,7 +631,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -676,7 +676,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -731,7 +731,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
                 row.set_all_carry(&carry);
             }
@@ -764,7 +764,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
             }
             OR_OP => {
@@ -796,7 +796,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
             }
             XOR_OP => {
@@ -828,7 +828,7 @@ impl<F: PrimeField64> BinaryBasicSM<F> {
                         plast[i],
                         flags,
                     );
-                    self.std.inc_virtual_row(self.table_id, row, 1);
+                    self.std.inc_virtual_row_one(self.table_id, row);
                 }
             }
             _ => panic!("BinaryBasicSM::process_slice() found invalid opcode={opcode}"),

--- a/state-machines/binary/src/binary_basic_collector.rs
+++ b/state-machines/binary/src/binary_basic_collector.rs
@@ -105,7 +105,7 @@ impl<F: PrimeField64> BinaryBasicCollector<F> {
         }
 
         if frops_row != BinaryBasicFrops::NO_FROPS {
-            self.std.inc_virtual_row(self.frops_table_id, frops_row as u64, 1);
+            self.std.inc_virtual_row_one(self.frops_table_id, frops_row);
             return true;
         }
 

--- a/state-machines/binary/src/binary_extension.rs
+++ b/state-machines/binary/src/binary_extension.rs
@@ -292,7 +292,7 @@ impl<F: PrimeField64> BinaryExtensionSM<F> {
                 *a_byte as u64,
                 in2_low,
             );
-            self.std.inc_virtual_row(self.table_id, row, 1);
+            self.std.inc_virtual_row_one(self.table_id, row);
         }
 
         row
@@ -349,7 +349,7 @@ impl<F: PrimeField64> BinaryExtensionSM<F> {
                 let op_is_shift = Self::opcode_is_shift(opcode);
                 if op_is_shift {
                     let row = (input.b >> 8) & 0xFFFFFF;
-                    self.std.range_check(self.range_id, row as i64, 1);
+                    self.std.range_check_one(self.range_id, row);
                 }
             }
         }

--- a/state-machines/binary/src/binary_extension_collector.rs
+++ b/state-machines/binary/src/binary_extension_collector.rs
@@ -87,7 +87,7 @@ impl<F: PrimeField64> BinaryExtensionCollector<F> {
         }
 
         if frops_row != BinaryExtensionFrops::NO_FROPS {
-            self.std.inc_virtual_row(self.frops_table_id, frops_row as u64, 1);
+            self.std.inc_virtual_row_one(self.frops_table_id, frops_row);
             return true;
         }
 

--- a/state-machines/main/src/main_sm.rs
+++ b/state-machines/main/src/main_sm.rs
@@ -362,14 +362,14 @@ impl<F: PrimeField64> MainInstance<F> {
         large_range_checks: &[u32],
     ) -> Result<(), MainSmError> {
         let range_id = self.std.get_range_id(0, MEM_REGS_MAX_DIFF as i64, None)?;
-        self.std.range_checks(range_id, step_range_check);
+        self.std.range_check_ranged(range_id, None, &step_range_check);
 
         for range in large_range_checks {
-            self.std.range_check(range_id, *range as i64, 1);
+            self.std.range_check_one(range_id, *range);
         }
 
         let range_id = self.std.get_range_id(0, Self::MAX_SEGMENT_ID as i64, None)?;
-        self.std.range_check(range_id, segment_id.as_usize() as i64, 1);
+        self.std.range_check_one(range_id, segment_id.as_usize());
         Ok(())
     }
 

--- a/state-machines/mem/src/input_data_sm.rs
+++ b/state-machines/mem/src/input_data_sm.rs
@@ -197,7 +197,7 @@ impl<F: PrimeField64> InputDataSM<F> {
             let addr_changes = last_addr != mem_op.addr;
             if addr_changes {
                 trace[i].set_addr_changes(true);
-                self.std.range_check(self.range_id, (mem_op.addr - last_addr - 1) as i64, 1);
+                self.std.range_check_one(self.range_id, mem_op.addr - last_addr - 1);
             } else {
                 trace[i].set_addr_changes(false);
             }
@@ -235,8 +235,8 @@ impl<F: PrimeField64> InputDataSM<F> {
 
         self.std.range_check(
             self.range_id,
-            SEGMENT_ADDR_MAX_RANGE as i64,
-            max_range_distance_count,
+            SEGMENT_ADDR_MAX_RANGE,
+            max_range_distance_count as u32,
         );
 
         // range of chunks
@@ -273,7 +273,7 @@ impl<F: PrimeField64> InputDataSM<F> {
         range_16bits[distance_end[0] as usize] += 1;
         range_16bits[distance_end[1] as usize] += 1;
 
-        self.std.range_checks(self.range_16bits_id, range_16bits);
+        self.std.range_check_ranged(self.range_16bits_id, None, &range_16bits);
 
         Ok(AirInstance::new_from_trace(FromTrace::new(&mut trace).with_air_values(&mut air_values)))
     }

--- a/state-machines/mem/src/mem_align_byte_sm.rs
+++ b/state-machines/mem/src/mem_align_byte_sm.rs
@@ -383,10 +383,10 @@ impl<F: PrimeField64> MemAlignByteSM<F> {
             }
         }
 
-        self.std.inc_virtual_rows_ranged(self.table_dual_byte_id, &dual_mults);
-        self.std.range_checks(self.table_16b_id, mults_16b);
+        self.std.inc_virtual_rows_ranged(self.table_dual_byte_id, None, &dual_mults);
+        self.std.range_check_ranged(self.table_16b_id, None, &mults_16b);
         if R::valid_for_write() {
-            self.std.range_checks(self.table_8b_id, mults_8b);
+            self.std.range_check_ranged(self.table_8b_id, None, &mults_8b);
         }
 
         Ok(R::create_instance_from_trace(&mut trace, irow))

--- a/state-machines/mem/src/mem_align_rom_sm.rs
+++ b/state-machines/mem/src/mem_align_rom_sm.rs
@@ -55,7 +55,7 @@ impl MemAlignRomSM {
 
         // Get the rows for the given program counter and operation size
         for i in 0..op_size {
-            std.inc_virtual_row(table_id, pc + i, 1);
+            std.inc_virtual_row_one(table_id, pc + i);
         }
     }
 

--- a/state-machines/mem/src/mem_align_sm.rs
+++ b/state-machines/mem/src/mem_align_sm.rs
@@ -909,6 +909,6 @@ impl<F: PrimeField64> MemAlignSM<F> {
 
     fn update_std_range_check(&self, reg_range_check: Vec<u32>) {
         // Perform the range checks
-        self.std.range_checks(self.range_id, reg_range_check);
+        self.std.range_check_ranged(self.range_id, None, &reg_range_check);
     }
 }

--- a/state-machines/mem/src/mem_sm.rs
+++ b/state-machines/mem/src/mem_sm.rs
@@ -182,12 +182,12 @@ impl<F: PrimeField64> MemSM<F> {
                         increment_step
                     );
                     if increment_step >= DUAL_PARTIAL_RANGE_MAX as u64 {
-                        self.std.range_check(self.dual_range_id, increment_step as i64, 1);
+                        self.std.range_check_one(self.dual_range_id, increment_step);
                     } else if dual_partial_range[increment_step as usize] == u16::MAX {
                         dual_partial_range[increment_step as usize] = 0;
                         self.std.range_check(
                             self.dual_range_id,
-                            increment_step as i64,
+                            increment_step,
                             u16::MAX as u64 + 1,
                         );
                     } else {
@@ -335,14 +335,14 @@ impl<F: PrimeField64> MemSM<F> {
         range_16bits[distance_end[0] as usize] += 1;
         range_16bits[distance_end[1] as usize] += 1;
 
-        self.std.range_checks(self.range_22bits_id, range_22bits);
-        self.std.range_checks(self.range_16bits_id, range_16bits);
+        self.std.range_check_ranged(self.range_22bits_id, None, &range_22bits);
+        self.std.range_check_ranged(self.range_16bits_id, None, &range_16bits);
 
         for (value, count) in dual_partial_range.iter().enumerate() {
             if *count == 0 {
                 continue;
             }
-            self.std.range_check(self.dual_range_id, value as i64, *count as u64);
+            self.std.range_check(self.dual_range_id, value, *count);
         }
 
         #[cfg(feature = "debug_mem")]

--- a/state-machines/mem/src/rom_data_sm.rs
+++ b/state-machines/mem/src/rom_data_sm.rs
@@ -134,11 +134,7 @@ impl<F: PrimeField64> RomDataSM<F> {
         );
 
         // range of instance
-        self.std.range_check(
-            self.range_id,
-            (previous_segment.addr - ROM_DATA_W_ADDR_INIT) as i64,
-            1,
-        );
+        self.std.range_check_one(self.range_id, previous_segment.addr - ROM_DATA_W_ADDR_INIT);
 
         let mut max_range_distance_count = 0;
 
@@ -211,7 +207,7 @@ impl<F: PrimeField64> RomDataSM<F> {
             let addr_changes = last_addr != mem_op.addr;
             if addr_changes || (i == 0 && segment_id == 0) {
                 trace[i].set_addr_changes(true);
-                self.std.range_check(self.range_id, (mem_op.addr - last_addr - 1) as i64, 1);
+                self.std.range_check_one(self.range_id, mem_op.addr - last_addr - 1);
             } else {
                 trace[i].set_addr_changes(false);
             }
@@ -239,10 +235,10 @@ impl<F: PrimeField64> RomDataSM<F> {
 
         self.std.range_check(
             self.range_id,
-            SEGMENT_ADDR_MAX_RANGE as i64,
-            max_range_distance_count,
+            SEGMENT_ADDR_MAX_RANGE,
+            max_range_distance_count as u32,
         );
-        self.std.range_check(self.range_id, (ROM_DATA_W_ADDR_END - last_addr) as i64, 1);
+        self.std.range_check_one(self.range_id, ROM_DATA_W_ADDR_END - last_addr);
 
         let mut air_values = RomDataAirValues::<F>::new();
         air_values.segment_id = F::from_usize(segment_id.into());

--- a/test-artifacts/Cargo.lock
+++ b/test-artifacts/Cargo.lock
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1074,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "fields 1.0.0-beta",
  "num-bigint",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2085,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2467,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2648,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "colored",
  "fields 1.0.0-beta",
@@ -3414,7 +3414,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "blake3",
@@ -3448,7 +3448,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "borsh",
@@ -3479,7 +3479,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "fields 1.0.0-beta",
  "itoa",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3502,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "colored",
@@ -3532,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "fields 1.0.0-beta",
@@ -5378,9 +5378,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5391,9 +5391,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5401,9 +5401,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5414,9 +5414,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -6041,7 +6041,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "colored",
  "fields 1.0.0-beta",

--- a/test-artifacts/programs/Cargo.lock
+++ b/test-artifacts/programs/Cargo.lock
@@ -214,7 +214,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -225,7 +225,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -767,7 +767,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1217,7 +1217,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1472,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "fields 1.0.0-beta",
  "num-bigint",
@@ -1696,7 +1696,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1815,7 +1815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1930,7 +1930,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2562,15 +2562,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3048,7 +3039,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3333,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "colored",
  "fields 1.0.0-beta",
@@ -3688,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "blake3",
@@ -3722,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "borsh",
@@ -3753,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "fields 1.0.0-beta",
  "itoa",
@@ -3766,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3776,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -3785,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "colored",
@@ -3806,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "bincode",
  "fields 1.0.0-beta",
@@ -4330,7 +4321,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4389,7 +4380,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4867,7 +4858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5030,7 +5021,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5833,7 +5824,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6378,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#4bf7ccbd9e6e91b15b8591e2b6ab737591763e02"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#1f2f539595e2efacc0662a852df361d2c08a08c3"
 dependencies = [
  "colored",
  "fields 1.0.0-beta",


### PR DESCRIPTION
This pull request refactors multiple precompile modules to use new, more specific methods for range checking and virtual row increment operations. The main goal is to replace generic methods such as `range_check`, `range_checks`, and `inc_virtual_row` with more targeted alternatives like `range_check_one`, `range_check_ranged`, and `inc_virtual_row_one` or `inc_virtual_rows_ranged`. This improves code clarity and enforces more precise semantics for single-value and ranged operations.

It depens on [PR 483](https://github.com/0xPolygonHermez/pil2-proofman/pull/483) from pil2-proofman.