### PR TITLE
fix: rustflags overriding

### DIFF
--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -53,8 +53,12 @@ impl ZiskBuild {
         command.args([&format!("+{toolchain_name}"), "build"]);
 
         // Set RUSTFLAGS for target-cpu=zisk, preserving existing flags
-        let flags = std::env::var("RUSTFLAGS").unwrap_or_default();
-        command.env("RUSTFLAGS", flags.trim());
+        if let Ok(flags) = std::env::var("RUSTFLAGS") {
+            let trimmed = flags.trim();
+            if !trimmed.is_empty() {
+                command.env("RUSTFLAGS", trimmed);
+            }
+        }
 
         command.args(["--target-dir", &format!("target/{}", HELPER_TARGET_SUBDIR)]);
 


### PR DESCRIPTION
## Summary

`cargo zisk build` was always setting `RUSTFLAGS` on the child `cargo` invocation, even when the user didn't pass one. The current code in `cli/src/commands/build.rs`:

```rust
let flags = std::env::var("RUSTFLAGS").unwrap_or_default();
command.env("RUSTFLAGS", flags.trim());
```

defaults the parent's `RUSTFLAGS` to `""` and then forwards that empty string. By [Cargo's precedence rules](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags), **`RUSTFLAGS=""` still counts as "set"** at priority 2 and silently overrides any lower-priority source — including `build.rustflags` and `target.<triple>.rustflags` from `.cargo/config.toml`.

## Fix

Only forward `RUSTFLAGS` when the parent process actually has it set to a non-empty value:

```rust
if let Ok(flags) = std::env::var("RUSTFLAGS") {
    let trimmed = flags.trim();
    if !trimmed.is_empty() {
        command.env("RUSTFLAGS", trimmed);
    }
}
```

After this change:

- `RUSTFLAGS=... cargo zisk build` — still forwarded as before.
- Plain `cargo-zisk build` with flags in `.cargo/config.toml` — config is now honored.
- Plain `cargo-zisk build` with no RUSTFLAGS anywhere — unchanged, builds with the toolchain's default flags.

## Why this matters

Without this fix, the only way to add custom rustflags to a ZisK guest build is to pass `RUSTFLAGS=...` on every invocation.