### PR TITLE
Fix false [gpu] version label from stale /usr/local/cuda directory

### DIFF
--- a/ziskbuild/build.rs
+++ b/ziskbuild/build.rs
@@ -18,7 +18,10 @@ fn main() {
     let compute_mode = if cpu_only {
         "cpu"
     } else {
-        let has_cuda = std::path::Path::new("/usr/local/cuda").exists()
+        // Check for nvcc itself, not just the directory: a stale /usr/local/cuda
+        // (e.g. old samples on macOS) must not flip the label to "gpu" when
+        // proofman-starks-lib-c's detection (which requires nvcc) builds CPU.
+        let has_cuda = std::path::Path::new("/usr/local/cuda/bin/nvcc").exists()
             || std::env::var("CUDA_HOME").is_ok()
             || std::process::Command::new("nvcc")
                 .arg("--version")


### PR DESCRIPTION
## Problem

`cargo-zisk --version` reported `[gpu]` on machines without a working CUDA toolkit. The CUDA auto-detection in `ziskbuild/build.rs` checks whether the `/usr/local/cuda` **directory** exists, so any stale leftover (e.g. an old CUDA samples directory on a Mac) flips the label to `gpu` — while `proofman-starks-lib-c`, whose detection requires `nvcc`, correctly builds the CPU library. Result: a CPU build labeled `[gpu]`.

## Fix

Check for `/usr/local/cuda/bin/nvcc` instead of just the directory, matching the detection logic in `proofman-starks-lib-c`'s build script. The `CUDA_HOME` and `nvcc`-on-PATH checks are unchanged.

Found while building natively on macOS arm64 (M2 Max), where a 2018-era `/usr/local/cuda` directory containing only CUDA samples triggered the false `[gpu]` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)