### PR TITLE
Fix worker reconnection OOM

### DIFF
--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -452,13 +452,21 @@ impl Coordinator {
             });
             if let Err(e) = self.workers_pool.send_message(worker_id, msg).await {
                 warn!("[Setup] Failed to send SetupProgram to worker {}: {}", worker_id, e);
-                // Remove unreachable worker from pending set — don't block on it.
                 self.setup_pending.write().await.entry(job_id.clone()).and_modify(|s| {
                     s.pending.remove(worker_id);
                 });
+                // Best-effort disconnect: if the worker didn't receive the message, it won't ACK and the setup will never complete, so disconnect it to unblock future setups. If the worker is still alive but just flakey, it will re-register and be healthy for the next setup attempt.
+                if let Some(gen) = self.workers_pool.connection_generation(worker_id).await {
+                    if let Err(de) =
+                        self.workers_pool.disconnect_worker_if_generation(worker_id, gen).await
+                    {
+                        warn!(
+                            "[Setup] Failed to disconnect {} after failed send: {}",
+                            worker_id, de
+                        );
+                    }
+                }
             }
-            // Workers were already flipped to `SettingUp` atomically in
-            // `try_reserve_all_for_setup`; no per-worker mark needed here.
         }
 
         // Edge case: all sends failed — complete immediately with failure.
@@ -1686,8 +1694,12 @@ mod tests {
         assert!(coordinator.pending_recovery.read().await.contains_key(&w0_id));
     }
 
+    /// A non-KeepComputing reconnect (here last_known_job_id=None, directive=None)
+    /// must drop the stale pending_recovery entry rather than rely on a WRC the
+    /// worker won't reliably send. A stray late WRC on the new stream is then a
+    /// no-op (no pending_recovery record).
     #[tokio::test]
-    async fn test_recovery_complete_survives_reconnect() {
+    async fn test_reconnect_without_live_job_clears_pending_recovery() {
         use zisk_cluster_common::WorkerReconnectRequestDto;
 
         let (coordinator, workers, job_id) =
@@ -1696,10 +1708,6 @@ mod tests {
         let w0_id = workers[0].0.clone();
 
         coordinator.fail_job(&job_id, "task failed").await.unwrap();
-        assert_eq!(
-            coordinator.workers_pool.worker_state(&w0_id).await,
-            Some(WorkerState::SettingUp)
-        );
         assert!(coordinator.pending_recovery.read().await.contains_key(&w0_id));
 
         coordinator.workers_pool.disconnect_worker(&w0_id).await.unwrap();
@@ -1713,16 +1721,10 @@ mod tests {
         let (accepted, _msg, _directive, _setup) =
             coordinator.handle_stream_reconnection(req, Box::new(sender2)).await;
         assert!(accepted);
-
-        // Reconnect must preserve the recovery intent.
-        assert_eq!(
-            coordinator.workers_pool.worker_state(&w0_id).await,
-            Some(WorkerState::SettingUp)
-        );
-
-        coordinator.handle_stream_recovery_complete(&w0_id).await.unwrap();
-        assert_eq!(coordinator.workers_pool.worker_state(&w0_id).await, Some(WorkerState::Ready));
         assert!(!coordinator.pending_recovery.read().await.contains_key(&w0_id));
+
+        // A late WRC is now a no-op since pending_recovery is empty.
+        coordinator.handle_stream_recovery_complete(&w0_id).await.unwrap();
     }
 
     /// `WorkerRecoveryComplete` arriving on the new stream before the failure
@@ -3095,5 +3097,146 @@ mod tests {
             coordinator.workers_pool.worker_state(&worker_id).await,
             Some(WorkerState::Idle)
         );
+    }
+
+    #[tokio::test]
+    async fn test_setup_ack_drops_stale_pending_recovery() {
+        use zisk_cluster_common::SetupProgramAckDto;
+
+        let (coordinator, workers, _) =
+            setup_coordinator_with_job(1, JobPhase::Contributions, |_| {}).await;
+        let w0_id = workers[0].0.clone();
+
+        coordinator
+            .workers_pool
+            .mark_worker_with_state(&w0_id, WorkerState::SettingUp)
+            .await
+            .unwrap();
+        coordinator.pending_recovery.write().await.insert(w0_id.clone(), Utc::now());
+
+        coordinator
+            .handle_stream_setup_program_ack(SetupProgramAckDto {
+                job_id: JobId::new().as_string(),
+                worker_id: w0_id.clone(),
+                hash_id: "h".into(),
+                success: true,
+                error_message: None,
+                vk: vec![1, 2, 3],
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(coordinator.workers_pool.worker_state(&w0_id).await, Some(WorkerState::Ready));
+        assert!(!coordinator.pending_recovery.read().await.contains_key(&w0_id));
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_cancelstalejob_clears_pending_recovery() {
+        use zisk_cluster_common::{ReconnectionDirectiveDto, WorkerReconnectRequestDto};
+
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(1, JobPhase::Contributions, |_| {}).await;
+        let w0_id = workers[0].0.clone();
+
+        coordinator.fail_job(&job_id, "simulated").await.unwrap();
+        assert!(coordinator.pending_recovery.read().await.contains_key(&w0_id));
+
+        coordinator.workers_pool.disconnect_worker(&w0_id).await.unwrap();
+
+        let (sender, _msgs) = MockMessageSender::new();
+        let (accepted, _msg, directive, _setup) = coordinator
+            .handle_stream_reconnection(
+                WorkerReconnectRequestDto {
+                    worker_id: w0_id.clone(),
+                    compute_capacity: ComputeCapacity::from(1u32),
+                    last_known_job_id: Some(job_id),
+                },
+                Box::new(sender),
+            )
+            .await;
+
+        assert!(accepted);
+        assert_eq!(directive, Some(ReconnectionDirectiveDto::CancelStaleJob));
+        assert!(!coordinator.pending_recovery.read().await.contains_key(&w0_id));
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_keepcomputing_preserves_pending_recovery() {
+        use zisk_cluster_common::{ReconnectionDirectiveDto, WorkerReconnectRequestDto};
+
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(1, JobPhase::Contributions, |_| {}).await;
+        let w0_id = workers[0].0.clone();
+
+        coordinator.pending_recovery.write().await.insert(w0_id.clone(), Utc::now());
+
+        let (sender, _msgs) = MockMessageSender::new();
+        let (accepted, _msg, directive, _setup) = coordinator
+            .handle_stream_reconnection(
+                WorkerReconnectRequestDto {
+                    worker_id: w0_id.clone(),
+                    compute_capacity: ComputeCapacity::from(1u32),
+                    last_known_job_id: Some(job_id),
+                },
+                Box::new(sender),
+            )
+            .await;
+
+        assert!(accepted);
+        assert_eq!(directive, Some(ReconnectionDirectiveDto::KeepComputing));
+        assert!(coordinator.pending_recovery.read().await.contains_key(&w0_id));
+    }
+
+    /// Integration of Fix 1 + Fix 3 across the full OOM-restart sequence.
+    /// fail_job parks the worker; reconnect clears pending_recovery (Fix 1);
+    /// a subsequent SetupProgramAck flips it Ready (the path that was wedged
+    /// in production). active_setups is left empty here so we manually mark
+    /// SettingUp post-reconnect to mimic what `read_all_setup_dtos` does in
+    /// production with a seeded setup.
+    #[tokio::test]
+    async fn test_fail_job_then_reconnect_then_setup_ack_yields_ready() {
+        use zisk_cluster_common::{SetupProgramAckDto, WorkerReconnectRequestDto};
+
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(1, JobPhase::Contributions, |_| {}).await;
+        let w0_id = workers[0].0.clone();
+
+        coordinator.fail_job(&job_id, "simulated OOM").await.unwrap();
+        assert!(coordinator.pending_recovery.read().await.contains_key(&w0_id));
+        coordinator.workers_pool.disconnect_worker(&w0_id).await.unwrap();
+
+        let (sender, _msgs) = MockMessageSender::new();
+        let (accepted, _msg, _directive, _setup) = coordinator
+            .handle_stream_reconnection(
+                WorkerReconnectRequestDto {
+                    worker_id: w0_id.clone(),
+                    compute_capacity: ComputeCapacity::from(1u32),
+                    last_known_job_id: Some(job_id),
+                },
+                Box::new(sender),
+            )
+            .await;
+        assert!(accepted);
+        assert!(!coordinator.pending_recovery.read().await.contains_key(&w0_id));
+
+        coordinator
+            .workers_pool
+            .mark_worker_with_state(&w0_id, WorkerState::SettingUp)
+            .await
+            .unwrap();
+
+        coordinator
+            .handle_stream_setup_program_ack(SetupProgramAckDto {
+                job_id: JobId::new().as_string(),
+                worker_id: w0_id.clone(),
+                hash_id: "h".into(),
+                success: true,
+                error_message: None,
+                vk: vec![1, 2, 3],
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(coordinator.workers_pool.worker_state(&w0_id).await, Some(WorkerState::Ready));
     }
 }

--- a/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
+++ b/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
@@ -342,10 +342,10 @@ impl Coordinator {
         // Non-KeepComputing reconnects won't produce a matching WRC, so any
         // leftover pending_recovery entry is stale and would wedge the worker
         // SettingUp via the SetupProgramAck guard.
-        if !matches!(directive, Some(ReconnectionDirectiveDto::KeepComputing)) {
-            if self.pending_recovery.write().await.remove(&worker_id).is_some() {
-                info!("[Recovery] Cleared stale pending_recovery for {}", worker_id);
-            }
+        if !matches!(directive, Some(ReconnectionDirectiveDto::KeepComputing))
+            && self.pending_recovery.write().await.remove(&worker_id).is_some()
+        {
+            info!("[Recovery] Cleared stale pending_recovery for {}", worker_id);
         }
 
         let mut setups = self.read_all_setup_dtos().await;

--- a/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
+++ b/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
@@ -52,14 +52,16 @@ impl Coordinator {
             );
         }
 
-        // A worker can be `SettingUp` either pending this `SetupProgramAck`
-        // or pending a `WorkerRecoveryComplete`. The recovery handshake owns
-        // the flip back to Ready in the latter case; setup-ack must not
-        // pre-empt it.
+        // A successful SetupProgramAck proves the prover is healthy; any
+        // lingering pending_recovery entry is stale (WRC will never arrive).
         let worker_id = ack.worker_id.clone();
-        if self.workers_pool.worker_state(&worker_id).await == Some(WorkerState::SettingUp)
-            && !self.pending_recovery.read().await.contains_key(&worker_id)
-        {
+        if self.workers_pool.worker_state(&worker_id).await == Some(WorkerState::SettingUp) {
+            if self.pending_recovery.write().await.remove(&worker_id).is_some() {
+                warn!(
+                    "[Recovery] Dropped stale pending_recovery for {} on SetupProgramAck",
+                    worker_id
+                );
+            }
             let _ = self.workers_pool.mark_worker_with_state(&worker_id, WorkerState::Ready).await;
             info!("[Setup] Worker {} finished setup, now Ready", ack.worker_id);
         }
@@ -337,21 +339,22 @@ impl Coordinator {
         let directive =
             self.compute_reconnection_directive(&worker_id, last_known_job_id.clone()).await;
 
-        // Read all known setups before registering so the initial state is set atomically —
-        // no window where the worker is Idle without having a guest program.
+        // Non-KeepComputing reconnects won't produce a matching WRC, so any
+        // leftover pending_recovery entry is stale and would wedge the worker
+        // SettingUp via the SetupProgramAck guard.
+        if !matches!(directive, Some(ReconnectionDirectiveDto::KeepComputing)) {
+            if self.pending_recovery.write().await.remove(&worker_id).is_some() {
+                info!("[Recovery] Cleared stale pending_recovery for {}", worker_id);
+            }
+        }
+
         let mut setups = self.read_all_setup_dtos().await;
         let first_setup = if setups.is_empty() { None } else { Some(setups.remove(0)) };
         let default_state =
             if first_setup.is_some() { WorkerState::SettingUp } else { WorkerState::Idle };
 
-        // KeepComputing preserves the Computing(_) state across the channel
-        // swap. Pending-recovery workers stay SettingUp so the dispatcher
-        // doesn't pick them up before the queued `WorkerRecoveryComplete`
-        // arrives on the new stream.
         let initial_state = if matches!(directive, Some(ReconnectionDirectiveDto::KeepComputing)) {
             self.workers_pool.worker_state(&worker_id).await.unwrap_or(default_state)
-        } else if self.pending_recovery.read().await.contains_key(&worker_id) {
-            WorkerState::SettingUp
         } else {
             default_state
         };

--- a/distributed/crates/worker/src/worker_node.rs
+++ b/distributed/crates/worker/src/worker_node.rs
@@ -257,11 +257,18 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                             // clears `current_computation` first, so the handle
                             // is None here and `current_job`/`state` were
                             // already cleaned up. Just forward the message.
+                            let rc_for_requeue = rc.clone();
                             let msg = WorkerMessage {
                                 payload: Some(worker_message::Payload::RecoveryComplete(rc)),
                             };
                             if let Err(e) = message_sender.send(msg) {
-                                warn!("Failed to forward WorkerRecoveryComplete: {e}");
+                                warn!("Failed to forward WorkerRecoveryComplete: {e}; re-enqueueing");
+                                // Put it back on the process-long channel so the
+                                // next stream re-delivers; otherwise the coordinator
+                                // stays parked in pending_recovery.
+                                if let Err(re) = loop_tx.send_recovery_complete(rc_for_requeue) {
+                                    error!("Failed to re-enqueue WorkerRecoveryComplete: {re}");
+                                }
                                 break;
                             }
                         }
@@ -320,11 +327,15 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
                                     }
                                 }
                                 Ok(LoopEvent::RecoveryComplete(rc)) => {
+                                    let rc_for_requeue = rc.clone();
                                     let msg = WorkerMessage {
                                         payload: Some(worker_message::Payload::RecoveryComplete(rc)),
                                     };
                                     if let Err(e) = message_sender.send(msg) {
-                                        warn!("Failed to forward WorkerRecoveryComplete: {e}");
+                                        warn!("Failed to forward WorkerRecoveryComplete: {e}; re-enqueueing");
+                                        if let Err(re) = loop_tx.send_recovery_complete(rc_for_requeue) {
+                                            error!("Failed to re-enqueue WorkerRecoveryComplete: {re}");
+                                        }
                                         break;
                                     }
                                     self.worker.set_current_job(None);


### PR DESCRIPTION
A worker on a failed job is parked in pending_recovery and won't be released until it sends WorkerRecoveryComplete, but when the worker reconnects via Reconnect (stream blip, ASM crash, OOM that didn't kill the main process), it only sends WRC if it still has an in-flight computation — otherwise WRC never arrives.

The coordinator's Reconnect handler didn't clear the orphaned pending_recovery entry (the Register path did), so subsequent SetupProgramAcks for that worker hit the guard state == SettingUp && !pending_recovery.contains(worker) and never flipped it to Ready.

Result: the worker shows "completed setup" in the logs but never "finished setup, now Ready", stays wedged SettingUp forever, and is silently excluded from every job because partition_and_reserve only picks Ready workers.