### PR TITLE
fix(lib-c): truncate libziskc.a before re-archiving to avoid duplicate symbols

### DIFF
--- a/lib-c/c/Makefile
+++ b/lib-c/c/Makefile
@@ -150,6 +150,7 @@ $(LIB_FILE): $(ALL_OBJS) | $(LIB_DIR)
 	nm -g --defined-only $(FIELD_INTERNAL_OBJS) | awk '$$2 !~ /[vVwW]/ {print $$3}' \
 		| sort -u > $(LOCALIZE_LIST)
 	objcopy --localize-symbols=$(LOCALIZE_LIST) $(COMBINED_OBJ)
+	rm -f $@
 	ar rcs $@ $(COMBINED_OBJ)
 else
 $(LIB_FILE): $(ALL_OBJS) | $(LIB_DIR)


### PR DESCRIPTION
## Problem

Linking fails with `rust-lld: error: duplicate symbol` for many symbols
(`Arith256`, `BLS12_381ComplexInv`, `secp256r1`, `BLS12_381CurveAdd`,
`InverseFnEc`, `ScalarP`, …). Each is reported as defined in both an
individual object (`fcall.o`, `arith256.o`, `globals.o`, `secp256r1.o`,
`bls12_381.o`) **and** in `ziskc_combined.o`, all inside the same archive
`liblib_c-*.rlib`.

## Root cause

On Linux, `lib-c/c/Makefile` combines every object into `ziskc_combined.o`
(via `ld -r`) and localizes the field-internal symbols so they don't clash
with the copies bundled by `proofman-starks-lib-c`. It then archives that
single combined object:

```make
ar rcs $@ $(COMBINED_OBJ)
```
`ar rcs` inserts/replaces members — it does not truncate the archive. An
existing `lib/libziskc.a` left over from the older rule (`ar rcs $@ $(ALL_OBJS)`) still contained all the individual object members. The new combined object was simply added on top of them, leaving every symbol
defined twice in the same archive (the individual `.o` plus its copy inside
`ziskc_combined.o`) → duplicate-symbol link errors.

## Fix

Add `rm -f $@` before the `ar` step so the archive is always rebuilt from
exactly the single combined object:
```make
objcopy --localize-symbols=$(LOCALIZE_LIST) $(COMBINED_OBJ)
rm -f $@
ar rcs $@ $(COMBINED_OBJ)
```
This makes the archive deterministic regardless of any stale archive left by
a previous build, and prevents the same class of accumulation in the future.