### PR TITLE
fix: fill result with zeros when point addition or msm outputs infinity

### DIFF
--- a/ziskos/entrypoint/src/zisklib/lib/zkvm_accelerators.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/zkvm_accelerators.rs
@@ -198,6 +198,9 @@ pub unsafe extern "C" fn zkvm_bn254_g1_add(
             hints,
         );
         if matches!(ret, bn254::G1_ADD_SUCCESS | bn254::G1_ADD_SUCCESS_INFINITY) {
+            if ret == bn254::G1_ADD_SUCCESS_INFINITY {
+                (*result).data.fill(0);
+            }
             ZKVM_EOK
         } else {
             ZKVM_EFAIL
@@ -231,6 +234,9 @@ pub unsafe extern "C" fn zkvm_bn254_g1_add(
                     (*result).data.as_mut_ptr(),
                 );
                 return if matches!(ret, bn254::G1_ADD_SUCCESS | bn254::G1_ADD_SUCCESS_INFINITY) {
+                    if ret == bn254::G1_ADD_SUCCESS_INFINITY {
+                        (*result).data.fill(0);
+                    }
                     ZKVM_EOK
                 } else {
                     ZKVM_EFAIL
@@ -271,6 +277,9 @@ pub unsafe extern "C" fn zkvm_bn254_g1_mul(
             hints,
         );
         if matches!(ret, bn254::G1_MUL_SUCCESS | bn254::G1_MUL_SUCCESS_INFINITY) {
+            if ret == bn254::G1_MUL_SUCCESS_INFINITY {
+                (*result).data.fill(0);
+            }
             ZKVM_EOK
         } else {
             ZKVM_EFAIL
@@ -304,6 +313,9 @@ pub unsafe extern "C" fn zkvm_bn254_g1_mul(
                     (*result).data.as_mut_ptr(),
                 );
                 return if matches!(ret, bn254::G1_MUL_SUCCESS | bn254::G1_MUL_SUCCESS_INFINITY) {
+                    if ret == bn254::G1_MUL_SUCCESS_INFINITY {
+                        (*result).data.fill(0);
+                    }
                     ZKVM_EOK
                 } else {
                     ZKVM_EFAIL
@@ -547,6 +559,9 @@ pub unsafe extern "C" fn zkvm_bls12_g1_add(
             hints,
         );
         if matches!(ret, bls12_381::G1_ADD_SUCCESS | bls12_381::G1_ADD_SUCCESS_INFINITY) {
+            if ret == bls12_381::G1_ADD_SUCCESS_INFINITY {
+                (*result).data.fill(0);
+            }
             ZKVM_EOK
         } else {
             ZKVM_EFAIL
@@ -583,6 +598,9 @@ pub unsafe extern "C" fn zkvm_bls12_g1_add(
                     ret,
                     bls12_381::G1_ADD_SUCCESS | bls12_381::G1_ADD_SUCCESS_INFINITY
                 ) {
+                    if ret == bls12_381::G1_ADD_SUCCESS_INFINITY {
+                        (*result).data.fill(0);
+                    }
                     ZKVM_EOK
                 } else {
                     ZKVM_EFAIL
@@ -623,6 +641,9 @@ pub unsafe extern "C" fn zkvm_bls12_g1_msm(
             hints,
         );
         if matches!(ret, bls12_381::G1_MSM_SUCCESS | bls12_381::G1_MSM_SUCCESS_INFINITY) {
+            if ret == bls12_381::G1_MSM_SUCCESS_INFINITY {
+                (*result).data.fill(0);
+            }
             ZKVM_EOK
         } else {
             ZKVM_EFAIL
@@ -652,6 +673,9 @@ pub unsafe extern "C" fn zkvm_bls12_g1_msm(
                     ret,
                     bls12_381::G1_MSM_SUCCESS | bls12_381::G1_MSM_SUCCESS_INFINITY
                 ) {
+                    if ret == bls12_381::G1_MSM_SUCCESS_INFINITY {
+                        (*result).data.fill(0);
+                    }
                     ZKVM_EOK
                 } else {
                     ZKVM_EFAIL
@@ -692,6 +716,9 @@ pub unsafe extern "C" fn zkvm_bls12_g2_add(
             hints,
         );
         if matches!(ret, bls12_381::G2_ADD_SUCCESS | bls12_381::G2_ADD_SUCCESS_INFINITY) {
+            if ret == bls12_381::G2_ADD_SUCCESS_INFINITY {
+                (*result).data.fill(0);
+            }
             ZKVM_EOK
         } else {
             ZKVM_EFAIL
@@ -728,6 +755,9 @@ pub unsafe extern "C" fn zkvm_bls12_g2_add(
                     ret,
                     bls12_381::G2_ADD_SUCCESS | bls12_381::G2_ADD_SUCCESS_INFINITY
                 ) {
+                    if ret == bls12_381::G2_ADD_SUCCESS_INFINITY {
+                        (*result).data.fill(0);
+                    }
                     ZKVM_EOK
                 } else {
                     ZKVM_EFAIL
@@ -768,6 +798,9 @@ pub unsafe extern "C" fn zkvm_bls12_g2_msm(
             hints,
         );
         if matches!(ret, bls12_381::G2_MSM_SUCCESS | bls12_381::G2_MSM_SUCCESS_INFINITY) {
+            if ret == bls12_381::G2_MSM_SUCCESS_INFINITY {
+                (*result).data.fill(0);
+            }
             ZKVM_EOK
         } else {
             ZKVM_EFAIL
@@ -797,6 +830,9 @@ pub unsafe extern "C" fn zkvm_bls12_g2_msm(
                     ret,
                     bls12_381::G2_MSM_SUCCESS | bls12_381::G2_MSM_SUCCESS_INFINITY
                 ) {
+                    if ret == bls12_381::G2_MSM_SUCCESS_INFINITY {
+                        (*result).data.fill(0);
+                    }
                     ZKVM_EOK
                 } else {
                     ZKVM_EFAIL


### PR DESCRIPTION
On `*_SUCCESS_INFINITY` the `zkvm_accelerators.rs` returns `ZKVM_EOK` without zero-filling the `result` (according to EIP-196 and EIP-2537, the point at infinity is encoded as all zero bytes). This PR fixes that so both successful paths have `result` written.
