### PR TITLE
Add offsets calculation feature on asm_CPU path

### DIFF
--- a/pil/src/pil_helpers/traces.rs
+++ b/pil/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "98453fa9f1a3d4283c60a23c833edc2cd2d85942d3f9df3d6f380d9009541e57";
+pub const PILOUT_HASH: &str = "90f192830a27a7de99355d2fed5be72e961230e5a524f0fda8a48afdeabaacf2";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 

--- a/state-machines/mem-common/src/mem_module_segment_check_point.rs
+++ b/state-machines/mem-common/src/mem_module_segment_check_point.rs
@@ -1,4 +1,9 @@
 use std::collections::HashMap;
+#[cfg(feature = "debug_mem")]
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+};
 
 use crate::MemModuleCheckPoint;
 use zisk_common::ChunkId;
@@ -242,6 +247,28 @@ impl MemModuleSegmentCheckPoint {
             page -= 1;
             upper = MEM_OFFSETS_PAGE_SIZE as usize;
         }
+    }
+
+    #[cfg(feature = "debug_mem")]
+    pub fn save_offsets_to_file(&self, file_name: &str) {
+        println!("[MemDebug] saving offsets to {} .....", file_name);
+        let file = File::create(file_name).unwrap();
+        let mut writer = BufWriter::new(file);
+        let base = self.offsets_base_addr as u64;
+        let mut prev_value = u32::MAX;
+        for index in 0..self.addr_range_slots {
+            let value = self.offset_at(index);
+            if value != prev_value {
+                let addr = index as u64 * 8 + base;
+                if value == 0 {
+                    writeln!(writer, "{:#010X} PREV_SEGMENT", addr).unwrap();
+                } else {
+                    writeln!(writer, "{:#010X} {}", addr, value - 1).unwrap();
+                }
+                prev_value = value;
+            }
+        }
+        println!("[MemDebug] done");
     }
 
     pub fn to_string(&self, segment_id: usize) -> String {

--- a/state-machines/mem-cpp/cpp/Makefile
+++ b/state-machines/mem-cpp/cpp/Makefile
@@ -10,7 +10,7 @@ TARGET := libmemcpp.a
 
 SRCS := tools.cpp api.cpp mem_count_and_plan.cpp immutable_mem_planner.cpp \
 		mem_align_counter.cpp mem_check_point.cpp mem_context.cpp mem_counter.cpp \
-		mem_locators.cpp mem_segment_hash_table.cpp mem_planner.cpp
+		mem_locators.cpp mem_segment_hash_table.cpp mem_planner.cpp mem_offsets.cpp
 
 OBJS := $(addprefix $(OUT_DIR)/, $(SRCS:.cpp=.o))
 

--- a/state-machines/mem-cpp/cpp/immutable_mem_planner.cpp
+++ b/state-machines/mem-cpp/cpp/immutable_mem_planner.cpp
@@ -305,8 +305,6 @@ void ImmutableMemPlanner::consume_intermediate_rows(uint32_t row_count) {
     #endif
     if (rows_available == 0) {
         open_segment();
-        mem_offsets->reset();
-
     }
     // add_chunk_to_segment(current_chunk, addr, rows, skip);
     rows_available -= row_count;

--- a/state-machines/mem-cpp/cpp/immutable_mem_planner.cpp
+++ b/state-machines/mem-cpp/cpp/immutable_mem_planner.cpp
@@ -1,8 +1,11 @@
 #include "immutable_mem_planner.hpp"
+#include <vector>
 
 ImmutableMemPlanner::ImmutableMemPlanner(uint32_t rows, uint32_t from_addr, uint32_t mb_size, bool intermediate_rows):
     rows_by_segment(rows),
-    intermediate_rows(intermediate_rows) {
+    intermediate_rows(intermediate_rows),
+    last_addr(0) {
+
     #ifndef MEM_CHECK_POINT_MAP
     hash_table = new MemSegmentHashTable(MAX_CHUNKS);   // 2^18 * 2^18 = 2^36   // 2^14 * 2^18 = 2^32
     #endif
@@ -26,6 +29,7 @@ ImmutableMemPlanner::ImmutableMemPlanner(uint32_t rows, uint32_t from_addr, uint
         msg << "MemPlanner::constructor: from_addr " << std::hex << from_addr << " not aligned to page " << std::dec << from_page;
         throw std::runtime_error(msg.str());
     }
+    segments_pages.reserve(512);
     initial_last_addr = MemCounter::page_to_addr(from_page);
     #ifndef MEM_CHECK_POINT_MAP
     chunk_table = (uint32_t *)malloc(MAX_CHUNKS * sizeof(uint32_t));
@@ -37,6 +41,11 @@ ImmutableMemPlanner::ImmutableMemPlanner(uint32_t rows, uint32_t from_addr, uint
     tot_chunks = 0;
     large_segments = 0;
     #endif
+    
+    // Initialize offset tracking with id=0 for immutable planner
+    this->mb_size = mb_size;
+    mem_offsets = new MemOffsets(from_page);
+    mem_offsets->enable_debug(); // Enable debug for mem_offsets to track intermediate addresses    
 }
 
 ImmutableMemPlanner::~ImmutableMemPlanner() {
@@ -45,11 +54,132 @@ ImmutableMemPlanner::~ImmutableMemPlanner() {
     delete hash_table;
     free(chunk_table);
     #endif
+    delete mem_offsets;
 }
+
+// Calculate memory requirements for offset pages across all segments
+// This function estimates the number of pages needed by identifying collapsible pages
+// (pages with only one offset value), allowing us to:
+// - Accurately predict memory consumption before allocation
+// - Avoid running into memory limits during execution
+// - Optimize storage by collapsing empty or single-value pages
+void ImmutableMemPlanner::calculate_pages(const std::vector<MemCounter *> &workers) {
+    uint32_t rows_available = rows_by_segment;
+    uint32_t last_addr_with_data = 0;
+    uint32_t segment_first_addr = 0;
+    uint32_t offset, last_offset;
+    uint32_t collapsible_pages = 0;
+
+    uint32_t count = 0;
+    for (uint32_t page = from_page; page <= to_page; ++page) {
+        get_offset_limits(workers, page, offset, last_offset);
+        for (; offset <= last_offset; ++offset) {
+            for (uint32_t thread_index = 0; thread_index < MAX_THREADS; ++thread_index) {
+                uint32_t real_count = workers[thread_index]->get_count_table(offset);
+                if (real_count == 0) continue;
+                
+                uint32_t real_addr = MemCounter::offset_to_addr(offset, thread_index);
+                
+                // Process the real address and any intermediate addresses that precede it.
+                // When intermediate_rows is enabled and the gap to the previous address exceeds
+                // MAX_IMMUTABLE_ADDR_DISTANCE, we inject intermediate addresses (count=1 each)
+                // to fill the gap, advancing MAX_IMMUTABLE_ADDR_DISTANCE at a time until we
+                // reach real_addr. Intermediates are treated as regular addresses for row/segment
+                // accounting purposes. The first address never generates intermediates
+                // (last_addr_with_data == 0).
+                uint32_t addr = 0;
+                while (addr < real_addr) {
+                    if (intermediate_rows && last_addr_with_data != 0 && (real_addr - last_addr_with_data) > MAX_IMMUTABLE_ADDR_DISTANCE) {
+                        // Inject an intermediate address at MAX_IMMUTABLE_ADDR_DISTANCE from last data
+                        addr = last_addr_with_data + MAX_IMMUTABLE_ADDR_DISTANCE;
+                        count = 1;
+                    } else {
+                        // No intermediates needed: process the real address with its full count
+                        addr = real_addr;
+                        count = real_count;
+                    }
+
+                    // Process 'addr' (intermediate or real), handling segment boundaries:
+                    // a single address with count > rows_available may span multiple segments.
+                    while (count > 0) {
+                        if (rows_available == 0) {
+                            // Current segment is full: store its page/collapsible info and open a new one
+                            if (segment_first_addr != 0) {
+                                // Round up to nearest page
+                                // + 8/8 - 1 = 0
+                                uint32_t pages = (((last_addr_with_data - segment_first_addr + 1) / 8) + OFFSET_PAGE_SIZE) / OFFSET_PAGE_SIZE; 
+                                segments_pages.push_back(std::make_pair(pages, collapsible_pages));
+                                collapsible_pages = 0;
+                            }
+                            rows_available = rows_by_segment;
+                            segment_first_addr = 0; // Will be set on first addr of new segment
+                            last_addr_with_data = 0; // Reset: collapsible pages must not span segment boundaries
+                        }
+                        
+                        // Record the first address of the current segment
+                        if (segment_first_addr == 0) {                        
+                            segment_first_addr = addr;
+                        }
+                        
+                        // Calculate collapsible pages between last_addr_with_data and addr.
+                        // A page is collapsible if it contains only one offset value:
+                        // either it is fully within the gap (all slots filled with offset_value),
+                        // or its last slot is 'addr' and all preceding slots are in the gap
+                        // (all slots also have offset_value since it only increments after adding).
+                        // Page p is collapsible iff: p >= last_data_page+1 AND p <= page_next_addr-1
+                        // => collapsible count = page_next_addr - last_data_page - 1
+                        if (last_addr_with_data != 0 && addr > (last_addr_with_data + 8)) {
+                            // Distance in number of addresses (each address is 8 bytes apart)
+                            uint32_t distance = (addr - last_addr_with_data) / 8;
+                            
+                            // Only relevant if the gap spans at least one full page
+                            if ((distance + 1) >= OFFSET_PAGE_SIZE) {
+                                // Index of last_addr_with_data within the segment
+                                uint32_t index = (last_addr_with_data - segment_first_addr) / 8;
+                                
+                                // Page containing last_addr_with_data
+                                uint32_t last_data_page = index / OFFSET_PAGE_SIZE;
+                                
+                                // Page of the slot immediately after addr
+                                // (equals addr's page + 1 when addr is the last slot of its page)
+                                uint32_t page_next_addr = (index + distance + 1) / OFFSET_PAGE_SIZE;
+                                
+                                // Collapsible pages are those entirely within [last_data_page+1, page_next_addr-1]
+                                if (page_next_addr > last_data_page + 1) {
+                                    uint32_t new_collapsible = page_next_addr - last_data_page - 1;
+                                    uint32_t first_coll_page = last_data_page + 1;
+                                    uint32_t last_coll_page  = page_next_addr - 1;
+                                    uint32_t coll_addr_start = segment_first_addr + first_coll_page * OFFSET_PAGE_SIZE * 8;
+                                    uint32_t coll_addr_end   = segment_first_addr + (last_coll_page + 1) * OFFSET_PAGE_SIZE * 8 - 8;
+                                    collapsible_pages += new_collapsible;
+                                }
+                            }
+                        }
+                        
+                        // Consume rows for this address (may be partial if near segment boundary)
+                        uint32_t consumed = std::min(count, rows_available);
+                        rows_available -= consumed;
+                        count -= consumed;
+                        
+                        last_addr_with_data = addr;
+                    }
+                }
+            }
+        }
+    }
+    if (rows_available < rows_by_segment) {
+        // + 8/8 - 1 = 0
+        uint32_t pages = (((last_addr_with_data - segment_first_addr + 1) / 8) + OFFSET_PAGE_SIZE) / OFFSET_PAGE_SIZE;
+        segments_pages.push_back(std::make_pair(pages, collapsible_pages));
+    }
+}
+
 void ImmutableMemPlanner::execute(const std::vector<MemCounter *> &workers) {
     uint32_t addr = 0;
     uint32_t offset;
     uint32_t last_offset;
+    calculate_pages(workers);
+    init_mem_offsets();
     last_addr = initial_last_addr;
     for (uint32_t page = from_page; page <= to_page; ++page) {
         get_offset_limits(workers, page, offset, last_offset);
@@ -92,13 +222,28 @@ void ImmutableMemPlanner::close_segment() {
     }
     tot_chunks += segment_chunks;
     #endif
-
+    #ifdef MEM_SAVE_CPP_OFFSETS
+    mem_offsets->save_offsets_to_file("tmp/" + std::string(MemCounter::page_to_tag(from_page)) + "_trace_" + std::to_string((uint32_t)segments.size()) + "_cpp_offsets.txt", false);
+    #endif
+    
+    // Move MemOffsets data to current_segment->offsets before saving
+    mem_offsets->move_to_paged_offsets(current_segment->offsets, current_segment->offsets_base_addr);
+    
     segments.emplace_back(current_segment);
+    init_mem_offsets();
+    
     #ifdef MEM_CHECK_POINT_MAP
     current_segment = new MemSegment();
     #else
     current_segment = new MemSegment(hash_table);
     #endif
+}
+void ImmutableMemPlanner::init_mem_offsets() {
+    uint32_t next_segment_index = segments.size();
+    if (next_segment_index < segments_pages.size()) {
+        const auto pages_info = segments_pages[next_segment_index];
+        mem_offsets->allocate(pages_info.first, pages_info.second); // Clear mem_offsets for next segment
+    }
 }
 void ImmutableMemPlanner::open_segment() {
     #ifndef MEM_CHECK_POINT_MAP
@@ -111,6 +256,7 @@ void ImmutableMemPlanner::open_segment() {
         #else
         current_segment->add_or_update(hash_table, reference_addr_chunk, reference_addr, reference_skip, 0);
         #endif
+        mem_offsets->update(reference_addr, reference_skip > 0 ? 0: 1);
     }
     rows_available = rows_by_segment;
 }
@@ -137,6 +283,10 @@ void ImmutableMemPlanner::consume_rows(uint32_t addr, uint32_t row_count, uint32
     if (rows_available == 0) {
         open_segment();
     }
+    
+    // Track offset before adding chunk
+    mem_offsets->update(addr, rows_available == 0 && skip > 0 ? 0 : (rows_by_segment - rows_available + 1));
+    
     add_chunk_to_segment(current_chunk, addr, row_count, skip);
     rows_available -= row_count;
     reference_skip += row_count;
@@ -155,6 +305,8 @@ void ImmutableMemPlanner::consume_intermediate_rows(uint32_t row_count) {
     #endif
     if (rows_available == 0) {
         open_segment();
+        mem_offsets->reset();
+
     }
     // add_chunk_to_segment(current_chunk, addr, rows, skip);
     rows_available -= row_count;
@@ -212,4 +364,8 @@ void ImmutableMemPlanner::collect_segments(MemSegments &mem_segments) {
 
 void ImmutableMemPlanner::stats() {
 
+}
+
+void ImmutableMemPlanner::save_offsets_to_file(const std::string &filename, bool compact) {
+    mem_offsets->save_offsets_to_file(filename, compact);
 }

--- a/state-machines/mem-cpp/cpp/immutable_mem_planner.hpp
+++ b/state-machines/mem-cpp/cpp/immutable_mem_planner.hpp
@@ -26,6 +26,7 @@
 #include "mem_locators.hpp"
 #include "mem_locator.hpp"
 #include "mem_segments.hpp"
+#include "mem_offsets.hpp"
 
 class ImmutableMemPlanner {
 private:
@@ -58,11 +59,18 @@ private:
     #endif
     std::vector<MemSegment *> segments;
     bool intermediate_rows;
+    
+    // Offset tracking (optional)
+    MemOffsets *mem_offsets;
+    uint32_t mb_size; // Store mb_size for recreating MemOffsets
+    std::vector<std::pair<uint32_t, uint32_t>> segments_pages;
+
 
 public:
     ImmutableMemPlanner(uint32_t rows, uint32_t from_addr, uint32_t mb_size, bool intermediate_rows = true);
     ~ImmutableMemPlanner();
     void execute(const std::vector<MemCounter *> &workers);
+    void calculate_pages(const std::vector<MemCounter *> &workers);
     void get_offset_limits(const std::vector<MemCounter *> &workers, uint32_t page, uint32_t &first_offset, uint32_t &last_offset);
     inline void add_to_current_segment(uint32_t chunk_id, uint32_t addr, uint32_t count);
     inline void set_reference(uint32_t chunk_id, uint32_t addr);
@@ -81,7 +89,11 @@ public:
     uint32_t add_intermediates(uint32_t addr);
     void collect_segments(MemSegments &mem_segments);
     void stats();
-    void set_last_addr(uint32_t addr) { initial_last_addr = addr; }    
+    void set_last_addr(uint32_t addr) { initial_last_addr = addr; }
+    void save_offsets_to_file(const std::string &filename, bool compact = true);
+    MemOffsets* get_mem_offsets() { return mem_offsets; }
+    void enable_debug() { if (mem_offsets) mem_offsets->enable_debug(); }
+    void init_mem_offsets();
 };
 
 void ImmutableMemPlanner::add_to_current_segment(uint32_t chunk_id, uint32_t addr, uint32_t count) {

--- a/state-machines/mem-cpp/cpp/mem_align_counter.cpp
+++ b/state-machines/mem-cpp/cpp/mem_align_counter.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include <assert.h>
 
-MemAlignCounter::MemAlignCounter(std::shared_ptr<MemContext> context) :context(context) {
+MemAlignCounter::MemAlignCounter(std::shared_ptr<MemContext> context) :context(context), elapsed_ms(0), total_usleep(0) {
     total_counters.chunk_id = 0xFFFFFFFF;
     total_counters.full_5 = 0;
     total_counters.full_3 = 0;

--- a/state-machines/mem-cpp/cpp/mem_config.hpp
+++ b/state-machines/mem-cpp/cpp/mem_config.hpp
@@ -16,6 +16,7 @@
 #define USE_ADDR_COUNT_TABLE
 #define MAX_SEGMENTS 512
 // #define MEM_PLANNER_STATS
+// #define MEM_SAVE_CPP_OFFSETS
 
 #define MEM_CHECK_POINT_MAP
 // #define SEGMENT_STATS
@@ -32,6 +33,8 @@
 #define ROM_ROWS (1 << 21)
 #define INPUT_ROWS (1 << 21)
 #define MEM_ROWS (1 << 22)
+
+
 #define MAX_CHUNKS (1 << 18)     // 2^36 / 2^18 = 2^18
 
 // THREAD_BITS >= 1
@@ -62,6 +65,15 @@
 #define NO_CHUNK_ID 0xFFFFFFFF
 #define EMPTY_PAGE 0xFFFFFFFF
 
+#define OFFSET_PAGE_SIZE 1024
+#define MAX_OFFSETS (1 << 22)
+
+#define MAX_OFFSET_PAGES_INCREMENT 8192
+#define MAX_OFFSET_INCREMENT (1024 * OFFSET_PAGE_SIZE)
+#define MEM_OFFSETS_PAGES 4096
+#define MEM_OFFSETS MAX_OFFSET_INCREMENT
+
+#define MAX_IMMUTABLE_ADDR_DISTANCE (1 << 24)
 
 // SINGLE WRITE FLAGS
 //                bits

--- a/state-machines/mem-cpp/cpp/mem_counter.hpp
+++ b/state-machines/mem-cpp/cpp/mem_counter.hpp
@@ -99,6 +99,7 @@ public:
     inline static uint32_t addr_to_offset(uint32_t addr, uint32_t chunk_id = 0);
     inline static uint32_t addr_to_page(uint32_t addr, uint32_t chunk_id = 0);
     inline static uint32_t page_to_addr(uint8_t page);
+    inline static const char *page_to_tag(uint8_t page);
     inline uint32_t get_used_slots(void) const;
     inline uint64_t get_first_chunk_us(void) const;
     void stats();
@@ -252,7 +253,43 @@ uint32_t MemCounter::addr_to_offset(uint32_t addr, uint32_t chunk_id) {
     msg << "ERROR: addr_to_offset: 0x" << std::hex << addr << " (" << std::dec << chunk_id << ")";
     throw std::runtime_error(msg.str());
 }
-
+const char *MemCounter::page_to_tag(uint8_t page) {
+    switch(page) {
+        // ROM: 128 MB
+        case 0:
+        case 1:
+            return "rom_data";
+        // INPUT: 1024 MB
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+        case 11:
+        case 12:
+        case 13:
+        case 14:
+        case 15:
+        case 16:
+        case 17:
+            return "input_data";
+        // RAM: 512 MB 
+        case 18:
+        case 19:
+        case 20:
+        case 21:
+        case 22:
+        case 23:
+        case 24:
+        case 25:
+            return "mem";
+    }
+    return "??";
+}
 uint32_t MemCounter::addr_to_page(uint32_t addr, uint32_t chunk_id) {
     switch((uint8_t)((addr >> 24) & 0xFC)) {
         // ROM: 128 MB 

--- a/state-machines/mem-cpp/cpp/mem_locator.hpp
+++ b/state-machines/mem-cpp/cpp/mem_locator.hpp
@@ -21,6 +21,7 @@
 #include "mem_config.hpp"
 #include "tools.hpp"
 struct MemLocator {
+    uint32_t previous_addr;
     uint32_t offset;
     uint32_t cpos;
     uint32_t skip;

--- a/state-machines/mem-cpp/cpp/mem_locators.cpp
+++ b/state-machines/mem-cpp/cpp/mem_locators.cpp
@@ -4,12 +4,13 @@
 MemLocators::MemLocators() {
 }
 
-void MemLocators::push_locator(uint32_t thread_index, uint32_t offset, uint32_t cpos, uint32_t skip) {
+void MemLocators::push_locator(uint32_t thread_index, uint32_t offset, uint32_t cpos, uint32_t skip, uint32_t previous_addr) {
     size_t pos = write_pos.load(std::memory_order_relaxed);
     assert(pos < MAX_LOCATORS);
     locators[pos].thread_index = thread_index;
     locators[pos].offset = offset;
     locators[pos].cpos = cpos;
+    locators[pos].previous_addr = previous_addr;
     locators[pos].skip = skip;
     write_pos.store(pos + 1, std::memory_order_relaxed);
 }

--- a/state-machines/mem-cpp/cpp/mem_locators.hpp
+++ b/state-machines/mem-cpp/cpp/mem_locators.hpp
@@ -30,7 +30,7 @@ public:
     std::atomic<bool> completed{false};
     MemLocator locators[MAX_LOCATORS];
     MemLocators();
-    void push_locator(uint32_t thread_index, uint32_t offset, uint32_t cpos, uint32_t skip);
+    void push_locator(uint32_t thread_index, uint32_t offset, uint32_t cpos, uint32_t skip, uint32_t previous_addr);
     MemLocator *get_locator(uint32_t &segment_id);
     inline void set_completed();
     inline bool is_completed();

--- a/state-machines/mem-cpp/cpp/mem_offsets.cpp
+++ b/state-machines/mem-cpp/cpp/mem_offsets.cpp
@@ -1,6 +1,7 @@
 #include "mem_offsets.hpp"
 #include <assert.h>
 #include <ostream>
+#include <algorithm>
 
 MemOffsets::MemOffsets(uint32_t id, uint32_t mb_size)
     : id(id), first_offset_addr(0), last_offset_addr(0), is_preallocated(true),
@@ -47,7 +48,7 @@ void MemOffsets::realloc_pages(uint32_t page) {
     #ifdef MEM_WARNINGS
     uint32_t _num_offset_pages = num_offset_pages;
     #endif
-    num_offset_pages = std::max(num_offset_pages, page) + std::min(num_offset_pages, (uint32_t) MAX_OFFSET_PAGES_INCREMENT);
+    num_offset_pages = std::max(1, std::max(num_offset_pages, page) + std::min(num_offset_pages, (uint32_t) MAX_OFFSET_PAGES_INCREMENT));
     #ifdef MEM_WARNINGS
     printf("MemOffsets::realloc_pages: reallocating from %u to %u pages (requested page %u)\n", _num_offset_pages, num_offset_pages, page);
     #endif
@@ -267,7 +268,7 @@ void MemOffsets::save_offsets_to_file(const std::string &filename, bool compact)
             // This is a compressed page - all entries have the same value
             uint32_t value = page_values[page];
             if (compact) {
-                uint32_t next_value = (page < last_page) ? (page_offsets[page + 1] == MEM_OFFSETS_PAGE_ABSENT ? page_values[page + 1] : offsets[page_offsets[page + 1]]) : 0;
+                uint32_t next_value = (page < last_page) ? (page_offsets[page + 1] == MEM_OFFSETS_PAGE_ABSENT ? page_values[page + 1] : offsets[page_offsets[page + 1] * OFFSET_PAGE_SIZE]) : 0;
                 if (value != next_value) {
                     uint32_t addr = (first_offset_addr >> 3) + (page + 1) * OFFSET_PAGE_SIZE - 1;
                     fprintf(file, "0x%X %d\n", addr * 8, value - 1);
@@ -286,7 +287,7 @@ void MemOffsets::save_offsets_to_file(const std::string &filename, bool compact)
             }
         } else {
             // Regular page with individual offset values
-            uint32_t base = page_offsets[page];
+            uint32_t base = page_offsets[page] * OFFSET_PAGE_SIZE;
             uint32_t entries_in_page = (page == last_page) ? ((last_index % OFFSET_PAGE_SIZE) + 1) : OFFSET_PAGE_SIZE;
             
             for (uint32_t i = 0; i < entries_in_page; ++i) {

--- a/state-machines/mem-cpp/cpp/mem_offsets.cpp
+++ b/state-machines/mem-cpp/cpp/mem_offsets.cpp
@@ -145,7 +145,7 @@ void MemOffsets::add_addr_offset(uint32_t addr, uint32_t offset_value) {
         uint32_t page = index / OFFSET_PAGE_SIZE;
         if (is_preallocated && page >= num_offset_pages) {
             // only one page of increment
-            realloc_pages();
+            realloc_pages(page);
         }
         if ((index % OFFSET_PAGE_SIZE) == 0) {  
             uint32_t page_index = page == 0 ? 0 : page_offsets[page - 1] + 1;

--- a/state-machines/mem-cpp/cpp/mem_offsets.cpp
+++ b/state-machines/mem-cpp/cpp/mem_offsets.cpp
@@ -1,0 +1,356 @@
+#include "mem_offsets.hpp"
+#include <assert.h>
+#include <ostream>
+
+MemOffsets::MemOffsets(uint32_t id, uint32_t mb_size)
+    : id(id), first_offset_addr(0), last_offset_addr(0), is_preallocated(true),
+      debug_mode(false), debug_absent_total(0) {
+    
+    num_offset_pages = MEM_OFFSETS_PAGES;
+    num_offsets = MEM_OFFSETS;
+    // number of pages was determined based on total address
+    page_offsets = (uint32_t *)calloc(num_offset_pages, sizeof(uint32_t));
+    page_values  = (uint32_t *)calloc(num_offset_pages, sizeof(uint32_t));
+    offsets      = (uint32_t *)calloc(num_offsets, sizeof(uint32_t));
+}
+
+MemOffsets::MemOffsets(uint32_t id, uint32_t pages, uint32_t collapsible_pages)
+    : id(id), first_offset_addr(0), last_offset_addr(0), is_preallocated(false),
+      debug_mode(false), debug_absent_total(0) {
+    inner_allocate(pages, collapsible_pages);
+}
+
+MemOffsets::MemOffsets(uint32_t id):id(id), first_offset_addr(0), last_offset_addr(0),
+      is_preallocated(false), debug_mode(false), debug_absent_total(0) {
+    page_offsets = nullptr;
+    page_values  = nullptr;
+    offsets      = nullptr;
+    num_offset_pages = 0;
+    num_offsets = 0;
+}
+
+MemOffsets::~MemOffsets() {
+    // Safe to call free(nullptr), but check for clarity
+    // After move_to_paged_offsets, these will be nullptr
+    if (page_offsets) {
+        free(page_offsets);
+    }
+    if (page_values) {
+        free(page_values);
+    }
+    if (offsets) {
+        free(offsets);
+    }
+}
+
+void MemOffsets::realloc_pages(uint32_t page) {
+    #ifdef MEM_WARNINGS
+    uint32_t _num_offset_pages = num_offset_pages;
+    #endif
+    num_offset_pages = std::max(num_offset_pages, page) + std::min(num_offset_pages, (uint32_t) MAX_OFFSET_PAGES_INCREMENT);
+    #ifdef MEM_WARNINGS
+    printf("MemOffsets::realloc_pages: reallocating from %u to %u pages (requested page %u)\n", _num_offset_pages, num_offset_pages, page);
+    #endif
+    page_values = (uint32_t *)realloc(page_values, num_offset_pages * sizeof(uint32_t));
+    page_offsets = (uint32_t *)realloc(page_offsets, num_offset_pages * sizeof(uint32_t));
+}
+
+void MemOffsets::allocate(uint32_t pages, uint32_t collapsible_pages) {
+    assert(page_values == nullptr && page_offsets == nullptr && offsets == nullptr);
+    inner_allocate(pages, collapsible_pages);
+}
+void MemOffsets::inner_allocate(uint32_t pages, uint32_t collapsible_pages) {
+    first_offset_addr = 0;
+    last_offset_addr = 0;
+    debug_absent_total = 0;
+    num_offset_pages = pages;
+    num_offsets = (pages - collapsible_pages) * OFFSET_PAGE_SIZE; // worst case: all pages are non-collapsible
+    page_values = (uint32_t *)calloc(pages, sizeof(uint32_t));
+    page_offsets = (uint32_t *)calloc(pages, sizeof(uint32_t));
+    offsets = (uint32_t *)calloc(num_offsets, sizeof(uint32_t));
+}
+#define MIN_OFFSET_PAGES_INCREMENT 16
+
+void MemOffsets::preallocate(uint32_t first_addr, uint32_t last_addr, uint32_t num_addrs) {
+    is_preallocated = true;
+    if (first_addr == 0 || last_addr == 0 || num_addrs == 0) {
+        return;
+    }
+    
+    // Calculate required pages based on address range
+    uint32_t addr_range = (last_addr - first_addr) / 8;
+    uint32_t required_offset_pages = (addr_range / OFFSET_PAGE_SIZE) + 1;
+    
+    // Pre-allocate page arrays if needed
+    if (required_offset_pages > num_offset_pages) {
+        realloc_pages(required_offset_pages - 1);
+    }
+    
+    // Estimate required offsets:
+    // Worst case: all addresses are in different pages = num_addrs * OFFSET_PAGE_SIZE
+    // But realistically, they're more spread out, so use a heuristic
+    uint32_t estimated_offsets = std::min(
+        num_addrs * 2,  // Conservative estimate
+        required_offset_pages * OFFSET_PAGE_SIZE
+    );
+    
+    // Pre-allocate offsets array with some margin
+    if (estimated_offsets > num_offsets) {
+        uint32_t target_size = estimated_offsets + (MIN_OFFSET_PAGES_INCREMENT * OFFSET_PAGE_SIZE);
+        num_offsets = std::min(target_size, (uint32_t)(MAX_OFFSET_INCREMENT * 2));
+        offsets = (uint32_t *)realloc(offsets, num_offsets * sizeof(uint32_t));
+        #ifdef MEM_WARNINGS
+        printf("MemOffsets::preallocate: allocated %u offsets (estimated %u from %u addrs)\n",
+               num_offsets, estimated_offsets, num_addrs);
+        #endif
+    }
+}
+
+void MemOffsets::realloc_offsets(uint32_t min_size) {
+    #ifdef MEM_WARNINGS
+    uint32_t _num_offsets = num_offsets;
+    #endif
+    
+    // Calculate how many offsets we need at minimum
+    uint32_t needed_increment = min_size - num_offsets + 1;
+    uint32_t min_increment = MIN_OFFSET_PAGES_INCREMENT * OFFSET_PAGE_SIZE;
+    
+    // Use at least MIN_OFFSET_PAGES_INCREMENT pages or what's needed, whichever is larger
+    // But cap at MAX_OFFSET_INCREMENT
+    uint32_t increment = std::min((uint32_t)MAX_OFFSET_INCREMENT, 
+                                   std::max(needed_increment, min_increment));
+    num_offsets += increment;
+                           
+    #ifdef MEM_WARNINGS
+    printf("MemOffsets::realloc_offsets: reallocating from %u to %u offsets (min_size=%u)\n", 
+           _num_offsets, num_offsets, min_size);
+    #endif
+    offsets = (uint32_t *)realloc(offsets, num_offsets * sizeof(uint32_t));
+}
+
+void MemOffsets::add_addr_offset(uint32_t addr, uint32_t offset_value) {
+    if (first_offset_addr == 0) {
+        // First call: addr is the origin of the table, always at index 0
+        first_offset_addr = addr;
+        page_offsets[0] = 0;
+        offsets[0] = offset_value;
+        last_offset_addr = addr;
+        return;
+    }
+
+    uint32_t index = ((addr - first_offset_addr) / 8);
+    if (addr == last_offset_addr + 8) {
+        // FAST PATH
+        uint32_t page = index / OFFSET_PAGE_SIZE;
+        if (is_preallocated && page >= num_offset_pages) {
+            // only one page of increment
+            realloc_pages();
+        }
+        if ((index % OFFSET_PAGE_SIZE) == 0) {  
+            uint32_t page_index = page == 0 ? 0 : page_offsets[page - 1] + 1;
+            uint32_t offsets_index = page_index * OFFSET_PAGE_SIZE;
+            // new page        
+            assert(page < num_offset_pages);    
+            page_offsets[page] = page_index;
+            if (is_preallocated) {
+                if (offsets_index >= num_offsets) {
+                    realloc_offsets(offsets_index);
+                }
+            } else if (offsets_index >= num_offsets) {
+                assert(offsets_index < num_offsets);    
+                return;
+            }
+            offsets[offsets_index] = offset_value;
+        } else {
+            uint32_t offsets_index = page_offsets[page] * OFFSET_PAGE_SIZE + (index % OFFSET_PAGE_SIZE);
+            if (is_preallocated) {
+                if (offsets_index >= num_offsets) {
+                    realloc_offsets(offsets_index);
+                }
+            } else if (offsets_index >= num_offsets) {
+                assert(offsets_index < num_offsets);    
+            }
+            offsets[offsets_index] = offset_value;
+        }           
+        last_offset_addr = addr;             
+        return;
+    }
+
+
+    // GENERIC PATH
+    uint32_t last_page = index / OFFSET_PAGE_SIZE;
+    uint32_t in_page_index = index % OFFSET_PAGE_SIZE;
+    uint32_t last_offset_index = ((last_offset_addr - first_offset_addr) / 8);
+    uint32_t last_offset_page  = last_offset_index / OFFSET_PAGE_SIZE;
+
+    if (is_preallocated) {
+        if (last_page >= num_offset_pages) {
+            realloc_pages(last_page);
+        }
+        
+        // Ensure we have enough space in offsets array for the worst case:
+        // - If same page: need space up to base + in_page_index
+        // - If different page: need space up to page_offsets[last_offset_page] + OFFSET_PAGE_SIZE + in_page_index
+        uint32_t max_offset_needed = page_offsets[last_offset_page] * OFFSET_PAGE_SIZE + OFFSET_PAGE_SIZE + in_page_index;
+        if (max_offset_needed >= num_offsets) {
+            realloc_offsets(max_offset_needed);
+        }
+    }
+    if (last_offset_page == last_page) {
+        // Same page: fill gap entries with offset_value, then write offset_value at target
+        uint32_t base = page_offsets[last_offset_page] * OFFSET_PAGE_SIZE;
+        uint32_t from_pos = (last_offset_index % OFFSET_PAGE_SIZE) + 1;
+        for (uint32_t i = from_pos; i < in_page_index; ++i) {
+            offsets[base + i] = offset_value;
+        }
+        offsets[base + in_page_index] = offset_value;
+    } else {
+        // 1. Fill the remainder of the last written page with offset_value
+        {
+            uint32_t base = page_offsets[last_offset_page] * OFFSET_PAGE_SIZE;
+            uint32_t from_pos = (last_offset_index % OFFSET_PAGE_SIZE) + 1;
+            for (uint32_t i = from_pos; i < OFFSET_PAGE_SIZE; ++i) {
+                offsets[base + i] = offset_value;
+            }
+        }
+        // 2. Compress entirely skipped pages.
+        // Also compress last_page itself when addr is its last slot (all slots = offset_value).
+        bool compress_last_page = (in_page_index == OFFSET_PAGE_SIZE - 1);
+        uint32_t compress_end = compress_last_page ? last_page + 1 : last_page;
+        for (uint32_t p = last_offset_page + 1; p < compress_end; ++p) {
+            page_offsets[p] = MEM_OFFSETS_PAGE_ABSENT;
+            page_values[p]  = offset_value;
+        }
+        if (debug_mode && compress_end > last_offset_page + 1) {
+            uint32_t first_absent  = last_offset_page + 1;
+            uint32_t last_absent   = compress_end - 1;
+            uint32_t absent_count  = compress_end - last_offset_page - 1;
+            uint32_t addr_start    = first_offset_addr + first_absent * OFFSET_PAGE_SIZE * 8;
+            uint32_t addr_end      = first_offset_addr + compress_end * OFFSET_PAGE_SIZE * 8 - 8;
+            debug_absent_total    += absent_count;
+        }
+        // 3. Allocate current page right after the last allocated one
+        // (skipped when last_page was already compressed above)
+        if (!compress_last_page) {
+            uint32_t new_offsets_index = page_offsets[last_offset_page] * OFFSET_PAGE_SIZE + OFFSET_PAGE_SIZE;
+            page_offsets[last_page] = new_offsets_index / OFFSET_PAGE_SIZE;
+            for (uint32_t i = 0; i < in_page_index; ++i) {
+                offsets[new_offsets_index + i] = offset_value;
+            }
+            offsets[new_offsets_index + in_page_index] = offset_value;
+        }
+    }
+    last_offset_addr = addr;
+}
+
+void MemOffsets::save_offsets_to_file(const std::string &filename, bool compact) {
+    FILE *file = fopen(filename.c_str(), "w");
+    if (file == nullptr) {
+        fprintf(stderr, "Error: Unable to open file %s for writing\n", filename.c_str());
+        return;
+    }
+
+    if (first_offset_addr == 0) {
+        fprintf(file, "# No offsets recorded yet\n");
+        fclose(file);
+        return;
+    }
+
+    uint32_t count = 0;
+    uint32_t last_index = ((last_offset_addr - first_offset_addr) / 8);
+    uint32_t last_page = last_index / OFFSET_PAGE_SIZE;
+
+    // Iterate through all pages up to the last page with data
+    uint32_t last_offset = 0xFFFFFFFE;
+    for (uint32_t page = 0; page <= last_page; ++page) {
+        if (page_offsets[page] == MEM_OFFSETS_PAGE_ABSENT) {
+            // This is a compressed page - all entries have the same value
+            uint32_t value = page_values[page];
+            if (compact) {
+                uint32_t next_value = (page < last_page) ? (page_offsets[page + 1] == MEM_OFFSETS_PAGE_ABSENT ? page_values[page + 1] : offsets[page_offsets[page + 1]]) : 0;
+                if (value != next_value) {
+                    uint32_t addr = (first_offset_addr >> 3) + (page + 1) * OFFSET_PAGE_SIZE - 1;
+                    fprintf(file, "0x%X %d\n", addr * 8, value - 1);
+                    ++count;
+                    last_offset = value;
+                }
+            } else {
+                uint32_t start_addr = first_offset_addr + (page * OFFSET_PAGE_SIZE * 8);
+                uint32_t entries_in_page = (page == last_page) ? ((last_index % OFFSET_PAGE_SIZE) + 1) : OFFSET_PAGE_SIZE;
+                
+                for (uint32_t i = 0; i < entries_in_page; ++i) {
+                    uint32_t addr = start_addr + (i * 8);
+                    fprintf(file, "0x%X %u\n", addr, value);
+                    ++count;
+                }
+            }
+        } else {
+            // Regular page with individual offset values
+            uint32_t base = page_offsets[page];
+            uint32_t entries_in_page = (page == last_page) ? ((last_index % OFFSET_PAGE_SIZE) + 1) : OFFSET_PAGE_SIZE;
+            
+            for (uint32_t i = 0; i < entries_in_page; ++i) {
+                uint32_t value = offsets[base + i]; 
+                if (!compact || value != last_offset) {
+                    uint32_t addr = (first_offset_addr >> 3) + (page * OFFSET_PAGE_SIZE + i);
+                    fprintf(file, "0x%X %d\n", addr * 8, value - 1);
+                    ++count;
+                }
+                last_offset = value;
+            }
+        }
+    }
+
+    fclose(file);
+    printf("MemOffsets::save_offsets_to_file: Saved %u offsets to %s\n", count, filename.c_str());
+}
+
+void MemOffsets::move_to_paged_offsets(PagedOffsets &paged_offsets, uint32_t &offsets_base_addr) {
+    // Move (transfer ownership) internal pointers to PagedOffsets structure
+    // PagedOffsets uses different naming:
+    //   page_starts = page_offsets
+    //   page_single_value = page_values  
+    //   pages_dense = offsets
+    
+    // Calculate the actual used range
+    uint32_t last_index = first_offset_addr == 0 ? 0 : ((last_offset_addr - first_offset_addr) / 8);
+    uint32_t last_page = last_index / OFFSET_PAGE_SIZE;
+    
+    // Count present (non-compressed) pages
+    uint32_t present_count = 0;
+    for (uint32_t p = 0; p <= last_page; ++p) {
+        if (page_offsets[p] != MEM_OFFSETS_PAGE_ABSENT) {
+            ++present_count;
+        }
+    }
+    
+    // Transfer ownership of the pointers
+    paged_offsets.page_starts = page_offsets;
+    paged_offsets.page_single_value = page_values;
+    paged_offsets.pages_dense = offsets;
+    #ifdef MEM_WARNINGS
+    if (last_page >= num_offset_pages) {
+        printf("\x1B[1;31mWARNING!! MemOffsets::move_to_paged_offsets: WARNING - last_page %u exceeds allocated num_offset_pages %u [0x%08X..=0x%08X]\x1B[0m\n", last_page, num_offset_pages,first_offset_addr, last_offset_addr);
+    }
+    #endif
+    paged_offsets.num_pages = last_page + 1;
+    paged_offsets.present_count = present_count;
+    paged_offsets.addr_range_slots = last_index + 1;
+    
+    offsets_base_addr = first_offset_addr;
+    
+    // Clear internal pointers (ownership transferred)
+    page_offsets = nullptr;
+    page_values = nullptr;
+    offsets = nullptr;
+    num_offset_pages = 0;
+    num_offsets = 0;
+    first_offset_addr = 0;
+    last_offset_addr = 0;
+    
+    #ifdef MEM_WARNINGS
+    printf("MemOffsets::move_to_paged_offsets: Transferred %u pages (%u present, %u slots) from addr 0x%X\n",
+           paged_offsets.num_pages, paged_offsets.present_count, 
+           paged_offsets.addr_range_slots, offsets_base_addr);
+    #endif
+}

--- a/state-machines/mem-cpp/cpp/mem_offsets.cpp
+++ b/state-machines/mem-cpp/cpp/mem_offsets.cpp
@@ -48,7 +48,7 @@ void MemOffsets::realloc_pages(uint32_t page) {
     #ifdef MEM_WARNINGS
     uint32_t _num_offset_pages = num_offset_pages;
     #endif
-    num_offset_pages = std::max(1, std::max(num_offset_pages, page) + std::min(num_offset_pages, (uint32_t) MAX_OFFSET_PAGES_INCREMENT));
+    num_offset_pages = std::max(num_offset_pages, page) + std::min(num_offset_pages, (uint32_t) MAX_OFFSET_PAGES_INCREMENT);
     #ifdef MEM_WARNINGS
     printf("MemOffsets::realloc_pages: reallocating from %u to %u pages (requested page %u)\n", _num_offset_pages, num_offset_pages, page);
     #endif

--- a/state-machines/mem-cpp/cpp/mem_offsets.hpp
+++ b/state-machines/mem-cpp/cpp/mem_offsets.hpp
@@ -1,0 +1,59 @@
+#ifndef __MEM_OFFSETS_HPP__
+#define __MEM_OFFSETS_HPP__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string>
+#include "mem_config.hpp"
+#include "instance_meta.hpp"
+
+class MemOffsets {
+private:
+    uint32_t id;
+    uint32_t first_offset_addr;
+    uint32_t last_offset_addr;
+    uint32_t *page_offsets;
+    uint32_t *page_values;
+    uint32_t *offsets;
+    uint32_t num_offset_pages;
+    uint32_t num_offsets;
+    bool is_preallocated;
+    bool debug_mode;
+    uint32_t debug_absent_total;
+
+public:
+    MemOffsets(uint32_t id, uint32_t mb_size);
+    MemOffsets(uint32_t id, uint32_t pages, uint32_t collapsible_pages);
+    MemOffsets(uint32_t id);
+    ~MemOffsets();
+    
+    void add_addr_offset(uint32_t addr, uint32_t offset_value);
+    void save_offsets_to_file(const std::string &filename, bool compact = true);
+    uint32_t get_first_offset_addr() const { return first_offset_addr; }
+    uint32_t get_last_offset_addr() const { return last_offset_addr; }
+    
+    // Prevent copying
+    MemOffsets(const MemOffsets&) = delete;
+    MemOffsets& operator=(const MemOffsets&) = delete;
+    void enable_debug() { debug_mode = true; debug_absent_total = 0; }
+    inline void update(uint32_t addr, uint32_t offset) {
+        if (addr > last_offset_addr) {
+            add_addr_offset(addr, offset);
+        }        
+    }
+    inline void reset() {
+        first_offset_addr = 0;
+        last_offset_addr = 0;
+        // Optionally, clear page_offsets and offsets arrays if needed
+    }   
+    void realloc_pages(uint32_t page = 0);
+    void realloc_offsets(uint32_t min_size);
+    void preallocate(uint32_t first_addr, uint32_t last_addr, uint32_t num_addrs);
+    void move_to_paged_offsets(PagedOffsets &paged_offsets, uint32_t &offsets_base_addr);
+    void allocate(uint32_t pages, uint32_t collapsible_pages);
+protected:
+    void inner_allocate(uint32_t pages, uint32_t collapsible_pages);
+};
+
+#endif

--- a/state-machines/mem-cpp/cpp/mem_planner.cpp
+++ b/state-machines/mem-cpp/cpp/mem_planner.cpp
@@ -1,4 +1,5 @@
 #include "mem_planner.hpp"
+#include <assert.h>
 
 MemPlanner::MemPlanner(uint32_t id, uint32_t rows, uint32_t from_addr, uint32_t mb_size)
 #ifdef MEM_CHECK_POINT_MAP
@@ -11,6 +12,7 @@ MemPlanner::MemPlanner(uint32_t id, uint32_t rows, uint32_t from_addr, uint32_t 
     reference_addr = 0;
     reference_skip = 0;
     locators_done = 0;
+    last_addr = 0;
     #ifdef MEM_PLANNER_STATS
     locators_time_count = 0;
     #endif
@@ -85,9 +87,45 @@ void MemPlanner::execute_from_locators(const std::vector<MemCounter *> &workers,
     #endif
 }
 
-void MemPlanner::execute_from_locator(const std::vector<MemCounter *> &workers, uint32_t segment_id, const MemLocator *locator) {
-    uint32_t addr = 0;
+void MemPlanner::precompute_locator_requirements(const std::vector<MemCounter *> &workers, const MemLocator *locator,
+                                                  uint32_t &first_addr_out, uint32_t &last_addr_out, uint32_t &num_addrs_out) {
+    first_addr_out = 0;
+    last_addr_out = 0;
+    num_addrs_out = 0;
+    
+    uint32_t offset = locator->offset;
+    uint32_t page = MemCounter::offset_to_page(offset);
+    uint32_t max_offset = get_max_offset(workers, page);
+    uint32_t thread_index = locator->thread_index;
+    
+    for (; page <= to_page; ++page, thread_index = 0, get_offset_limits(workers, page, offset, max_offset)) {
+        for (; offset <= max_offset; ++offset, thread_index = 0) {
+            for (; thread_index < MAX_THREADS; ++thread_index) {
+                uint32_t pos = workers[thread_index]->get_addr_table(offset);
+                if (pos == 0) continue;
+                
+                uint32_t addr = MemCounter::offset_to_addr(offset, thread_index);
+                if (first_addr_out == 0) {
+                    first_addr_out = addr;
+                }
+                last_addr_out = addr;
+                ++num_addrs_out;
+            }
+        }
+    }
+}
 
+void MemPlanner::execute_from_locator(const std::vector<MemCounter *> &workers, uint32_t segment_id, const MemLocator *locator) {
+    current_segment = nullptr;
+    uint32_t addr = 0;
+    
+    // Pre-compute requirements and preallocate
+    uint32_t first_addr, last_addr, num_addrs;
+    precompute_locator_requirements(workers, locator, first_addr, last_addr, num_addrs);
+    
+    // Create local MemOffsets for this segment
+    MemOffsets mem_offsets(10000 + segment_id);
+    mem_offsets.preallocate(first_addr, last_addr, num_addrs);
     ++locators_done;
     #ifdef MEM_PLANNER_STATS
     uint32_t addr_count = 0;
@@ -104,6 +142,7 @@ void MemPlanner::execute_from_locator(const std::vector<MemCounter *> &workers, 
     uint32_t first_segment_addr = MemCounter::offset_to_addr(offset, thread_index);
     uint32_t last_segment_addr = first_segment_addr;
     #endif
+    rows_available = rows;
     for (;page <= to_page; ++page, thread_index = 0, get_offset_limits(workers, page, offset, max_offset)) {
         for (;offset <= max_offset; ++offset, thread_index = 0) {
             addr = MemCounter::offset_to_addr(offset, thread_index);
@@ -124,13 +163,22 @@ void MemPlanner::execute_from_locator(const std::vector<MemCounter *> &workers, 
                     skip = 0;      
                     cpos = workers[thread_index]->get_initial_pos(pos); 
                 }
+
                 while (cpos != 0) {
                     uint32_t chunk_id = workers[thread_index]->get_pos_value(cpos);
                     uint32_t count = workers[thread_index]->get_pos_count(cpos+1);
+                    // Update offsets before adding chunk
+                    mem_offsets.update(addr, (segment_id > 0 && rows_available == rows && skip > 0) ? 0 : (rows - rows_available + 1));
+
                     if (add_chunk(chunk_id, addr, count - skip, skip) == false) {
                         #ifdef MEM_PLANNER_STATS
                         update_segment_stats(addr_count, offset_count, first_segment_addr, last_segment_addr);
                         #endif
+                        #ifdef MEM_SAVE_CPP_OFFSETS
+                        mem_offsets.save_offsets_to_file("tmp/mem_trace_" + std::to_string(segment_id) + "_cpp_offsets.txt", false);
+                        #endif
+                        // Move MemOffsets data to current_segment->offsets
+                        mem_offsets.move_to_paged_offsets(current_segment->offsets, current_segment->offsets_base_addr);
                         return;
                     }
                     skip = 0;
@@ -140,9 +188,15 @@ void MemPlanner::execute_from_locator(const std::vector<MemCounter *> &workers, 
             }
         }
     }
+    #ifdef MEM_SAVE_CPP_OFFSETS
+    mem_offsets.save_offsets_to_file("tmp/mem_trace_" + std::to_string(segment_id) + "_cpp_offsets.txt", false);
+    #endif
     #ifdef MEM_PLANNER_STATS
     update_segment_stats(addr_count, offset_count, first_segment_addr, last_segment_addr);
     #endif
+    
+    // Move MemOffsets data to current_segment->offsets
+    mem_offsets.move_to_paged_offsets(current_segment->offsets, current_segment->offsets_base_addr);
 }
 
 #ifdef MEM_PLANNER_STATS
@@ -163,17 +217,20 @@ void MemPlanner::generate_locators(const std::vector<MemCounter *> &workers, Mem
     rows_available = rows;
     uint32_t count;
     uint32_t offset, max_offset;
+    uint32_t previous_addr, addr = 0;
     bool inserted_first_locator = false;
     for (uint32_t page = from_page; page <= to_page; ++page) {
         get_offset_limits(workers, page, offset, max_offset);
         for (;offset <= max_offset; ++offset) {
             for (uint32_t thread_index = 0; thread_index < MAX_THREADS; ++thread_index) {
+                previous_addr = addr;
+                addr = MemCounter::offset_to_addr(offset, thread_index);
                 uint32_t pos = workers[thread_index]->get_addr_table(offset);
                 if (pos == 0) continue;
                 // the first locator must be open
                 if (inserted_first_locator == false) {
                     inserted_first_locator = true;
-                    locators.push_locator(thread_index, offset, pos, 0);
+                    locators.push_locator(thread_index, offset, pos, 0, 0);
                 }
                 uint32_t addr_count = workers[thread_index]->get_count_table(offset);
 
@@ -198,7 +255,7 @@ void MemPlanner::generate_locators(const std::vector<MemCounter *> &workers, Mem
                             #endif
                             count -= rows_available;
                             uint32_t skip = initial_count - count;
-                            locators.push_locator(thread_index, offset, cpos, skip);
+                            locators.push_locator(thread_index, offset, cpos, skip, previous_addr);
                             rows_available = rows;
                         }
                     }

--- a/state-machines/mem-cpp/cpp/mem_planner.hpp
+++ b/state-machines/mem-cpp/cpp/mem_planner.hpp
@@ -26,6 +26,7 @@
 #include "mem_locators.hpp"
 #include "mem_locator.hpp"
 #include "mem_segments.hpp"
+#include "mem_offsets.hpp"
 
 #ifdef MEM_PLANNER_STATS
 struct SegmentStats {
@@ -92,6 +93,8 @@ public:
     uint32_t get_max_offset(const std::vector<MemCounter *> &workers, uint32_t page);
     bool add_chunk(uint32_t chunk_id, uint32_t addr, uint32_t count, uint32_t skip = 0);
     void current_segment_add(uint32_t chunk_id, uint32_t addr, uint32_t count);
+    void precompute_locator_requirements(const std::vector<MemCounter *> &workers, const MemLocator *locator,
+                                         uint32_t &first_addr, uint32_t &last_addr, uint32_t &num_addrs);
     void stats();
     inline uint64_t *get_locators_times(uint32_t &count);
 };
@@ -106,4 +109,5 @@ uint64_t *MemPlanner::get_locators_times(uint32_t &count) {
     return nullptr;
     #endif
 }
+
 #endif

--- a/state-machines/mem-cpp/src/mem_planner.rs
+++ b/state-machines/mem-cpp/src/mem_planner.rs
@@ -210,6 +210,7 @@ impl MemPlanner {
                         &mut pages_dense_ptr as *mut *const u32,
                     )
                 };
+                assert!(offsets_base_addr > 0);
                 if !page_starts_ptr.is_null() && num_pages > 0 {
                     segment.offsets_base_addr = offsets_base_addr;
                     segment.addr_range_slots = addr_range_slots;

--- a/state-machines/mem-cpp/src/mem_planner.rs
+++ b/state-machines/mem-cpp/src/mem_planner.rs
@@ -210,8 +210,8 @@ impl MemPlanner {
                         &mut pages_dense_ptr as *mut *const u32,
                     )
                 };
-                assert!(offsets_base_addr > 0);
                 if !page_starts_ptr.is_null() && num_pages > 0 {
+                    assert!(offsets_base_addr > 0);
                     segment.offsets_base_addr = offsets_base_addr;
                     segment.addr_range_slots = addr_range_slots;
                     segment.num_pages = num_pages;

--- a/state-machines/mem/Cargo.toml
+++ b/state-machines/mem/Cargo.toml
@@ -27,7 +27,7 @@ rayon = { workspace = true }
 
 [features]
 default = []
-debug_mem = []
+debug_mem = ["mem-common/debug_mem"]
 debug_mem_align = []
 debug_mem_offsets = []
 debug_mem_bin_offsets = []

--- a/state-machines/mem/src/input_data_sm.rs
+++ b/state-machines/mem/src/input_data_sm.rs
@@ -78,7 +78,6 @@ impl<F: PrimeField64> InputDataSM<F> {
         let num_rows = InputDataTrace::<R>::NUM_ROWS;
 
         let mut last_addr = u32::MAX;
-        let mut first = true;
         for i in 0..num_rows {
             let addr = trace[i].get_addr();
             if addr != last_addr {

--- a/state-machines/mem/src/input_data_sm.rs
+++ b/state-machines/mem/src/input_data_sm.rs
@@ -1,5 +1,8 @@
 use std::sync::Arc;
 
+#[cfg(feature = "debug_mem")]
+use std::io::Write;
+
 use crate::{MemInput, MemModule, MemPreviousSegment};
 use mem_common::{MemModuleSegmentCheckPoint, MEM_BYTES_BITS, SEGMENT_ADDR_MAX_RANGE};
 
@@ -62,6 +65,29 @@ impl<F: PrimeField64> InputDataSM<F> {
     }
     pub fn get_to_addr() -> u32 {
         (INPUT_ADDR + MAX_INPUT_SIZE - 1) as u32
+    }
+
+    #[cfg(feature = "debug_mem")]
+    pub fn save_addr_offsets_to_file<R: InputDataTraceRowOps<F>>(
+        trace: &InputDataTrace<R>,
+        file_name: &str,
+    ) {
+        println!("[InputDataDebug] saving address offsets to {} .....", file_name);
+        let file = std::fs::File::create(file_name).unwrap();
+        let mut writer = std::io::BufWriter::new(file);
+        let num_rows = InputDataTrace::<R>::NUM_ROWS;
+
+        let mut last_addr = u32::MAX;
+        let mut first = true;
+        for i in 0..num_rows {
+            let addr = trace[i].get_addr();
+            if addr != last_addr {
+                writeln!(writer, "0x{:08X} {i}", addr * 8).unwrap();
+                last_addr = addr;
+            }
+        }
+        writeln!(writer).unwrap();
+        println!("[InputDataDebug] done");
     }
     /// Fills the witness trace from a **sorted** input slice (legacy path).
     ///
@@ -264,6 +290,12 @@ impl<F: PrimeField64> InputDataSM<F> {
         range_16bits[distance_end[1] as usize] += 1;
 
         self.std.range_check_ranged(self.range_16bits_id, None, &range_16bits);
+
+        #[cfg(feature = "debug_mem")]
+        Self::save_addr_offsets_to_file(
+            &trace,
+            &format!("tmp/input_data_trace_{segment_id:04}_offsets.txt"),
+        );
 
         Ok(AirInstance::new_from_trace(FromTrace::new(&mut trace).with_air_values(&mut air_values)))
     }

--- a/state-machines/mem/src/mem_planner.rs
+++ b/state-machines/mem/src/mem_planner.rs
@@ -90,7 +90,6 @@ impl MemPlanner {
                 (*chunk_id, Metrics::as_any(&**metric).downcast_ref::<MemCounters>().unwrap())
             })
             .collect();
-        println!("Collected memory counters for {} chunks", counters.len());
         counters.par_sort_by_key(|(chunk_id, _)| *chunk_id);
         let counters = Arc::new(counters);
         #[cfg(feature = "save_mem_counters")]

--- a/state-machines/mem/src/mem_sm.rs
+++ b/state-machines/mem/src/mem_sm.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use zisk_common::SegmentId;
 use zisk_pil::{MemAirValues, MemTrace, MemTraceRow, MemTraceRowOps, MemTraceRowPacked};
 
-#[cfg(any(feature = "debug_mem"))]
+#[cfg(feature = "debug_mem")]
 use std::{
     env,
     fs::File,
@@ -639,6 +639,17 @@ impl<F: PrimeField64> MemSM<F> {
                     let previous_addr_w = seg
                         .previous_change_addr_w(addr_index as u32)
                         .unwrap_or(previous_segment.addr as u64);
+
+                    debug_assert!(
+                        previous_addr_w < mem_op.addr as u64,
+                        "MemSM: Warning: address goes back \
+                              or no change (on addr_changes path) from 0x{:X} to 0x{:X} \
+                              at irow {irow} (offset_base_addr_w: 0x{:X})",
+                        mem_op.addr * 8,
+                        previous_addr_w * 8,
+                        offset_base_addr_w * 8
+                    );
+
                     mem_op.addr as u64 - previous_addr_w - 1
                 } else {
                     // How addr_changes is false, means that the previous row belongs to same address,
@@ -679,12 +690,12 @@ impl<F: PrimeField64> MemSM<F> {
                 // dual available
                 init_row = true;
 
-                let previous_addr = seg
+                let previous_addr: u64 = seg
                     .previous_change_addr_w(addr_index as u32)
                     .unwrap_or(previous_segment.addr as u64);
-                debug_assert!(previous_addr <= mem_op.addr as u64, "MemSM: Warning: address goes back \
-                              from 0x{:X} to 0x{previous_addr:X} at irow {irow} (offset_base_addr_w: \
-                              0x{offset_base_addr_w:X})",
+                debug_assert!(previous_addr < mem_op.addr as u64, "MemSM: Warning: address goes back \
+                              or no change (on addr_changes path) from 0x{:X} to 0x{previous_addr:X} \
+                              at irow {irow} (offset_base_addr_w: 0x{offset_base_addr_w:X})",
                     mem_op.addr);
                 mem_op.addr as u64 - previous_addr - 1
             } else if dual_available {
@@ -708,13 +719,6 @@ impl<F: PrimeField64> MemSM<F> {
                 // dual available
                 init_row = true;
                 if irow >= trace.num_rows() {
-                    println!(
-                        "MemSM: Warning: irow {irow} goes beyond trace num_rows {} for mem_op at \
-                        index {index} with addr 0x{:X} step {} {index}/{mem_op_count}",
-                        trace.num_rows(),
-                        mem_op.addr,
-                        mem_op.step
-                    );
                     break;
                 }
                 // set specific values of trace for regular memory operation
@@ -728,8 +732,6 @@ impl<F: PrimeField64> MemSM<F> {
             };
             if init_row {
                 if irow >= trace.num_rows() {
-                    println!("MemSM: Warning: irow {irow} goes beyond trace num_rows {} for mem_op at index {index} with addr 0x{:X} step {} {index}/{mem_op_count}",
-                        trace.num_rows(),mem_op.addr, mem_op.step);
                     break;
                 }
                 #[cfg(feature = "debug_mem")]
@@ -739,8 +741,6 @@ impl<F: PrimeField64> MemSM<F> {
                             &trace,
                             &format!("tmp/mem_trace_gpu_{segment_id:04}_dump.txt"),
                         );
-                        println!("MemSM: overriting non empty row {irow} for mem_op at index {index} with addr 0x{:X} => 0x{:X} step ({},{}) => {} {index}/{mem_op_count}",
-                    trace[irow].get_addr() * 8, mem_op.addr * 8, trace[irow].get_step(),trace[irow].get_step_dual(), mem_op.step);
                         break;
                     }
                     filled_rows[irow] = true;

--- a/state-machines/mem/src/mem_sm.rs
+++ b/state-machines/mem/src/mem_sm.rs
@@ -695,7 +695,7 @@ impl<F: PrimeField64> MemSM<F> {
                 debug_assert!(previous_addr < mem_op.addr as u64, "MemSM: Warning: address goes back \
                               or no change (on addr_changes path) from 0x{:X} to 0x{previous_addr:X} \
                               at irow {irow} (offset_base_addr_w: 0x{offset_base_addr_w:X})",
-                    mem_op.addr);
+                    mem_op.addr * 8, previous_addr * 8, offset_base_addr_w * 8);
                 mem_op.addr as u64 - previous_addr - 1
             } else if dual_available {
                 // It's dual read, not addr_changes.

--- a/state-machines/mem/src/mem_sm.rs
+++ b/state-machines/mem/src/mem_sm.rs
@@ -692,10 +692,15 @@ impl<F: PrimeField64> MemSM<F> {
                 let previous_addr: u64 = seg
                     .previous_change_addr_w(addr_index as u32)
                     .unwrap_or(previous_segment.addr as u64);
-                debug_assert!(previous_addr < mem_op.addr as u64, "MemSM: Warning: address goes back \
-                              or no change (on addr_changes path) from 0x{:X} to 0x{previous_addr:X} \
-                              at irow {irow} (offset_base_addr_w: 0x{offset_base_addr_w:X})",
-                    mem_op.addr * 8, previous_addr * 8, offset_base_addr_w * 8);
+                debug_assert!(
+                    previous_addr < mem_op.addr as u64,
+                    "MemSM: Warning: address goes back \
+                              or no change (on addr_changes path) from 0x{:X} to 0x{:X} \
+                              at irow {irow} (offset_base_addr_w: 0x{:X})",
+                    mem_op.addr * 8,
+                    previous_addr * 8,
+                    offset_base_addr_w * 8
+                );
                 mem_op.addr as u64 - previous_addr - 1
             } else if dual_available {
                 // It's dual read, not addr_changes.

--- a/state-machines/mem/src/rom_data_sm.rs
+++ b/state-machines/mem/src/rom_data_sm.rs
@@ -362,7 +362,7 @@ impl<F: PrimeField64> RomDataSM<F> {
             };
             #[cfg(debug_assertions)]
             {
-                assert!(!filled_rows[irow],"RomDataSM: overriting non empty row {irow} for mem_op with addr 0x{:X} => 0x{:X} step:{} => {}",
+                assert!(!filled_rows[irow],"RomDataSM: overwriting non empty row {irow} for mem_op with addr 0x{:X} => 0x{:X} step:{} => {}",
                     trace[irow].get_addr() * 8, mem_op.addr * 8, trace[irow].get_step(), mem_op.step);
                 filled_rows[irow] = true;
             }

--- a/state-machines/mem/src/rom_data_sm.rs
+++ b/state-machines/mem/src/rom_data_sm.rs
@@ -238,6 +238,12 @@ impl<F: PrimeField64> RomDataSM<F> {
             Self::save_to_file(&trace, &filename);
         }
 
+        #[cfg(feature = "debug_mem")]
+        Self::save_addr_offsets_to_file(
+            &trace,
+            &format!("tmp/rom_data_trace_{segment_id:04}_offsets.txt"),
+        );
+
         Self::dump_trace_to_file(
             &trace,
             &format!("tmp/rom_data_trace_legacy_{segment_id:04}_dump.txt"),
@@ -341,7 +347,7 @@ impl<F: PrimeField64> RomDataSM<F> {
             // first address == halo
         }
 
-        for (index, mem_op) in mem_ops.iter().enumerate() {
+        for mem_op in mem_ops.iter() {
             let addr_index = (mem_op.addr - offset_base_addr_w) as usize;
             let addr_changes = current_offsets[addr_index] == 0;
 
@@ -356,7 +362,7 @@ impl<F: PrimeField64> RomDataSM<F> {
             };
             #[cfg(debug_assertions)]
             {
-                assert!(!filled_rows[irow],"RomDataSM: overriting non empty row {irow} for mem_op at index {index} with addr 0x{:X} => 0x{:X} step:{} => {}",
+                assert!(!filled_rows[irow],"RomDataSM: overriting non empty row {irow} for mem_op with addr 0x{:X} => 0x{:X} step:{} => {}",
                     trace[irow].get_addr() * 8, mem_op.addr * 8, trace[irow].get_step(), mem_op.step);
                 filled_rows[irow] = true;
             }
@@ -499,6 +505,29 @@ impl<F: PrimeField64> RomDataSM<F> {
             )
             .unwrap();
         }
+    }
+
+    #[cfg(feature = "debug_mem")]
+    pub fn save_addr_offsets_to_file<R: RomDataTraceRowOps<F>>(
+        trace: &RomDataTrace<R>,
+        file_name: &str,
+    ) {
+        println!("[RomDataDebug] saving address offsets to {} .....", file_name);
+        let file = std::fs::File::create(file_name).unwrap();
+        let mut writer = std::io::BufWriter::new(file);
+        let num_rows = RomDataTrace::<R>::NUM_ROWS;
+
+        let mut last_addr = u32::MAX;
+        let mut first = true;
+        for i in 0..num_rows {
+            let addr = trace[i].get_addr();
+            if addr != last_addr {
+                writeln!(writer, "0x{:08X} {i}", addr * 8).unwrap();
+                last_addr = addr;
+            }
+        }
+        writeln!(writer).unwrap();
+        println!("[RomDataDebug] done");
     }
 }
 

--- a/state-machines/mem/src/rom_data_sm.rs
+++ b/state-machines/mem/src/rom_data_sm.rs
@@ -518,7 +518,6 @@ impl<F: PrimeField64> RomDataSM<F> {
         let num_rows = RomDataTrace::<R>::NUM_ROWS;
 
         let mut last_addr = u32::MAX;
-        let mut first = true;
         for i in 0..num_rows {
             let addr = trace[i].get_addr();
             if addr != last_addr {


### PR DESCRIPTION
Introduce a feature for calculating offsets in the asm_CPU path, enhancing memory management capabilities. This includes modifications to memory locator structures and the addition of methods for saving offsets to files for debugging purposes. The changes also involve updates to existing classes and methods to accommodate the new functionality.