### PR TITLE
fix(rom-setup): key asm/ROM caches on their build inputs

### DIFF
--- a/.github/workflows/asm_cache_invalidation.yml
+++ b/.github/workflows/asm_cache_invalidation.yml
@@ -1,0 +1,59 @@
+name: asm cache invalidation
+
+# Guards that the rom-setup asm/ROM cache key tracks every input that determines
+# the generated binaries (the linked C libs, the embedded float ELF, and the
+# transpiler / emulator-asm sources). Mutating any of them must change the cache
+# filename; otherwise stale binaries get silently reused. See
+# tools/test_asm_cache_invalidation.sh and rom-setup/build.rs.
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - "pre-develop-[0-9]+.[0-9]+.[0-9]*"
+    paths:
+      - "rom-setup/**"
+      - "core/src/**"
+      - "emulator-asm/**"
+      - "lib-c/**"
+      - "lib-float/c/lib/ziskfloat.elf"
+      - "tools/test_asm_cache_invalidation.sh"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cache-invalidation:
+    name: asm cache key tracks its inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          cd "$GITHUB_WORKSPACE/tools/test-env"
+          sudo ./install_deps.sh
+
+      - name: Run cache-invalidation test
+        run: ./tools/test_asm_cache_invalidation.sh --ci

--- a/.github/workflows/asm_cache_invalidation.yml
+++ b/.github/workflows/asm_cache_invalidation.yml
@@ -37,7 +37,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
           android: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5022,6 +5022,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "fields 1.0.0-beta",
+ "lib-float",
  "proofman-common",
  "sm-rom",
  "tracing",

--- a/lib-c/c/Makefile
+++ b/lib-c/c/Makefile
@@ -144,9 +144,6 @@ $(LIB_DIR):
 #
 # Elsewhere (macOS, where build.rs skips the C build entirely) just archive the
 # objects directly, avoiding the GNU-binutils-specific `ld -r`/`objcopy` step.
-#
-# `ar D` = deterministic archive (zeroed mtimes): unchanged source -> identical
-# bytes, so the rom-setup asm cache key (which hashes libziskc.a) is stable.
 ifeq ($(UNAME_S),Linux)
 $(LIB_FILE): $(ALL_OBJS) | $(LIB_DIR)
 	ld -r -z noexecstack -o $(COMBINED_OBJ) $(ALL_OBJS)
@@ -154,10 +151,10 @@ $(LIB_FILE): $(ALL_OBJS) | $(LIB_DIR)
 		| sort -u > $(LOCALIZE_LIST)
 	objcopy --localize-symbols=$(LOCALIZE_LIST) $(COMBINED_OBJ)
 	rm -f $@
-	ar Drcs $@ $(COMBINED_OBJ)
+	ar rcs $@ $(COMBINED_OBJ)
 else
 $(LIB_FILE): $(ALL_OBJS) | $(LIB_DIR)
-	ar Drcs $@ $(ALL_OBJS)
+	ar rcs $@ $(ALL_OBJS)
 endif
 
 # Test binary: link the raw objects (not the symbol-trimmed archive) so the

--- a/lib-c/c/Makefile
+++ b/lib-c/c/Makefile
@@ -144,6 +144,9 @@ $(LIB_DIR):
 #
 # Elsewhere (macOS, where build.rs skips the C build entirely) just archive the
 # objects directly, avoiding the GNU-binutils-specific `ld -r`/`objcopy` step.
+#
+# `ar D` = deterministic archive (zeroed mtimes): unchanged source -> identical
+# bytes, so the rom-setup asm cache key (which hashes libziskc.a) is stable.
 ifeq ($(UNAME_S),Linux)
 $(LIB_FILE): $(ALL_OBJS) | $(LIB_DIR)
 	ld -r -z noexecstack -o $(COMBINED_OBJ) $(ALL_OBJS)
@@ -151,10 +154,10 @@ $(LIB_FILE): $(ALL_OBJS) | $(LIB_DIR)
 		| sort -u > $(LOCALIZE_LIST)
 	objcopy --localize-symbols=$(LOCALIZE_LIST) $(COMBINED_OBJ)
 	rm -f $@
-	ar rcs $@ $(COMBINED_OBJ)
+	ar Drcs $@ $(COMBINED_OBJ)
 else
 $(LIB_FILE): $(ALL_OBJS) | $(LIB_DIR)
-	ar rcs $@ $(ALL_OBJS)
+	ar Drcs $@ $(ALL_OBJS)
 endif
 
 # Test binary: link the raw objects (not the symbol-trimmed archive) so the

--- a/prover-backend/src/utils.rs
+++ b/prover-backend/src/utils.rs
@@ -29,9 +29,8 @@ pub fn get_rom_bin_path<F: PrimeField64>(
 pub fn get_asm_paths(elf: &GuestProgram, with_hints: bool) -> Result<(String, String)> {
     let name = elf.name();
     let hash = get_elf_data_hash(elf.elf());
-    let prefix = if name != hash { format!("{name}-{hash}") } else { hash };
-    let base = if with_hints { format!("{prefix}-hints") } else { prefix };
 
+    let base = rom_setup::compute_asm_basename(name, &hash, with_hints);
     Ok((format!("{base}-mt.bin"), format!("{base}-rh.bin")))
 }
 

--- a/rom-setup/Cargo.toml
+++ b/rom-setup/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 
 [build-dependencies]
 blake3 = { workspace = true }
+lib-float = { workspace = true }
 
 [dependencies]
 sm-rom = { workspace = true }

--- a/rom-setup/Cargo.toml
+++ b/rom-setup/Cargo.toml
@@ -6,6 +6,10 @@ license = { workspace = true }
 keywords = { workspace = true }
 repository = { workspace = true }
 categories = { workspace = true }
+build = "build.rs"
+
+[build-dependencies]
+blake3 = { workspace = true }
 
 [dependencies]
 sm-rom = { workspace = true }

--- a/rom-setup/build.rs
+++ b/rom-setup/build.rs
@@ -41,11 +41,15 @@ fn main() {
 
     // The asm binaries additionally link two libs; hashing their *source* (not
     // the compiled archives) keeps the key a pure build-time constant, so the
-    // path a consumer computes always matches what the producer generates.
+    // path a consumer computes always matches what the producer generates. The
+    // libs' build *config* (ziskclib's manifest, lib-c's Makefile) is folded in
+    // too, since it changes the produced libs without touching their src/.
     let mut asm_files = collect_files(&emu_src, &[]);
     asm_files.push(ws.join("emulator-asm/Makefile"));
     asm_files.extend(collect_files(&ws.join("ziskclib/src"), &[])); // -> libziskclib.a
+    asm_files.push(ws.join("ziskclib/Cargo.toml"));
     asm_files.extend(collect_files(&ws.join("lib-c/c/src"), &[])); // -> libziskc.a
+    asm_files.push(ws.join("lib-c/c/Makefile"));
     let mut seeded = blake3::Hasher::new();
     seeded.update(rom_hash.as_bytes());
     seeded.update(&[0xffu8]);
@@ -64,10 +68,10 @@ fn hash_files(mut hasher: blake3::Hasher, ws: &Path, mut files: Vec<PathBuf>) ->
         let rel = f.strip_prefix(ws).unwrap_or(f);
         hasher.update(rel.to_string_lossy().as_bytes());
         hasher.update(&[0u8]);
-        if let Ok(bytes) = std::fs::read(f) {
-            hasher.update(&(bytes.len() as u64).to_le_bytes());
-            hasher.update(&bytes);
-        }
+        let bytes = std::fs::read(f)
+            .unwrap_or_else(|e| panic!("rom-setup build.rs: cannot read {}: {e}", f.display()));
+        hasher.update(&(bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
         hasher.update(&[0xffu8]);
     }
     hasher.finalize().to_hex().as_str()[..12].to_string()

--- a/rom-setup/build.rs
+++ b/rom-setup/build.rs
@@ -1,0 +1,90 @@
+//! Bakes two fingerprints of the *source* inputs behind the on-disk caches, so
+//! a change forces regeneration (the caches are keyed by filename, and none of
+//! these inputs has a runtime-hashable compiled artifact).
+//!
+//! `ZISK_ROM_INPUTS_HASH` covers the transpiler (`zisk-core`) plus the float ELF
+//! `elf2rom` embeds, and keys the ROM/verkey cache (`utils.rs`).
+//! `ZISK_ASM_INPUTS_HASH` covers the ROM inputs plus `emulator-asm/src`, and
+//! keys the asm-binary cache (`asm_setup.rs`) alongside the linked libs hashed
+//! at runtime.
+//!
+//! The ROM inputs are a subset of the asm inputs; keeping them separate avoids
+//! regenerating the expensive ROM/verkey on an `emulator-asm`-only change.
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // rom-setup lives at <workspace>/rom-setup.
+    let ws = manifest.parent().expect("rom-setup has a parent dir");
+
+    let core_src = ws.join("core/src");
+    let emu_src = ws.join("emulator-asm/src");
+
+    // We `rerun-if-changed` each existing file below, not the dirs (cargo's
+    // directory watch doesn't reliably fire on file *adds*). That's sufficient:
+    // a new source file only affects the output once it's referenced — a `mod`
+    // in `lib.rs`, an entry in `emulator-asm/Makefile`, or an `.asm`/`.inc`
+    // include — and editing that referencing file (which IS watched) triggers
+    // the rerun that picks the new file up.
+
+    // Deny-list (fail-safe): `zisk-core` files that don't affect the transpiled
+    // ROM — the Rust-emulator runtime and CLI binaries. Anything else is hashed
+    // by default, so a new transpiler module is covered automatically.
+    let rom_excluded =
+        [ws.join("core/src/bin"), core_src.join("inst_context.rs"), core_src.join("mem.rs")];
+    let mut rom_files = collect_files(&core_src, &rom_excluded);
+    rom_files.push(ws.join("lib-float/c/lib/ziskfloat.elf")); // embedded into the ROM
+    let rom_hash = hash_files(blake3::Hasher::new(), ws, rom_files);
+
+    let mut asm_files = collect_files(&emu_src, &[]);
+    asm_files.push(ws.join("emulator-asm/Makefile"));
+    let mut seeded = blake3::Hasher::new();
+    seeded.update(rom_hash.as_bytes());
+    seeded.update(&[0xffu8]);
+    let asm_hash = hash_files(seeded, ws, asm_files);
+
+    println!("cargo:rustc-env=ZISK_ROM_INPUTS_HASH={rom_hash}");
+    println!("cargo:rustc-env=ZISK_ASM_INPUTS_HASH={asm_hash}");
+}
+
+/// Fold a list of files (workspace-relative path + content) into `hasher` and
+/// return a 12-hex digest, emitting `rerun-if-changed` for each.
+fn hash_files(mut hasher: blake3::Hasher, ws: &Path, mut files: Vec<PathBuf>) -> String {
+    files.sort(); // deterministic, independent of readdir order
+    for f in &files {
+        println!("cargo:rerun-if-changed={}", f.display());
+        let rel = f.strip_prefix(ws).unwrap_or(f);
+        hasher.update(rel.to_string_lossy().as_bytes());
+        hasher.update(&[0u8]);
+        if let Ok(bytes) = std::fs::read(f) {
+            hasher.update(&(bytes.len() as u64).to_le_bytes());
+            hasher.update(&bytes);
+        }
+        hasher.update(&[0xffu8]);
+    }
+    hasher.finalize().to_hex().as_str()[..12].to_string()
+}
+
+/// Recursively collect files under `dir` (no-op if absent), skipping anything
+/// matched by `excluded` (an exact path or an ancestor dir).
+fn collect_files(dir: &Path, excluded: &[PathBuf]) -> Vec<PathBuf> {
+    let is_excluded = |p: &Path| excluded.iter().any(|e| p == e || p.starts_with(e));
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&d) else { continue };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if is_excluded(&path) {
+                continue;
+            }
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out
+}

--- a/rom-setup/build.rs
+++ b/rom-setup/build.rs
@@ -4,12 +4,14 @@
 //!
 //! `ZISK_ROM_INPUTS_HASH` covers the transpiler (`zisk-core`) plus the float ELF
 //! `elf2rom` embeds, and keys the ROM/verkey cache (`utils.rs`).
-//! `ZISK_ASM_INPUTS_HASH` covers the ROM inputs plus `emulator-asm/src`, and
-//! keys the asm-binary cache (`asm_setup.rs`) alongside the linked libs hashed
-//! at runtime.
+//! `ZISK_ASM_INPUTS_HASH` covers the ROM inputs plus the asm build:
+//! `emulator-asm/src` and the *source* of the linked libs (`ziskclib/src`,
+//! `lib-c/c/src`). It keys the asm-binary cache (`asm_setup.rs`). Hashing lib
+//! source rather than the compiled archives keeps the key a build-time constant,
+//! so the path a consumer computes always matches what the producer generates.
 //!
 //! The ROM inputs are a subset of the asm inputs; keeping them separate avoids
-//! regenerating the expensive ROM/verkey on an `emulator-asm`-only change.
+//! regenerating the expensive ROM/verkey on an asm-only change.
 
 use std::path::{Path, PathBuf};
 
@@ -37,8 +39,13 @@ fn main() {
     rom_files.push(ws.join("lib-float/c/lib/ziskfloat.elf")); // embedded into the ROM
     let rom_hash = hash_files(blake3::Hasher::new(), ws, rom_files);
 
+    // The asm binaries additionally link two libs; hashing their *source* (not
+    // the compiled archives) keeps the key a pure build-time constant, so the
+    // path a consumer computes always matches what the producer generates.
     let mut asm_files = collect_files(&emu_src, &[]);
     asm_files.push(ws.join("emulator-asm/Makefile"));
+    asm_files.extend(collect_files(&ws.join("ziskclib/src"), &[])); // -> libziskclib.a
+    asm_files.extend(collect_files(&ws.join("lib-c/c/src"), &[])); // -> libziskc.a
     let mut seeded = blake3::Hasher::new();
     seeded.update(rom_hash.as_bytes());
     seeded.update(&[0xffu8]);

--- a/rom-setup/examples/cache_probe.rs
+++ b/rom-setup/examples/cache_probe.rs
@@ -1,0 +1,18 @@
+//! Throwaway probe: prints the asm-binary cache base name for a fixed guest ELF
+//! identity, so a wrapper script can mutate an input (lib / float / transpiler)
+//! and observe whether the cache filename changes.
+//!
+//! `get_assembly_file_paths_from_id` is `pub` on both the base branch and the
+//! fix branch, so the same probe runs on either — the point is that on base the
+//! name is invariant to lib/float/transpiler changes (the bug), and on the fix
+//! branch it changes (the fix).
+
+fn main() {
+    let [mt, _rh, _mo] = rom_setup::get_assembly_file_paths_from_id(
+        "probe",
+        "deadbeefcafef00d",
+        std::path::Path::new("/tmp"),
+        false,
+    );
+    println!("{}", mt.file_name().unwrap().to_string_lossy());
+}

--- a/rom-setup/src/asm_setup.rs
+++ b/rom-setup/src/asm_setup.rs
@@ -143,13 +143,75 @@ pub fn ensure_ziskclib(emu_dir: &Path, source: EmulatorAsmSource) -> Result<()> 
     Ok(())
 }
 
-fn asm_file_base(name: &str, hash: &str, hints: bool) -> String {
+fn asm_file_base(name: &str, hash: &str, hints: bool, deps_hash: &str) -> String {
     let prefix = if name != hash { format!("{name}-{hash}") } else { hash.to_string() };
+    let prefix = if deps_hash.is_empty() { prefix } else { format!("{prefix}-d{deps_hash}") };
     if hints {
         format!("{prefix}-hints")
     } else {
         prefix
     }
+}
+
+/// The C libs the asm emulator links (`-lziskc`, `-lziskclib`), at the paths
+/// `emulator-asm/Makefile` finds them. Empty in installed mode (no `target/`).
+fn resolve_link_inputs(emulator_asm_path: &Path) -> Vec<PathBuf> {
+    let Some(parent) = emulator_asm_path.parent() else { return Vec::new() };
+    let target_dir = parent.join("target");
+    if !target_dir.exists() {
+        return Vec::new();
+    }
+    vec![
+        parent.join("lib-c").join("c").join("lib").join("libziskc.a"),
+        target_dir.join("release").join("libziskclib.a"),
+    ]
+}
+
+/// Hash of the asm build inputs (transpiler + float ELF + `emulator-asm/src`),
+/// baked by `build.rs`. See [`compute_asm_basename`].
+const ASM_INPUTS_HASH: &str = env!("ZISK_ASM_INPUTS_HASH");
+
+fn compute_deps_hash(emulator_asm_path: &Path) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(ASM_INPUTS_HASH.as_bytes());
+    hasher.update(&[0xffu8]);
+    for path in resolve_link_inputs(emulator_asm_path) {
+        // basename || 0x00 || len || bytes || 0xff — so identical bytes in
+        // different roles can't collide and a missing lib hashes distinctly.
+        let name = path.file_name().map(|n| n.to_string_lossy()).unwrap_or_default();
+        hasher.update(name.as_bytes());
+        hasher.update(&[0u8]);
+        match std::fs::read(&path) {
+            Ok(bytes) => {
+                hasher.update(&(bytes.len() as u64).to_le_bytes());
+                hasher.update(&bytes);
+            }
+            Err(_) => {
+                hasher.update(b"<missing>");
+            }
+        }
+        hasher.update(&[0xffu8]);
+    }
+    hasher.finalize().to_hex().as_str()[..12].to_string()
+}
+
+/// Canonical cache base name for the asm binaries (`<base>-{mt,rh,mo}.bin`).
+///
+/// The cache is keyed by filename alone, so the name must change whenever the
+/// binaries would. Besides the guest ELF (`elf_hash`) that means: the linked C
+/// libs (hashed at runtime), and the transpiler + embedded float ELF +
+/// `emulator-asm` sources (hashed at build time via [`ASM_INPUTS_HASH`]).
+/// Without this, rebuilding a lib or the transpiler left the old name in place
+/// and stale binaries were reused. Relies on `lib-c`'s `ar D` so an unchanged
+/// lib doesn't flip the hash.
+///
+/// Every producer and consumer MUST go through here so they agree on the key.
+pub fn compute_asm_basename(elf_name: &str, elf_hash: &str, hints: bool) -> String {
+    let deps_hash = match resolve_emulator_asm() {
+        Ok((p, _)) => compute_deps_hash(&p),
+        Err(_) => String::new(),
+    };
+    asm_file_base(elf_name, elf_hash, hints, &deps_hash)
 }
 
 /// Get the paths to all assembly binary files for a given ELF and output path
@@ -175,7 +237,7 @@ pub fn get_assembly_file_paths_from_id(
     output_path: &Path,
     hints: bool,
 ) -> [PathBuf; 3] {
-    let base = asm_file_base(elf_name, elf_hash, hints);
+    let base = compute_asm_basename(elf_name, elf_hash, hints);
     [
         output_path.join(format!("{base}-mt.bin")),
         output_path.join(format!("{base}-rh.bin")),
@@ -226,14 +288,16 @@ pub fn generate_assembly(
         anyhow::bail!("ROM file is not a valid ELF file");
     }
 
-    let base = asm_file_base(elf_name, &elf_hash, hints);
+    let (emulator_asm_path, asm_source) = resolve_emulator_asm()?;
+    ensure_ziskclib(&emulator_asm_path, asm_source)?;
 
+    // Compute the cache base *after* `ensure_ziskclib` so the libs exist and the
+    // deps_hash reflects their freshly-built contents.
+    let deps_hash = compute_deps_hash(&emulator_asm_path);
+    let base = asm_file_base(elf_name, &elf_hash, hints, &deps_hash);
     let bin_mt_file = output_path.join(format!("{base}-mt.bin"));
     let bin_rh_file = output_path.join(format!("{base}-rh.bin"));
     let bin_mo_file = output_path.join(format!("{base}-mo.bin"));
-
-    let (emulator_asm_path, asm_source) = resolve_emulator_asm()?;
-    ensure_ziskclib(&emulator_asm_path, asm_source)?;
 
     let emulator_asm_path =
         emulator_asm_path.to_str().context("Failed to convert emulator-asm path to string")?;
@@ -283,4 +347,36 @@ pub fn generate_assembly(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::asm_file_base;
+
+    // The core invariant of the cache-invalidation fix: the base name embeds
+    // `deps_hash`, so a change in the linked libs / transpiler / float (which
+    // all flow into `deps_hash`) yields a *different* filename and forces
+    // regeneration — while identical inputs reproduce the identical name.
+    #[test]
+    fn deps_hash_changes_the_name() {
+        let a = asm_file_base("prog", "elfhash", false, "aaaaaaaaaaaa");
+        let b = asm_file_base("prog", "elfhash", false, "bbbbbbbbbbbb");
+        assert_ne!(a, b, "different deps_hash must produce different cache names");
+        assert!(a.contains("-daaaaaaaaaaaa"), "name must carry the -d<deps_hash> segment: {a}");
+    }
+
+    #[test]
+    fn same_inputs_same_name() {
+        let a = asm_file_base("prog", "elfhash", true, "aaaaaaaaaaaa");
+        let b = asm_file_base("prog", "elfhash", true, "aaaaaaaaaaaa");
+        assert_eq!(a, b, "identical inputs must be cache-stable");
+    }
+
+    // Empty deps_hash (toolchain unresolved) reproduces the legacy elf-only name
+    // exactly, so pre-existing caches in that mode stay valid.
+    #[test]
+    fn empty_deps_hash_is_legacy_name() {
+        assert_eq!(asm_file_base("prog", "elfhash", false, ""), "prog-elfhash");
+        assert_eq!(asm_file_base("prog", "elfhash", true, ""), "prog-elfhash-hints");
+    }
 }

--- a/rom-setup/src/asm_setup.rs
+++ b/rom-setup/src/asm_setup.rs
@@ -153,65 +153,23 @@ fn asm_file_base(name: &str, hash: &str, hints: bool, deps_hash: &str) -> String
     }
 }
 
-/// The C libs the asm emulator links (`-lziskc`, `-lziskclib`), at the paths
-/// `emulator-asm/Makefile` finds them. Empty in installed mode (no `target/`).
-fn resolve_link_inputs(emulator_asm_path: &Path) -> Vec<PathBuf> {
-    let Some(parent) = emulator_asm_path.parent() else { return Vec::new() };
-    let target_dir = parent.join("target");
-    if !target_dir.exists() {
-        return Vec::new();
-    }
-    vec![
-        parent.join("lib-c").join("c").join("lib").join("libziskc.a"),
-        target_dir.join("release").join("libziskclib.a"),
-    ]
-}
-
-/// Hash of the asm build inputs (transpiler + float ELF + `emulator-asm/src`),
-/// baked by `build.rs`. See [`compute_asm_basename`].
+/// Build-time hash of everything (besides the guest ELF) that determines the asm
+/// binaries: the transpiler, embedded float ELF, `emulator-asm/src`, and the
+/// *source* of the linked libs (`ziskclib`, `lib-c`). Baked by `build.rs`.
 const ASM_INPUTS_HASH: &str = env!("ZISK_ASM_INPUTS_HASH");
-
-fn compute_deps_hash(emulator_asm_path: &Path) -> String {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(ASM_INPUTS_HASH.as_bytes());
-    hasher.update(&[0xffu8]);
-    for path in resolve_link_inputs(emulator_asm_path) {
-        // basename || 0x00 || len || bytes || 0xff — so identical bytes in
-        // different roles can't collide and a missing lib hashes distinctly.
-        let name = path.file_name().map(|n| n.to_string_lossy()).unwrap_or_default();
-        hasher.update(name.as_bytes());
-        hasher.update(&[0u8]);
-        match std::fs::read(&path) {
-            Ok(bytes) => {
-                hasher.update(&(bytes.len() as u64).to_le_bytes());
-                hasher.update(&bytes);
-            }
-            Err(_) => {
-                hasher.update(b"<missing>");
-            }
-        }
-        hasher.update(&[0xffu8]);
-    }
-    hasher.finalize().to_hex().as_str()[..12].to_string()
-}
 
 /// Canonical cache base name for the asm binaries (`<base>-{mt,rh,mo}.bin`).
 ///
 /// The cache is keyed by filename alone, so the name must change whenever the
-/// binaries would. Besides the guest ELF (`elf_hash`) that means: the linked C
-/// libs (hashed at runtime), and the transpiler + embedded float ELF +
-/// `emulator-asm` sources (hashed at build time via [`ASM_INPUTS_HASH`]).
-/// Without this, rebuilding a lib or the transpiler left the old name in place
-/// and stale binaries were reused. Relies on `lib-c`'s `ar D` so an unchanged
-/// lib doesn't flip the hash.
+/// binaries would — i.e. whenever the guest ELF or any input in
+/// [`ASM_INPUTS_HASH`] changes. Without this, rebuilding a lib or the transpiler
+/// left the old name in place and stale binaries were reused.
 ///
-/// Every producer and consumer MUST go through here so they agree on the key.
+/// `ASM_INPUTS_HASH` is a compile-time constant, so every producer and consumer
+/// derives the identical key — a consumer never computes a path the producer
+/// won't generate. Every caller MUST route through here.
 pub fn compute_asm_basename(elf_name: &str, elf_hash: &str, hints: bool) -> String {
-    let deps_hash = match resolve_emulator_asm() {
-        Ok((p, _)) => compute_deps_hash(&p),
-        Err(_) => String::new(),
-    };
-    asm_file_base(elf_name, elf_hash, hints, &deps_hash)
+    asm_file_base(elf_name, elf_hash, hints, ASM_INPUTS_HASH)
 }
 
 /// Get the paths to all assembly binary files for a given ELF and output path
@@ -291,10 +249,9 @@ pub fn generate_assembly(
     let (emulator_asm_path, asm_source) = resolve_emulator_asm()?;
     ensure_ziskclib(&emulator_asm_path, asm_source)?;
 
-    // Compute the cache base *after* `ensure_ziskclib` so the libs exist and the
-    // deps_hash reflects their freshly-built contents.
-    let deps_hash = compute_deps_hash(&emulator_asm_path);
-    let base = asm_file_base(elf_name, &elf_hash, hints, &deps_hash);
+    // Same canonical key the consumers use, so the files we write are exactly
+    // the ones they look for.
+    let base = compute_asm_basename(elf_name, &elf_hash, hints);
     let bin_mt_file = output_path.join(format!("{base}-mt.bin"));
     let bin_rh_file = output_path.join(format!("{base}-rh.bin"));
     let bin_mo_file = output_path.join(format!("{base}-mo.bin"));

--- a/rom-setup/src/utils.rs
+++ b/rom-setup/src/utils.rs
@@ -75,6 +75,12 @@ pub fn get_elf_data_hash(elf: &[u8]) -> String {
     blake3::hash(elf).to_hex().to_string()
 }
 
+/// Hash of the ROM inputs (transpiler + embedded float ELF), baked by
+/// `build.rs`. Folded into the ROM/verkey filenames so a transpiler or float
+/// change invalidates them — otherwise a warm cache returns a verkey stale
+/// w.r.t. the current `zisk-core`, i.e. the wrong program vk.
+const ROM_INPUTS_HASH: &str = env!("ZISK_ROM_INPUTS_HASH");
+
 pub fn get_elf_bin_file_path_with_hash(
     hash: &str,
     default_cache_path: &Path,
@@ -86,8 +92,9 @@ pub fn get_elf_bin_file_path_with_hash(
 
     let gpu_suffix = if gpu { "_gpu" } else { "" };
     let rom_cache_file_name = format!(
-        "{}_{}_{}_{}_{}{}.bin",
+        "{}-d{}_{}_{}_{}_{}{}.bin",
         hash,
+        ROM_INPUTS_HASH,
         pilout_hash,
         &n.to_string(),
         &ROM_BLOWUP_FACTOR.to_string(),
@@ -107,8 +114,9 @@ pub fn get_elf_bin_verkey_file_path_with_hash(
     let n = RomRomTrace::<Goldilocks>::NUM_ROWS;
 
     let rom_cache_file_name = format!(
-        "{}_{}_{}_{}_{}.verkey.bin",
+        "{}-d{}_{}_{}_{}_{}.verkey.bin",
         hash,
+        ROM_INPUTS_HASH,
         pilout_hash,
         &n.to_string(),
         &ROM_BLOWUP_FACTOR.to_string(),

--- a/tools/test_asm_cache_invalidation.sh
+++ b/tools/test_asm_cache_invalidation.sh
@@ -1,85 +1,74 @@
 #!/usr/bin/env bash
 # Proves the asm-binary cache key tracks its inputs: mutate each input that the
-# asm binaries depend on, and check that the cache filename `cargo-zisk` would
+# asm binaries depend on and check that the cache filename `cargo-zisk` would
 # compute actually changes (so a stale binary can't be reused).
 #
-#   ./tools/test_asm_cache_invalidation.sh        # local: SKIPs absent inputs
-#   ./tools/test_asm_cache_invalidation.sh --ci    # CI: build libziskc.a; absent = FAIL
+#   ./tools/test_asm_cache_invalidation.sh         # local
+#   ./tools/test_asm_cache_invalidation.sh --ci     # CI: absent input = hard FAIL
 #
 # Exit 0 = every mutation changed the name (the fix works).
 # Exit 1 = some mutation left the name unchanged (input NOT tracked by the key),
 #          or (with --ci) a required input was absent.
 # Running it with the rom-setup cache fix reverted reproduces the original bug
-# (all three report UNCHANGED).
+# (every input reports UNCHANGED).
 #
-# The probe is rom-setup/examples/cache_probe.rs. `cargo run` rebuilds when an
-# input changed, so the build-time hashes (float / transpiler) refresh; the lib
-# hash is read at runtime. Every mutated file is restored on exit.
+# All inputs are hashed at build time (see rom-setup/build.rs), so each mutation
+# needs a rebuild — `cargo run` on the cache_probe example does that. The libs
+# are hashed by *source* (ziskclib/src, lib-c/c/src), not by their compiled
+# archives, so this mutates the sources. Every mutated file is restored on exit.
 set -uo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 CI=0
 [ "${1:-}" = "--ci" ] && CI=1
 
-PROBE='cargo run -q -p rom-setup --example cache_probe'
-LIBZISKC=lib-c/c/lib/libziskc.a
-FLOAT=lib-float/c/lib/ziskfloat.elf
-TRANSPILER=core/src/zisk_rom_2_asm.rs
+# (label, file) pairs — every input that flows into the asm cache key.
+INPUTS=(
+  "transpiler source:core/src/zisk_rom_2_asm.rs"
+  "emulator-asm source:emulator-asm/src/emu.c"
+  "ziskclib source:ziskclib/src/lib.rs"
+  "lib-c source:lib-c/c/src/main.cpp"
+  "embedded float ELF:lib-float/c/lib/ziskfloat.elf"
+)
+
+# Run the probe; abort on a build/run failure so a failed probe can never be
+# misread as an empty-string "CHANGED" result.
+run_probe() {
+  local out
+  if ! out=$(cargo run -q -p rom-setup --example cache_probe); then
+    echo "probe build/run failed" >&2
+    exit 2
+  fi
+  printf '%s' "$out"
+}
 
 pass=0; fail=0
-note() { printf '%-26s before=%s after=%s  ' "$1" "$2" "$3"; }
-expect_change() { if [ "$2" != "$3" ]; then echo "CHANGED ✅"; pass=$((pass+1)); else echo "UNCHANGED ❌"; fail=$((fail+1)); fi; }
-# An absent input is a SKIP locally but a hard FAIL under --ci (so a green CI run
-# means every input was genuinely exercised).
-missing() { if [ "$CI" = 1 ]; then echo "MISSING ❌ ($1)"; fail=$((fail+1)); else echo "SKIP ($1)"; fi; }
-
-# In CI, build the C lib so its mutation step runs instead of skipping. `lib-c`
-# isn't in rom-setup's dep tree, so the probe build alone won't produce it.
-if [ "$CI" = 1 ]; then
-  echo "[--ci] building lib-c to produce libziskc.a ..."
-  cargo build -q -p lib-c || { echo "lib-c build failed"; exit 2; }
-fi
-
-# Snapshot files we mutate so we can restore exactly (binaries can't be git-checkout'd if untracked).
 tmp=$(mktemp -d)
-cp "$LIBZISKC" "$tmp/libziskc.a" 2>/dev/null
-cp "$FLOAT"    "$tmp/ziskfloat.elf" 2>/dev/null
-cp "$TRANSPILER" "$tmp/transpiler.rs"
-restore() {
-  [ -f "$tmp/libziskc.a" ]    && cp "$tmp/libziskc.a" "$LIBZISKC"
-  [ -f "$tmp/ziskfloat.elf" ] && cp "$tmp/ziskfloat.elf" "$FLOAT"
-  cp "$tmp/transpiler.rs" "$TRANSPILER"
-}
-trap 'restore; rm -rf "$tmp"' EXIT
+trap 'rm -rf "$tmp"' EXIT
 
-base=$($PROBE) || { echo "probe build failed"; exit 2; }
+base=$(run_probe)
 echo "baseline name: $base"
 echo
 
-# 1. Linked C lib change (runtime hash; no rebuild needed).
-if [ -f "$LIBZISKC" ]; then
-  printf '\x00probe' >> "$LIBZISKC"
-  after=$($PROBE); restore
-  note "libziskc.a change" "$base" "$after"; expect_change "x" "$base" "$after"
-else
-  printf '%-26s ' "libziskc.a change"; missing "not built; run a workspace build first"
-fi
-
-# 2. Embedded float ELF change (build-time hash; rebuild picks it up).
-if [ -f "$FLOAT" ]; then
-  printf '\x00probe' >> "$FLOAT"
-  after=$($PROBE); restore
-  note "ziskfloat.elf change" "$base" "$after"; expect_change "x" "$base" "$after"
-else
-  printf '%-26s ' "ziskfloat.elf change"; missing "not present"
-fi
-
-# 3. Transpiler source change (build-time hash; rebuild picks it up).
-printf '\n// cache-probe %s\n' "$RANDOM" >> "$TRANSPILER"
-after=$($PROBE); restore
-note "transpiler source change" "$base" "$after"; expect_change "x" "$base" "$after"
+i=0
+for entry in "${INPUTS[@]}"; do
+  label=${entry%%:*}; file=${entry#*:}
+  printf '%-22s ' "$label"
+  if [ ! -f "$file" ]; then
+    if [ "$CI" = 1 ]; then echo "MISSING ❌ ($file)"; fail=$((fail+1)); else echo "SKIP ($file not present)"; fi
+    continue
+  fi
+  # Snapshot, mutate, probe, restore. `//` is a valid comment in Rust/C/C++
+  # (the transpiler .rs is compiled during the probe build, so it must stay
+  # valid) and harmless trailing bytes for the ELF (never parsed by the probe).
+  cp "$file" "$tmp/snap.$i"
+  printf '\n// cache-probe %s\n' "$RANDOM" >> "$file"
+  after=$(run_probe)
+  cp "$tmp/snap.$i" "$file"
+  if [ "$base" != "$after" ]; then echo "CHANGED ✅"; pass=$((pass+1)); else echo "UNCHANGED ❌"; fail=$((fail+1)); fi
+  i=$((i+1))
+done
 
 echo
 echo "PASS (changed): $pass    FAIL (unchanged): $fail"
-# On the fix branch we expect all to change. Exit non-zero if any did NOT.
 [ "$fail" -eq 0 ]

--- a/tools/test_asm_cache_invalidation.sh
+++ b/tools/test_asm_cache_invalidation.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Proves the asm-binary cache key tracks its inputs: mutate each input that the
+# asm binaries depend on, and check that the cache filename `cargo-zisk` would
+# compute actually changes (so a stale binary can't be reused).
+#
+#   ./tools/test_asm_cache_invalidation.sh        # local: SKIPs absent inputs
+#   ./tools/test_asm_cache_invalidation.sh --ci    # CI: build libziskc.a; absent = FAIL
+#
+# Exit 0 = every mutation changed the name (the fix works).
+# Exit 1 = some mutation left the name unchanged (input NOT tracked by the key),
+#          or (with --ci) a required input was absent.
+# Running it with the rom-setup cache fix reverted reproduces the original bug
+# (all three report UNCHANGED).
+#
+# The probe is rom-setup/examples/cache_probe.rs. `cargo run` rebuilds when an
+# input changed, so the build-time hashes (float / transpiler) refresh; the lib
+# hash is read at runtime. Every mutated file is restored on exit.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+CI=0
+[ "${1:-}" = "--ci" ] && CI=1
+
+PROBE='cargo run -q -p rom-setup --example cache_probe'
+LIBZISKC=lib-c/c/lib/libziskc.a
+FLOAT=lib-float/c/lib/ziskfloat.elf
+TRANSPILER=core/src/zisk_rom_2_asm.rs
+
+pass=0; fail=0
+note() { printf '%-26s before=%s after=%s  ' "$1" "$2" "$3"; }
+expect_change() { if [ "$2" != "$3" ]; then echo "CHANGED ✅"; pass=$((pass+1)); else echo "UNCHANGED ❌"; fail=$((fail+1)); fi; }
+# An absent input is a SKIP locally but a hard FAIL under --ci (so a green CI run
+# means every input was genuinely exercised).
+missing() { if [ "$CI" = 1 ]; then echo "MISSING ❌ ($1)"; fail=$((fail+1)); else echo "SKIP ($1)"; fi; }
+
+# In CI, build the C lib so its mutation step runs instead of skipping. `lib-c`
+# isn't in rom-setup's dep tree, so the probe build alone won't produce it.
+if [ "$CI" = 1 ]; then
+  echo "[--ci] building lib-c to produce libziskc.a ..."
+  cargo build -q -p lib-c || { echo "lib-c build failed"; exit 2; }
+fi
+
+# Snapshot files we mutate so we can restore exactly (binaries can't be git-checkout'd if untracked).
+tmp=$(mktemp -d)
+cp "$LIBZISKC" "$tmp/libziskc.a" 2>/dev/null
+cp "$FLOAT"    "$tmp/ziskfloat.elf" 2>/dev/null
+cp "$TRANSPILER" "$tmp/transpiler.rs"
+restore() {
+  [ -f "$tmp/libziskc.a" ]    && cp "$tmp/libziskc.a" "$LIBZISKC"
+  [ -f "$tmp/ziskfloat.elf" ] && cp "$tmp/ziskfloat.elf" "$FLOAT"
+  cp "$tmp/transpiler.rs" "$TRANSPILER"
+}
+trap 'restore; rm -rf "$tmp"' EXIT
+
+base=$($PROBE) || { echo "probe build failed"; exit 2; }
+echo "baseline name: $base"
+echo
+
+# 1. Linked C lib change (runtime hash; no rebuild needed).
+if [ -f "$LIBZISKC" ]; then
+  printf '\x00probe' >> "$LIBZISKC"
+  after=$($PROBE); restore
+  note "libziskc.a change" "$base" "$after"; expect_change "x" "$base" "$after"
+else
+  printf '%-26s ' "libziskc.a change"; missing "not built; run a workspace build first"
+fi
+
+# 2. Embedded float ELF change (build-time hash; rebuild picks it up).
+if [ -f "$FLOAT" ]; then
+  printf '\x00probe' >> "$FLOAT"
+  after=$($PROBE); restore
+  note "ziskfloat.elf change" "$base" "$after"; expect_change "x" "$base" "$after"
+else
+  printf '%-26s ' "ziskfloat.elf change"; missing "not present"
+fi
+
+# 3. Transpiler source change (build-time hash; rebuild picks it up).
+printf '\n// cache-probe %s\n' "$RANDOM" >> "$TRANSPILER"
+after=$($PROBE); restore
+note "transpiler source change" "$base" "$after"; expect_change "x" "$base" "$after"
+
+echo
+echo "PASS (changed): $pass    FAIL (unchanged): $fail"
+# On the fix branch we expect all to change. Exit non-zero if any did NOT.
+[ "$fail" -eq 0 ]

--- a/tools/test_asm_cache_invalidation.sh
+++ b/tools/test_asm_cache_invalidation.sh
@@ -44,7 +44,9 @@ run_probe() {
 
 pass=0; fail=0
 tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
+CUR_FILE=""; CUR_SNAP=""
+cleanup() { [ -n "$CUR_FILE" ] && cp "$CUR_SNAP" "$CUR_FILE"; rm -rf "$tmp"; }
+trap cleanup EXIT INT TERM
 
 base=$(run_probe)
 echo "baseline name: $base"
@@ -62,9 +64,11 @@ for entry in "${INPUTS[@]}"; do
   # (the transpiler .rs is compiled during the probe build, so it must stay
   # valid) and harmless trailing bytes for the ELF (never parsed by the probe).
   cp "$file" "$tmp/snap.$i"
+  CUR_FILE="$file"; CUR_SNAP="$tmp/snap.$i"   # arm restore-on-exit
   printf '\n// cache-probe %s\n' "$RANDOM" >> "$file"
   after=$(run_probe)
   cp "$tmp/snap.$i" "$file"
+  CUR_FILE=""; CUR_SNAP=""                    # disarm: file restored
   if [ "$base" != "$after" ]; then echo "CHANGED ✅"; pass=$((pass+1)); else echo "UNCHANGED ❌"; fail=$((fail+1)); fi
   i=$((i+1))
 done


### PR DESCRIPTION
The asm binaries and ROM/verkey were cached by guest-ELF hash alone, so a change to the transpiler, the embedded float ELF, or the linked C libs reused stale artifacts — including returning the wrong program vk.

Fold a fingerprint of those inputs into the cache filenames: build.rs bakes build-time hashes of the transpiler + float (ROM) and + emulator-asm sources (asm); asm_setup.rs adds the runtime lib contents; utils.rs keys the ROM/verkey on them. lib-c uses  so the hash is stable.

Adds unit tests, a before/after script, and a CI workflow.