### PR TITLE
Fix error on proofval continuations constraints

### DIFF
--- a/pil/src/pil_helpers/traces.rs
+++ b/pil/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "8a7f02b69858918c67193fad74902edddcfebf739ae6d764b8c293815c649261";
+pub const PILOUT_HASH: &str = "9125bf5647309396e79051910953780ee93a5c99254e3425cd4325d7b1511adf";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 
@@ -26,69 +26,69 @@ pub const ZISK_AIRGROUP_ID: usize = 0;
 
 //AIR CONSTANTS
 
-pub const DMA_AIR_IDS: &[usize] = &[0];
+pub const MAIN_AIR_IDS: &[usize] = &[0];
 
-pub const DMA_MEM_CPY_AIR_IDS: &[usize] = &[1];
+pub const ROM_AIR_IDS: &[usize] = &[1];
 
-pub const DMA_INPUT_CPY_AIR_IDS: &[usize] = &[2];
+pub const MEM_AIR_IDS: &[usize] = &[2];
 
-pub const DMA_64_ALIGNED_AIR_IDS: &[usize] = &[3];
+pub const INPUT_DATA_AIR_IDS: &[usize] = &[3];
 
-pub const DMA_64_ALIGNED_INPUT_CPY_AIR_IDS: &[usize] = &[4];
+pub const ROM_DATA_AIR_IDS: &[usize] = &[4];
 
-pub const DMA_64_ALIGNED_MEM_SET_AIR_IDS: &[usize] = &[5];
+pub const MEM_ALIGN_AIR_IDS: &[usize] = &[5];
 
-pub const DMA_64_ALIGNED_MEM_AIR_IDS: &[usize] = &[6];
+pub const MEM_ALIGN_BYTE_AIR_IDS: &[usize] = &[6];
 
-pub const DMA_64_ALIGNED_MEM_CPY_AIR_IDS: &[usize] = &[7];
+pub const MEM_ALIGN_READ_BYTE_AIR_IDS: &[usize] = &[7];
 
-pub const DMA_UNALIGNED_AIR_IDS: &[usize] = &[8];
+pub const MEM_ALIGN_WRITE_BYTE_AIR_IDS: &[usize] = &[8];
 
-pub const DMA_PRE_POST_AIR_IDS: &[usize] = &[9];
+pub const ARITH_AIR_IDS: &[usize] = &[9];
 
-pub const DMA_PRE_POST_MEM_CPY_AIR_IDS: &[usize] = &[10];
+pub const BINARY_AIR_IDS: &[usize] = &[10];
 
-pub const DMA_PRE_POST_INPUT_CPY_AIR_IDS: &[usize] = &[11];
+pub const BINARY_ADD_AIR_IDS: &[usize] = &[11];
 
-pub const MAIN_AIR_IDS: &[usize] = &[12];
+pub const BINARY_EXTENSION_AIR_IDS: &[usize] = &[12];
 
-pub const ROM_AIR_IDS: &[usize] = &[13];
+pub const ADD_256_AIR_IDS: &[usize] = &[13];
 
-pub const MEM_AIR_IDS: &[usize] = &[14];
+pub const ARITH_EQ_AIR_IDS: &[usize] = &[14];
 
-pub const INPUT_DATA_AIR_IDS: &[usize] = &[15];
+pub const ARITH_EQ_384_AIR_IDS: &[usize] = &[15];
 
-pub const ROM_DATA_AIR_IDS: &[usize] = &[16];
+pub const KECCAKF_AIR_IDS: &[usize] = &[16];
 
-pub const MEM_ALIGN_AIR_IDS: &[usize] = &[17];
+pub const SHA_256_F_AIR_IDS: &[usize] = &[17];
 
-pub const MEM_ALIGN_BYTE_AIR_IDS: &[usize] = &[18];
+pub const POSEIDON_2_AIR_IDS: &[usize] = &[18];
 
-pub const MEM_ALIGN_READ_BYTE_AIR_IDS: &[usize] = &[19];
+pub const BLAKE_2_BR_AIR_IDS: &[usize] = &[19];
 
-pub const MEM_ALIGN_WRITE_BYTE_AIR_IDS: &[usize] = &[20];
+pub const DMA_AIR_IDS: &[usize] = &[20];
 
-pub const ARITH_AIR_IDS: &[usize] = &[21];
+pub const DMA_MEM_CPY_AIR_IDS: &[usize] = &[21];
 
-pub const BINARY_AIR_IDS: &[usize] = &[22];
+pub const DMA_INPUT_CPY_AIR_IDS: &[usize] = &[22];
 
-pub const BINARY_ADD_AIR_IDS: &[usize] = &[23];
+pub const DMA_64_ALIGNED_AIR_IDS: &[usize] = &[23];
 
-pub const BINARY_EXTENSION_AIR_IDS: &[usize] = &[24];
+pub const DMA_64_ALIGNED_INPUT_CPY_AIR_IDS: &[usize] = &[24];
 
-pub const ADD_256_AIR_IDS: &[usize] = &[25];
+pub const DMA_64_ALIGNED_MEM_SET_AIR_IDS: &[usize] = &[25];
 
-pub const ARITH_EQ_AIR_IDS: &[usize] = &[26];
+pub const DMA_64_ALIGNED_MEM_AIR_IDS: &[usize] = &[26];
 
-pub const ARITH_EQ_384_AIR_IDS: &[usize] = &[27];
+pub const DMA_64_ALIGNED_MEM_CPY_AIR_IDS: &[usize] = &[27];
 
-pub const KECCAKF_AIR_IDS: &[usize] = &[28];
+pub const DMA_UNALIGNED_AIR_IDS: &[usize] = &[28];
 
-pub const SHA_256_F_AIR_IDS: &[usize] = &[29];
+pub const DMA_PRE_POST_AIR_IDS: &[usize] = &[29];
 
-pub const POSEIDON_2_AIR_IDS: &[usize] = &[30];
+pub const DMA_PRE_POST_MEM_CPY_AIR_IDS: &[usize] = &[30];
 
-pub const BLAKE_2_BR_AIR_IDS: &[usize] = &[31];
+pub const DMA_PRE_POST_INPUT_CPY_AIR_IDS: &[usize] = &[31];
 
 pub const VIRTUAL_TABLE_ZISK_0_AIR_IDS: &[usize] = &[32];
 
@@ -136,357 +136,357 @@ values!(ZiskProofValues<F> {
  enable_input_data: F, enable_rom_data: F, enable_dma_64_aligned: F, enable_dma_64_aligned_inputcpy: F, enable_dma_64_aligned_mem: F, enable_dma_64_aligned_memcpy: F, enable_dma_64_aligned_memset: F, enable_dma_unaligned: F,
 });
  
-trace_row!(DmaFixedRow<F> {
- __L1__: F,
-});
-pub type DmaFixed<F> = GenericTrace<DmaFixedRow<F>, 2097152, 0, 0>;
-
-trace_row!(DmaTraceRow<F> {
- sel_memcpy:bit, sel_memcmp:bit, sel_memset:bit, fill_byte:u8, sel_extended:bit, sel_inputcpy:bit, h_count:ubit(24), count_lt_256:bit, l_count:ubit(9), count_diff_chunks:[u16; 2], h_dst64:ubit(22), l_dst64:ubit(7), dst_offset:ubit(3), main_step:ubit(36), h_src64:ubit(22), l_src64:ubit(7), src_offset:ubit(3), src_offset_after_pre:ubit(3), src64_inc_by_pre:bit, use_pre:bit, use_loop:bit, use_post:bit, pre_count:ubit(3), l_count64:ubit(9), pre_result_nz:bit, post_result_nz:bit, bus_pre_result:[u32; 2], bus_post_result:[u32; 2], loop_b0:u32, loop_extended_arg:u32, static_count:u32,
-});
-
-pub type DmaTrace<R> = GenericTrace<R, 2097152, 0, 0>;
-
-trace_row!(DmaMemCpyFixedRow<F> {
- __L1__: F,
-});
-pub type DmaMemCpyFixed<F> = GenericTrace<DmaMemCpyFixedRow<F>, 2097152, 0, 1>;
-
-trace_row!(DmaMemCpyTraceRow<F> {
- sel_memcpy:bit, sel_extended:bit, h_count:ubit(24), count_lt_256:bit, l_count:ubit(9), h_dst64:ubit(22), l_dst64:ubit(7), dst_offset:ubit(3), main_step:ubit(36), h_src64:ubit(22), l_src64:ubit(7), src_offset:ubit(3), src_offset_after_pre:ubit(3), src64_inc_by_pre:bit, use_pre:bit, use_loop:bit, use_post:bit, pre_count:ubit(3), l_count64:ubit(9), loop_b0:u32, loop_extended_arg:u32, static_count:u32,
-});
-
-pub type DmaMemCpyTrace<R> = GenericTrace<R, 2097152, 0, 1>;
-
-trace_row!(DmaInputCpyFixedRow<F> {
- __L1__: F,
-});
-pub type DmaInputCpyFixed<F> = GenericTrace<DmaInputCpyFixedRow<F>, 2097152, 0, 2>;
-
-trace_row!(DmaInputCpyTraceRow<F> {
- sel_extended:bit, sel_inputcpy:bit, h_count:ubit(24), count_lt_256:bit, l_count:ubit(9), h_dst64:ubit(22), l_dst64:ubit(7), dst_offset:ubit(3), main_step:ubit(36), use_pre:bit, use_loop:bit, use_post:bit, pre_count:ubit(3), l_count64:ubit(9), loop_b0:u32, static_count:u32,
-});
-
-pub type DmaInputCpyTrace<R> = GenericTrace<R, 2097152, 0, 2>;
-
-trace_row!(Dma64AlignedFixedRow<F> {
- __L1__: F,
-});
-pub type Dma64AlignedFixed<F> = GenericTrace<Dma64AlignedFixedRow<F>, 2097152, 0, 3>;
-
-trace_row!(Dma64AlignedTraceRow<F> {
- src64:ubit(29), seq_end:bit, previous_seq_end:bit, sel_memcpy:bit, sel_memeq:bit, sel_memset:bit, fill_byte:u8, sel_memcpy_count_load:bit, sel_inputcpy:bit, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 3], l_value_chunks:[[u8; 2]; 4], h_value_chunks:[[ubit(24); 2]; 4], sel_op_mem_load:[bit; 4],
-});
-
-pub type Dma64AlignedTrace<R> = GenericTrace<R, 2097152, 0, 3>;
-
-trace_row!(Dma64AlignedInputCpyFixedRow<F> {
- __L1__: F,
-});
-pub type Dma64AlignedInputCpyFixed<F> = GenericTrace<Dma64AlignedInputCpyFixedRow<F>, 2097152, 0, 4>;
-
-trace_row!(Dma64AlignedInputCpyTraceRow<F> {
- seq_end:bit, previous_seq_end:bit, sel_inputcpy:bit, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 3], l_value_chunks:[[u8; 2]; 4], h_value_chunks:[[ubit(24); 2]; 4],
-});
-
-pub type Dma64AlignedInputCpyTrace<R> = GenericTrace<R, 2097152, 0, 4>;
-
-trace_row!(Dma64AlignedMemSetFixedRow<F> {
- __L1__: F,
-});
-pub type Dma64AlignedMemSetFixed<F> = GenericTrace<Dma64AlignedMemSetFixedRow<F>, 2097152, 0, 5>;
-
-trace_row!(Dma64AlignedMemSetTraceRow<F> {
- seq_end:bit, previous_seq_end:bit, sel_memset:bit, fill_byte:u8, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 7],
-});
-
-pub type Dma64AlignedMemSetTrace<R> = GenericTrace<R, 2097152, 0, 5>;
-
-trace_row!(Dma64AlignedMemFixedRow<F> {
- __L1__: F,
-});
-pub type Dma64AlignedMemFixed<F> = GenericTrace<Dma64AlignedMemFixedRow<F>, 2097152, 0, 6>;
-
-trace_row!(Dma64AlignedMemTraceRow<F> {
- src64:ubit(29), seq_end:bit, previous_seq_end:bit, sel_memcpy:bit, sel_memeq:bit, sel_memset:bit, fill_byte:u8, sel_memcpy_count_load:bit, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 3], value:[[u32; 2]; 4], sel_op_mem_load:[bit; 4],
-});
-
-pub type Dma64AlignedMemTrace<R> = GenericTrace<R, 2097152, 0, 6>;
-
-trace_row!(Dma64AlignedMemCpyFixedRow<F> {
- __L1__: F,
-});
-pub type Dma64AlignedMemCpyFixed<F> = GenericTrace<Dma64AlignedMemCpyFixedRow<F>, 2097152, 0, 7>;
-
-trace_row!(Dma64AlignedMemCpyTraceRow<F> {
- src64:ubit(29), seq_end:bit, previous_seq_end:bit, sel_memcpy:bit, sel_memcpy_count_load:bit, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 7], value:[[u32; 2]; 8],
-});
-
-pub type Dma64AlignedMemCpyTrace<R> = GenericTrace<R, 2097152, 0, 7>;
-
-trace_row!(DmaUnalignedFixedRow<F> {
- __L1__: F,
-});
-pub type DmaUnalignedFixed<F> = GenericTrace<DmaUnalignedFixedRow<F>, 2097152, 0, 8>;
-
-trace_row!(DmaUnalignedTraceRow<F> {
- main_step:ubit(36), src64:ubit(29), dst64:ubit(29), count:u32, seq_end:bit, previous_seq_end:bit, is_memeq:bit, offset_7:bit, offset_6:bit, offset_5:bit, offset_4:bit, offset_3:bit, offset_2:bit, read_bytes:[u8; 8], no_last_no_seq_end:bit, write_value:[u32; 2],
-});
-
-pub type DmaUnalignedTrace<R> = GenericTrace<R, 2097152, 0, 8>;
-
-trace_row!(DmaPrePostFixedRow<F> {
- __L1__: F,
-});
-pub type DmaPrePostFixed<F> = GenericTrace<DmaPrePostFixedRow<F>, 2097152, 0, 9>;
-
-trace_row!(DmaPrePostTraceRow<F> {
- main_step:ubit(36), dst64:ubit(29), dst_offset:ubit(3), count:ubit(4), is_post:bit, sel_memcpy:bit, sel_memcmp:bit, memcmp_result_nz:bit, l_memcmp_result:u32, sel_inputcpy:bit, sel_memset:bit, selr:[bit; 7], dst_offset_gt_src_offset:bit, src64:ubit(29), src_offset:ubit(3), enabled_second_read:bit, fill_byte:u8, rb:[u8; 16], pb:[u8; 8], sb:[bit; 8], last_dst_byte:u8, abs_diff_dst_src:u8, memcmp_result_is_negative:bit, diff_factor:[u64; 2], bus_write_value:[u32; 2], write_value:[u32; 4],
-});
-
-pub type DmaPrePostTrace<R> = GenericTrace<R, 2097152, 0, 9>;
-
-trace_row!(DmaPrePostMemCpyFixedRow<F> {
- __L1__: F,
-});
-pub type DmaPrePostMemCpyFixed<F> = GenericTrace<DmaPrePostMemCpyFixedRow<F>, 2097152, 0, 10>;
-
-trace_row!(DmaPrePostMemCpyTraceRow<F> {
- main_step:ubit(36), dst64:ubit(29), dst_offset:ubit(3), count:ubit(4), is_post:bit, sel_memcpy:bit, selr:[bit; 7], dst_offset_gt_src_offset:bit, src64:ubit(29), src_offset:ubit(3), enabled_second_read:bit, rb:[u8; 16], pb:[u8; 8], sb:[bit; 8], bus_write_value:[u32; 2], write_value:[u32; 4],
-});
-
-pub type DmaPrePostMemCpyTrace<R> = GenericTrace<R, 2097152, 0, 10>;
-
-trace_row!(DmaPrePostInputCpyFixedRow<F> {
- __L1__: F,
-});
-pub type DmaPrePostInputCpyFixed<F> = GenericTrace<DmaPrePostInputCpyFixedRow<F>, 2097152, 0, 11>;
-
-trace_row!(DmaPrePostInputCpyTraceRow<F> {
- main_step:ubit(36), dst64:ubit(29), dst_offset:ubit(3), count:ubit(4), is_post:bit, sel_inputcpy:bit, rb:[u8; 8], pb:[u8; 8], sb:[bit; 8], bus_write_value:[u32; 2],
-});
-
-pub type DmaPrePostInputCpyTrace<R> = GenericTrace<R, 2097152, 0, 11>;
-
 trace_row!(MainFixedRow<F> {
  SEGMENT_L1: F, SEGMENT_STEP: F, __L1__: F,
 });
-pub type MainFixed<F> = GenericTrace<MainFixedRow<F>, 4194304, 0, 12>;
+pub type MainFixed<F> = GenericTrace<MainFixedRow<F>, 4194304, 0, 0>;
 
 trace_row!(MainTraceRow<F> {
  a:[u32; 2], b:[u32; 2], c:[u32; 2], flag:bit, pc:u32, a_src_imm:bit, a_src_mem:bit, a_offset_imm0:u64, a_imm1:u32, is_precompiled:bit, b_src_imm:bit, b_src_mem:bit, b_offset_imm0:u64, b_imm1:u32, b_src_ind:bit, ind_width:ubit(4), is_external_op:bit, op:u8, store_pc:bit, store_mem:bit, store_ind:bit, store_offset:u64, set_pc:bit, jmp_offset1:u64, jmp_offset2:u64, m32:bit, addr1:u32, a_reg_prev_mem_step:ubit(38), b_reg_prev_mem_step:ubit(38), store_reg_prev_mem_step:ubit(38), store_reg_prev_value:[u32; 2], a_src_reg:bit, b_src_reg:bit, store_reg:bit,
 });
 
-pub type MainTrace<R> = GenericTrace<R, 4194304, 0, 12>;
+pub type MainTrace<R> = GenericTrace<R, 4194304, 0, 0>;
 
 trace_row!(RomFixedRow<F> {
  __L1__: F,
 });
-pub type RomFixed<F> = GenericTrace<RomFixedRow<F>, 4194304, 0, 13>;
+pub type RomFixed<F> = GenericTrace<RomFixedRow<F>, 4194304, 0, 1>;
 
 trace_row!(RomTraceRow<F> {
  multiplicity:F,
 });
 
-pub type RomTrace<F> = GenericTrace<RomTraceRow<F>, 4194304, 0, 13>;
+pub type RomTrace<F> = GenericTrace<RomTraceRow<F>, 4194304, 0, 1>;
 
 trace_row!(MemFixedRow<F> {
  SEGMENT_L1: F, __L1__: F,
 });
-pub type MemFixed<F> = GenericTrace<MemFixedRow<F>, 4194304, 0, 14>;
+pub type MemFixed<F> = GenericTrace<MemFixedRow<F>, 4194304, 0, 2>;
 
 trace_row!(MemTraceRow<F> {
  addr:ubit(29), step:ubit(38), sel:bit, addr_changes:bit, step_dual:ubit(38), sel_dual:bit, value:[u32; 2], wr:bit, previous_step:ubit(40), l_increment:ubit(22), h_increment:u16, read_same_addr:bit,
 });
 
-pub type MemTrace<R> = GenericTrace<R, 4194304, 0, 14>;
+pub type MemTrace<R> = GenericTrace<R, 4194304, 0, 2>;
 
 trace_row!(InputDataFixedRow<F> {
  SEGMENT_L1: F, __L1__: F,
 });
-pub type InputDataFixed<F> = GenericTrace<InputDataFixedRow<F>, 2097152, 0, 15>;
+pub type InputDataFixed<F> = GenericTrace<InputDataFixedRow<F>, 2097152, 0, 3>;
 
 trace_row!(InputDataTraceRow<F> {
  addr:ubit(29), step:ubit(38), sel:bit, addr_changes:bit, value_word:[u16; 4], is_free_read:bit,
 });
 
-pub type InputDataTrace<R> = GenericTrace<R, 2097152, 0, 15>;
+pub type InputDataTrace<R> = GenericTrace<R, 2097152, 0, 3>;
 
 trace_row!(RomDataFixedRow<F> {
  __L1__: F,
 });
-pub type RomDataFixed<F> = GenericTrace<RomDataFixedRow<F>, 2097152, 0, 16>;
+pub type RomDataFixed<F> = GenericTrace<RomDataFixedRow<F>, 2097152, 0, 4>;
 
 trace_row!(RomDataTraceRow<F> {
  addr_change:bit, addr:ubit(29), step:ubit(40), value:[u32; 2],
 });
 
-pub type RomDataTrace<R> = GenericTrace<R, 2097152, 0, 16>;
+pub type RomDataTrace<R> = GenericTrace<R, 2097152, 0, 4>;
 
 trace_row!(MemAlignFixedRow<F> {
  L1: F, __L1__: F,
 });
-pub type MemAlignFixed<F> = GenericTrace<MemAlignFixedRow<F>, 2097152, 0, 17>;
+pub type MemAlignFixed<F> = GenericTrace<MemAlignFixedRow<F>, 2097152, 0, 5>;
 
 trace_row!(MemAlignTraceRow<F> {
  addr:ubit(29), offset:ubit(3), width:ubit(4), wr:bit, pc:u8, reset:bit, sel_up_to_down:bit, sel_down_to_up:bit, reg:[u8; 8], sel:[bit; 8], step:ubit(40), delta_addr:u64, sel_prove:bit, value:[u32; 2],
 });
 
-pub type MemAlignTrace<R> = GenericTrace<R, 2097152, 0, 17>;
+pub type MemAlignTrace<R> = GenericTrace<R, 2097152, 0, 5>;
 
 trace_row!(MemAlignByteFixedRow<F> {
  __L1__: F,
 });
-pub type MemAlignByteFixed<F> = GenericTrace<MemAlignByteFixedRow<F>, 4194304, 0, 18>;
+pub type MemAlignByteFixed<F> = GenericTrace<MemAlignByteFixedRow<F>, 4194304, 0, 6>;
 
 trace_row!(MemAlignByteTraceRow<F> {
  sel_high_4b:bit, sel_high_2b:bit, sel_high_b:bit, direct_value:u32, composed_value:u32, written_composed_value:u32, written_byte_value:u8, value_16b:u16, value_8b:u8, byte_value:u8, addr_w:ubit(29), step:ubit(40), is_write:bit, mem_write_values:[u32; 2], bus_byte:u8,
 });
 
-pub type MemAlignByteTrace<R> = GenericTrace<R, 4194304, 0, 18>;
+pub type MemAlignByteTrace<R> = GenericTrace<R, 4194304, 0, 6>;
 
 trace_row!(MemAlignReadByteFixedRow<F> {
  __L1__: F,
 });
-pub type MemAlignReadByteFixed<F> = GenericTrace<MemAlignReadByteFixedRow<F>, 4194304, 0, 19>;
+pub type MemAlignReadByteFixed<F> = GenericTrace<MemAlignReadByteFixedRow<F>, 4194304, 0, 7>;
 
 trace_row!(MemAlignReadByteTraceRow<F> {
  sel_high_4b:bit, sel_high_2b:bit, sel_high_b:bit, direct_value:u32, composed_value:u32, value_16b:u16, value_8b:u8, byte_value:u8, addr_w:ubit(29), step:ubit(40),
 });
 
-pub type MemAlignReadByteTrace<R> = GenericTrace<R, 4194304, 0, 19>;
+pub type MemAlignReadByteTrace<R> = GenericTrace<R, 4194304, 0, 7>;
 
 trace_row!(MemAlignWriteByteFixedRow<F> {
  __L1__: F,
 });
-pub type MemAlignWriteByteFixed<F> = GenericTrace<MemAlignWriteByteFixedRow<F>, 4194304, 0, 20>;
+pub type MemAlignWriteByteFixed<F> = GenericTrace<MemAlignWriteByteFixedRow<F>, 4194304, 0, 8>;
 
 trace_row!(MemAlignWriteByteTraceRow<F> {
  sel_high_4b:bit, sel_high_2b:bit, sel_high_b:bit, direct_value:u32, composed_value:u32, written_composed_value:u32, written_byte_value:u8, value_16b:u16, value_8b:u8, byte_value:u8, addr_w:ubit(29), step:ubit(40), mem_write_values:[u32; 2],
 });
 
-pub type MemAlignWriteByteTrace<R> = GenericTrace<R, 4194304, 0, 20>;
+pub type MemAlignWriteByteTrace<R> = GenericTrace<R, 4194304, 0, 8>;
 
 trace_row!(ArithFixedRow<F> {
  __L1__: F,
 });
-pub type ArithFixed<F> = GenericTrace<ArithFixedRow<F>, 2097152, 0, 21>;
+pub type ArithFixed<F> = GenericTrace<ArithFixedRow<F>, 2097152, 0, 9>;
 
 trace_row!(ArithTraceRow<F> {
  carry:[u64; 7], a:[u16; 4], b:[u16; 4], c:[u16; 4], d:[u16; 4], na:bit, nb:bit, nr:bit, np:bit, sext:bit, m32:bit, div:bit, fab:u64, na_fb:u64, nb_fa:u64, main_div:bit, main_mul:bit, signed:bit, div_by_zero:bit, div_overflow_mul_rz:bit, inv_sum_all_bs:u64, op:u8, bus_res1:u32, multiplicity:bit, range_ab:ubit(7), range_cd:ubit(7),
 });
 
-pub type ArithTrace<R> = GenericTrace<R, 2097152, 0, 21>;
+pub type ArithTrace<R> = GenericTrace<R, 2097152, 0, 9>;
 
 trace_row!(BinaryFixedRow<F> {
  __L1__: F,
 });
-pub type BinaryFixed<F> = GenericTrace<BinaryFixedRow<F>, 4194304, 0, 22>;
+pub type BinaryFixed<F> = GenericTrace<BinaryFixedRow<F>, 4194304, 0, 10>;
 
 trace_row!(BinaryTraceRow<F> {
  b_op:ubit(7), free_in_a:[u8; 8], free_in_b:[u8; 8], free_in_c:[u8; 8], carry:[ubit(2); 8], mode32:bit, result_is_a:bit, use_first_byte:bit, c_is_signed:bit, b_op_or_sext:ubit(10), mode32_and_c_is_signed:bit,
 });
 
-pub type BinaryTrace<R> = GenericTrace<R, 4194304, 0, 22>;
+pub type BinaryTrace<R> = GenericTrace<R, 4194304, 0, 10>;
 
 trace_row!(BinaryAddFixedRow<F> {
  __L1__: F,
 });
-pub type BinaryAddFixed<F> = GenericTrace<BinaryAddFixedRow<F>, 4194304, 0, 23>;
+pub type BinaryAddFixed<F> = GenericTrace<BinaryAddFixedRow<F>, 4194304, 0, 11>;
 
 trace_row!(BinaryAddTraceRow<F> {
  a:[u32; 2], b:[u32; 2], c_chunks:[u16; 4], cout:[bit; 2],
 });
 
-pub type BinaryAddTrace<R> = GenericTrace<R, 4194304, 0, 23>;
+pub type BinaryAddTrace<R> = GenericTrace<R, 4194304, 0, 11>;
 
 trace_row!(BinaryExtensionFixedRow<F> {
  __L1__: F,
 });
-pub type BinaryExtensionFixed<F> = GenericTrace<BinaryExtensionFixedRow<F>, 4194304, 0, 24>;
+pub type BinaryExtensionFixed<F> = GenericTrace<BinaryExtensionFixedRow<F>, 4194304, 0, 12>;
 
 trace_row!(BinaryExtensionTraceRow<F> {
  op:ubit(6), free_in_a:[u8; 8], free_in_b:u8, free_in_c:[[u32; 2]; 8], op_is_shift:bit, b:[u32; 2],
 });
 
-pub type BinaryExtensionTrace<R> = GenericTrace<R, 4194304, 0, 24>;
+pub type BinaryExtensionTrace<R> = GenericTrace<R, 4194304, 0, 12>;
 
 trace_row!(Add256FixedRow<F> {
  __L1__: F,
 });
-pub type Add256Fixed<F> = GenericTrace<Add256FixedRow<F>, 1048576, 0, 25>;
+pub type Add256Fixed<F> = GenericTrace<Add256FixedRow<F>, 1048576, 0, 13>;
 
 trace_row!(Add256TraceRow<F> {
  a:[[u32; 2]; 4], b:[[u32; 2]; 4], c_chunks:[[u16; 4]; 4], cout:[[bit; 2]; 4], addr_params:u32, addr_a:u32, addr_b:u32, addr_c:u32, step:ubit(40), cin:bit, sel:bit,
 });
 
-pub type Add256Trace<R> = GenericTrace<R, 1048576, 0, 25>;
+pub type Add256Trace<R> = GenericTrace<R, 1048576, 0, 13>;
 
 trace_row!(ArithEqFixedRow<F> {
  CLK_0: F, __L1__: F,
 });
-pub type ArithEqFixed<F> = GenericTrace<ArithEqFixedRow<F>, 1048576, 0, 26>;
+pub type ArithEqFixed<F> = GenericTrace<ArithEqFixedRow<F>, 1048576, 0, 14>;
 
 trace_row!(ArithEqTraceRow<F> {
  x1:u16, y1:u16, x2:u16, y2:u16, x3:u16, y3:u16, q0:ubit(22), q1:ubit(22), q2:ubit(22), s:ubit(22), sel_op:[bit; 11], sel_op_clk0:[bit; 11], x_delta_chunk_inv:u64, x_are_different:bit, x3_lt:bit, y3_lt:bit, delta_x3:u64, delta_y3:u64, carry:[[u64; 2]; 3], step_addr:ubit(40),
 });
 
-pub type ArithEqTrace<R> = GenericTrace<R, 1048576, 0, 26>;
+pub type ArithEqTrace<R> = GenericTrace<R, 1048576, 0, 14>;
 
 trace_row!(ArithEq384FixedRow<F> {
  CLK_0: F, __L1__: F,
 });
-pub type ArithEq384Fixed<F> = GenericTrace<ArithEq384FixedRow<F>, 1048576, 0, 27>;
+pub type ArithEq384Fixed<F> = GenericTrace<ArithEq384FixedRow<F>, 1048576, 0, 15>;
 
 trace_row!(ArithEq384TraceRow<F> {
  x1:u16, y1:u16, x2:u16, y2:u16, x3:u16, y3:u16, q0:ubit(22), q1:ubit(22), q2:ubit(22), s:ubit(22), sel_op:[bit; 6], sel_op_clk0:[bit; 6], x_delta_chunk_inv:u64, x_are_different:bit, x3_lt:bit, y3_lt:bit, delta_x3:u64, delta_y3:u64, carry:[[u64; 2]; 3], step_addr:ubit(40),
 });
 
-pub type ArithEq384Trace<R> = GenericTrace<R, 1048576, 0, 27>;
+pub type ArithEq384Trace<R> = GenericTrace<R, 1048576, 0, 15>;
 
 trace_row!(KeccakfFixedRow<F> {
  CLK_0: F, __L1__: F,
 });
-pub type KeccakfFixed<F> = GenericTrace<KeccakfFixedRow<F>, 131072, 0, 28>;
+pub type KeccakfFixed<F> = GenericTrace<KeccakfFixedRow<F>, 131072, 0, 16>;
 
 trace_row!(KeccakfTraceRow<F> {
  in_use:bit, in_use_clk_0:bit, state:[bit; 1600], chunk_acc:[ubit(22); 534], step_addr:ubit(40),
 });
 
-pub type KeccakfTrace<R> = GenericTrace<R, 131072, 0, 28>;
+pub type KeccakfTrace<R> = GenericTrace<R, 131072, 0, 16>;
 
 trace_row!(Sha256fFixedRow<F> {
  CLK_0: F, __L1__: F,
 });
-pub type Sha256fFixed<F> = GenericTrace<Sha256fFixedRow<F>, 262144, 0, 29>;
+pub type Sha256fFixed<F> = GenericTrace<Sha256fFixedRow<F>, 262144, 0, 17>;
 
 trace_row!(Sha256fTraceRow<F> {
  a:[bit; 32], e:[bit; 32], w:[bit; 32], new_a_carry_bits:u8, new_e_carry_bits:u8, new_w_carry_bits:ubit(4), step_addr:ubit(40), in_use:bit, in_use_clk_0:bit,
 });
 
-pub type Sha256fTrace<R> = GenericTrace<R, 262144, 0, 29>;
+pub type Sha256fTrace<R> = GenericTrace<R, 262144, 0, 17>;
 
 trace_row!(Poseidon2FixedRow<F> {
  CLK_0: F, __L1__: F,
 });
-pub type Poseidon2Fixed<F> = GenericTrace<Poseidon2FixedRow<F>, 131072, 0, 30>;
+pub type Poseidon2Fixed<F> = GenericTrace<Poseidon2FixedRow<F>, 131072, 0, 18>;
 
 trace_row!(Poseidon2TraceRow<F> {
  in_use:bit, in_use_clk_0:bit, chunks:[[u32; 2]; 16], step_addr:ubit(40),
 });
 
-pub type Poseidon2Trace<R> = GenericTrace<R, 131072, 0, 30>;
+pub type Poseidon2Trace<R> = GenericTrace<R, 131072, 0, 18>;
 
 trace_row!(Blake2brFixedRow<F> {
  CLK_0: F, MSG_IDX: F, __L1__: F,
 });
-pub type Blake2brFixed<F> = GenericTrace<Blake2brFixedRow<F>, 262144, 0, 31>;
+pub type Blake2brFixed<F> = GenericTrace<Blake2brFixedRow<F>, 262144, 0, 19>;
 
 trace_row!(Blake2brTraceRow<F> {
  in_use:bit, round_idx:ubit(4), round_idx_sel:[bit; 10], sigma_idx:ubit(4), m_limbs:[[u16; 2]; 2], ms:[u32; 2], perm_active:bit, g_active:bit, va_limbs:[[u16; 2]; 2], vc_limbs:[[u16; 2]; 2], vb:[[bit; 32]; 2], vd:[[bit; 32]; 2], step_addr:ubit(40), in_use_clk_0:bit,
 });
 
-pub type Blake2brTrace<R> = GenericTrace<R, 262144, 0, 31>;
+pub type Blake2brTrace<R> = GenericTrace<R, 262144, 0, 19>;
+
+trace_row!(DmaFixedRow<F> {
+ __L1__: F,
+});
+pub type DmaFixed<F> = GenericTrace<DmaFixedRow<F>, 2097152, 0, 20>;
+
+trace_row!(DmaTraceRow<F> {
+ sel_memcpy:bit, sel_memcmp:bit, sel_memset:bit, fill_byte:u8, sel_extended:bit, sel_inputcpy:bit, h_count:ubit(24), count_lt_256:bit, l_count:ubit(9), count_diff_chunks:[u16; 2], h_dst64:ubit(22), l_dst64:ubit(7), dst_offset:ubit(3), main_step:ubit(36), h_src64:ubit(22), l_src64:ubit(7), src_offset:ubit(3), src_offset_after_pre:ubit(3), src64_inc_by_pre:bit, use_pre:bit, use_loop:bit, use_post:bit, pre_count:ubit(3), l_count64:ubit(9), pre_result_nz:bit, post_result_nz:bit, bus_pre_result:[u32; 2], bus_post_result:[u32; 2], loop_b0:u32, loop_extended_arg:u32, static_count:u32,
+});
+
+pub type DmaTrace<R> = GenericTrace<R, 2097152, 0, 20>;
+
+trace_row!(DmaMemCpyFixedRow<F> {
+ __L1__: F,
+});
+pub type DmaMemCpyFixed<F> = GenericTrace<DmaMemCpyFixedRow<F>, 2097152, 0, 21>;
+
+trace_row!(DmaMemCpyTraceRow<F> {
+ sel_memcpy:bit, sel_extended:bit, h_count:ubit(24), count_lt_256:bit, l_count:ubit(9), h_dst64:ubit(22), l_dst64:ubit(7), dst_offset:ubit(3), main_step:ubit(36), h_src64:ubit(22), l_src64:ubit(7), src_offset:ubit(3), src_offset_after_pre:ubit(3), src64_inc_by_pre:bit, use_pre:bit, use_loop:bit, use_post:bit, pre_count:ubit(3), l_count64:ubit(9), loop_b0:u32, loop_extended_arg:u32, static_count:u32,
+});
+
+pub type DmaMemCpyTrace<R> = GenericTrace<R, 2097152, 0, 21>;
+
+trace_row!(DmaInputCpyFixedRow<F> {
+ __L1__: F,
+});
+pub type DmaInputCpyFixed<F> = GenericTrace<DmaInputCpyFixedRow<F>, 2097152, 0, 22>;
+
+trace_row!(DmaInputCpyTraceRow<F> {
+ sel_extended:bit, sel_inputcpy:bit, h_count:ubit(24), count_lt_256:bit, l_count:ubit(9), h_dst64:ubit(22), l_dst64:ubit(7), dst_offset:ubit(3), main_step:ubit(36), use_pre:bit, use_loop:bit, use_post:bit, pre_count:ubit(3), l_count64:ubit(9), loop_b0:u32, static_count:u32,
+});
+
+pub type DmaInputCpyTrace<R> = GenericTrace<R, 2097152, 0, 22>;
+
+trace_row!(Dma64AlignedFixedRow<F> {
+ __L1__: F,
+});
+pub type Dma64AlignedFixed<F> = GenericTrace<Dma64AlignedFixedRow<F>, 2097152, 0, 23>;
+
+trace_row!(Dma64AlignedTraceRow<F> {
+ src64:ubit(29), seq_end:bit, previous_seq_end:bit, sel_memcpy:bit, sel_memeq:bit, sel_memset:bit, fill_byte:u8, sel_memcpy_count_load:bit, sel_inputcpy:bit, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 3], l_value_chunks:[[u8; 2]; 4], h_value_chunks:[[ubit(24); 2]; 4], sel_op_mem_load:[bit; 4],
+});
+
+pub type Dma64AlignedTrace<R> = GenericTrace<R, 2097152, 0, 23>;
+
+trace_row!(Dma64AlignedInputCpyFixedRow<F> {
+ __L1__: F,
+});
+pub type Dma64AlignedInputCpyFixed<F> = GenericTrace<Dma64AlignedInputCpyFixedRow<F>, 2097152, 0, 24>;
+
+trace_row!(Dma64AlignedInputCpyTraceRow<F> {
+ seq_end:bit, previous_seq_end:bit, sel_inputcpy:bit, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 3], l_value_chunks:[[u8; 2]; 4], h_value_chunks:[[ubit(24); 2]; 4],
+});
+
+pub type Dma64AlignedInputCpyTrace<R> = GenericTrace<R, 2097152, 0, 24>;
+
+trace_row!(Dma64AlignedMemSetFixedRow<F> {
+ __L1__: F,
+});
+pub type Dma64AlignedMemSetFixed<F> = GenericTrace<Dma64AlignedMemSetFixedRow<F>, 2097152, 0, 25>;
+
+trace_row!(Dma64AlignedMemSetTraceRow<F> {
+ seq_end:bit, previous_seq_end:bit, sel_memset:bit, fill_byte:u8, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 7],
+});
+
+pub type Dma64AlignedMemSetTrace<R> = GenericTrace<R, 2097152, 0, 25>;
+
+trace_row!(Dma64AlignedMemFixedRow<F> {
+ __L1__: F,
+});
+pub type Dma64AlignedMemFixed<F> = GenericTrace<Dma64AlignedMemFixedRow<F>, 2097152, 0, 26>;
+
+trace_row!(Dma64AlignedMemTraceRow<F> {
+ src64:ubit(29), seq_end:bit, previous_seq_end:bit, sel_memcpy:bit, sel_memeq:bit, sel_memset:bit, fill_byte:u8, sel_memcpy_count_load:bit, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 3], value:[[u32; 2]; 4], sel_op_mem_load:[bit; 4],
+});
+
+pub type Dma64AlignedMemTrace<R> = GenericTrace<R, 2097152, 0, 26>;
+
+trace_row!(Dma64AlignedMemCpyFixedRow<F> {
+ __L1__: F,
+});
+pub type Dma64AlignedMemCpyFixed<F> = GenericTrace<Dma64AlignedMemCpyFixedRow<F>, 2097152, 0, 27>;
+
+trace_row!(Dma64AlignedMemCpyTraceRow<F> {
+ src64:ubit(29), seq_end:bit, previous_seq_end:bit, sel_memcpy:bit, sel_memcpy_count_load:bit, main_step:ubit(36), dst64:ubit(29), count64:u32, sel_op_from_1:[bit; 7], value:[[u32; 2]; 8],
+});
+
+pub type Dma64AlignedMemCpyTrace<R> = GenericTrace<R, 2097152, 0, 27>;
+
+trace_row!(DmaUnalignedFixedRow<F> {
+ __L1__: F,
+});
+pub type DmaUnalignedFixed<F> = GenericTrace<DmaUnalignedFixedRow<F>, 2097152, 0, 28>;
+
+trace_row!(DmaUnalignedTraceRow<F> {
+ main_step:ubit(36), src64:ubit(29), dst64:ubit(29), count:u32, seq_end:bit, previous_seq_end:bit, is_memeq:bit, offset_7:bit, offset_6:bit, offset_5:bit, offset_4:bit, offset_3:bit, offset_2:bit, read_bytes:[u8; 8], no_last_no_seq_end:bit, write_value:[u32; 2],
+});
+
+pub type DmaUnalignedTrace<R> = GenericTrace<R, 2097152, 0, 28>;
+
+trace_row!(DmaPrePostFixedRow<F> {
+ __L1__: F,
+});
+pub type DmaPrePostFixed<F> = GenericTrace<DmaPrePostFixedRow<F>, 2097152, 0, 29>;
+
+trace_row!(DmaPrePostTraceRow<F> {
+ main_step:ubit(36), dst64:ubit(29), dst_offset:ubit(3), count:ubit(4), is_post:bit, sel_memcpy:bit, sel_memcmp:bit, memcmp_result_nz:bit, l_memcmp_result:u32, sel_inputcpy:bit, sel_memset:bit, selr:[bit; 7], dst_offset_gt_src_offset:bit, src64:ubit(29), src_offset:ubit(3), enabled_second_read:bit, fill_byte:u8, rb:[u8; 16], pb:[u8; 8], sb:[bit; 8], last_dst_byte:u8, abs_diff_dst_src:u8, memcmp_result_is_negative:bit, diff_factor:[u64; 2], bus_write_value:[u32; 2], write_value:[u32; 4],
+});
+
+pub type DmaPrePostTrace<R> = GenericTrace<R, 2097152, 0, 29>;
+
+trace_row!(DmaPrePostMemCpyFixedRow<F> {
+ __L1__: F,
+});
+pub type DmaPrePostMemCpyFixed<F> = GenericTrace<DmaPrePostMemCpyFixedRow<F>, 2097152, 0, 30>;
+
+trace_row!(DmaPrePostMemCpyTraceRow<F> {
+ main_step:ubit(36), dst64:ubit(29), dst_offset:ubit(3), count:ubit(4), is_post:bit, sel_memcpy:bit, selr:[bit; 7], dst_offset_gt_src_offset:bit, src64:ubit(29), src_offset:ubit(3), enabled_second_read:bit, rb:[u8; 16], pb:[u8; 8], sb:[bit; 8], bus_write_value:[u32; 2], write_value:[u32; 4],
+});
+
+pub type DmaPrePostMemCpyTrace<R> = GenericTrace<R, 2097152, 0, 30>;
+
+trace_row!(DmaPrePostInputCpyFixedRow<F> {
+ __L1__: F,
+});
+pub type DmaPrePostInputCpyFixed<F> = GenericTrace<DmaPrePostInputCpyFixedRow<F>, 2097152, 0, 31>;
+
+trace_row!(DmaPrePostInputCpyTraceRow<F> {
+ main_step:ubit(36), dst64:ubit(29), dst_offset:ubit(3), count:ubit(4), is_post:bit, sel_inputcpy:bit, rb:[u8; 8], pb:[u8; 8], sb:[bit; 8], bus_write_value:[u32; 2],
+});
+
+pub type DmaPrePostInputCpyTrace<R> = GenericTrace<R, 2097152, 0, 31>;
 
 trace_row!(VirtualTableZisk0FixedRow<F> {
  UID: [F; 23], column: [F; 64], __L1__: F,
@@ -513,32 +513,8 @@ pub type VirtualTableZisk1Trace<F> = GenericTrace<VirtualTableZisk1TraceRow<F>, 
 trace_row!(RomRomTraceRow<F> {
  is_data: F, line: F, a_offset_imm0: F, a_imm1: F, b_offset_imm0: F, b_imm1: F, ind_width: F, op: F, store_offset: F, jmp_offset1: F, jmp_offset2: F, flags: F,
 });
-pub type RomRomTrace<F> = GenericTrace<RomRomTraceRow<F>, 4194304, 0, 13, 0>;
+pub type RomRomTrace<F> = GenericTrace<RomRomTraceRow<F>, 4194304, 0, 1, 0>;
 
-
-values!(Dma64AlignedAirValues<F> {
- segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, segment_previous_src64: F, segment_last_src64: F, segment_previous_fill_byte: F, segment_last_fill_byte: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
-});
-
-values!(Dma64AlignedInputCpyAirValues<F> {
- segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
-});
-
-values!(Dma64AlignedMemSetAirValues<F> {
- segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, segment_previous_fill_byte: F, segment_last_fill_byte: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
-});
-
-values!(Dma64AlignedMemAirValues<F> {
- segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, segment_previous_src64: F, segment_last_src64: F, segment_previous_fill_byte: F, segment_last_fill_byte: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
-});
-
-values!(Dma64AlignedMemCpyAirValues<F> {
- segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, segment_previous_src64: F, segment_last_src64: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
-});
-
-values!(DmaUnalignedAirValues<F> {
- segment_id: F, segment_previous_seq_end: F, segment_previous_src64: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_offset: F, segment_previous_count: F, segment_first_bytes: [F; 8], segment_last_seq_end: F, segment_last_src64: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_offset: F, segment_last_count: F, segment_next_bytes: [F; 8], is_last_segment: F, segment_previous_is_memeq: F, segment_last_is_memeq: F, padding_size: F, last_count_chunk: [F; 2], im_direct: [FieldExtension<F>; 6],
-});
 
 values!(MainAirValues<F> {
  main_last_segment: F, main_segment: F, segment_initial_pc: F, segment_previous_c: [F; 2], segment_next_pc: F, segment_last_c: [F; 2], last_reg_value: [[F; 2]; 31], last_reg_mem_step: [F; 31], im_direct: [FieldExtension<F>; 96],
@@ -580,52 +556,28 @@ values!(BinaryExtensionAirValues<F> {
  padding_size: F, im_direct: [FieldExtension<F>; 1],
 });
 
-values!(DmaAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
+values!(Dma64AlignedAirValues<F> {
+ segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, segment_previous_src64: F, segment_last_src64: F, segment_previous_fill_byte: F, segment_last_fill_byte: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
 });
 
-values!(DmaMemCpyAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
+values!(Dma64AlignedInputCpyAirValues<F> {
+ segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
 });
 
-values!(DmaInputCpyAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
+values!(Dma64AlignedMemSetAirValues<F> {
+ segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, segment_previous_fill_byte: F, segment_last_fill_byte: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
 });
 
-values!(Dma64AlignedAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
+values!(Dma64AlignedMemAirValues<F> {
+ segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, segment_previous_src64: F, segment_last_src64: F, segment_previous_fill_byte: F, segment_last_fill_byte: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
 });
 
-values!(Dma64AlignedInputCpyAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
+values!(Dma64AlignedMemCpyAirValues<F> {
+ segment_id: F, segment_previous_seq_end: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_count64: F, segment_previous_flags: F, segment_last_seq_end: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_count64: F, segment_last_flags: F, is_last_segment: F, segment_previous_src64: F, segment_last_src64: F, last_count_chunk: [F; 2], padding_size: F, im_direct: [FieldExtension<F>; 5],
 });
 
-values!(Dma64AlignedMemSetAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
-});
-
-values!(Dma64AlignedMemAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
-});
-
-values!(Dma64AlignedMemCpyAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
-});
-
-values!(DmaUnalignedAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
-});
-
-values!(DmaPrePostAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
-});
-
-values!(DmaPrePostMemCpyAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
-});
-
-values!(DmaPrePostInputCpyAirGroupValues<F> {
- gsum_result: FieldExtension<F>,
+values!(DmaUnalignedAirValues<F> {
+ segment_id: F, segment_previous_seq_end: F, segment_previous_src64: F, segment_previous_dst64: F, segment_previous_main_step: F, segment_previous_offset: F, segment_previous_count: F, segment_first_bytes: [F; 8], segment_last_seq_end: F, segment_last_src64: F, segment_last_dst64: F, segment_last_main_step: F, segment_last_offset: F, segment_last_count: F, segment_next_bytes: [F; 8], is_last_segment: F, segment_previous_is_memeq: F, segment_last_is_memeq: F, padding_size: F, last_count_chunk: [F; 2], im_direct: [FieldExtension<F>; 6],
 });
 
 values!(MainAirGroupValues<F> {
@@ -708,6 +660,54 @@ values!(Blake2brAirGroupValues<F> {
  gsum_result: FieldExtension<F>,
 });
 
+values!(DmaAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(DmaMemCpyAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(DmaInputCpyAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(Dma64AlignedAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(Dma64AlignedInputCpyAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(Dma64AlignedMemSetAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(Dma64AlignedMemAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(Dma64AlignedMemCpyAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(DmaUnalignedAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(DmaPrePostAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(DmaPrePostMemCpyAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
+values!(DmaPrePostInputCpyAirGroupValues<F> {
+ gsum_result: FieldExtension<F>,
+});
+
 values!(VirtualTableZisk0AirGroupValues<F> {
  gsum_result: FieldExtension<F>,
 });
@@ -719,157 +719,157 @@ values!(VirtualTableZisk1AirGroupValues<F> {
 pub const PACKED_INFO: &[(usize, usize, PackedInfoConst)] = &[
     (0, 0, PackedInfoConst {
         is_packed: true,
-        num_packed_words: 7,
-        unpack_info: &[1, 1, 1, 8, 1, 1, 24, 1, 9, 16, 16, 22, 7, 3, 36, 22, 7, 3, 3, 1, 1, 1, 1, 3, 9, 1, 1, 32, 32, 32, 32, 32, 32, 32],
-    }),
-    (0, 1, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 4,
-        unpack_info: &[1, 1, 24, 1, 9, 22, 7, 3, 36, 22, 7, 3, 3, 1, 1, 1, 1, 3, 9, 32, 32, 32],
-    }),
-    (0, 2, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 3,
-        unpack_info: &[1, 1, 24, 1, 9, 22, 7, 3, 36, 1, 1, 1, 3, 9, 32, 32],
-    }),
-    (0, 3, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 7,
-        unpack_info: &[29, 1, 1, 1, 1, 1, 8, 1, 1, 36, 29, 32, 1, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 24, 24, 24, 24, 24, 24, 24, 24, 1, 1, 1, 1],
-    }),
-    (0, 4, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 6,
-        unpack_info: &[1, 1, 1, 36, 29, 32, 1, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 24, 24, 24, 24, 24, 24, 24, 24],
-    }),
-    (0, 5, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 2,
-        unpack_info: &[1, 1, 1, 8, 36, 29, 32, 1, 1, 1, 1, 1, 1, 1],
-    }),
-    (0, 6, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 7,
-        unpack_info: &[29, 1, 1, 1, 1, 1, 8, 1, 36, 29, 32, 1, 1, 1, 32, 32, 32, 32, 32, 32, 32, 32, 1, 1, 1, 1],
-    }),
-    (0, 7, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 11,
-        unpack_info: &[29, 1, 1, 1, 1, 36, 29, 32, 1, 1, 1, 1, 1, 1, 1, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32],
-    }),
-    (0, 8, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 5,
-        unpack_info: &[36, 29, 29, 32, 1, 1, 1, 1, 1, 1, 1, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 1, 32, 32],
-    }),
-    (0, 9, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 11,
-        unpack_info: &[36, 29, 3, 4, 1, 1, 1, 1, 32, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 29, 3, 1, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1, 8, 8, 1, 64, 64, 32, 32, 32, 32, 32, 32],
-    }),
-    (0, 10, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 8,
-        unpack_info: &[36, 29, 3, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 29, 3, 1, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1, 32, 32, 32, 32, 32, 32],
-    }),
-    (0, 11, PackedInfoConst {
-        is_packed: true,
-        num_packed_words: 5,
-        unpack_info: &[36, 29, 3, 4, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1, 32, 32],
-    }),
-    (0, 12, PackedInfoConst {
-        is_packed: true,
         num_packed_words: 14,
         unpack_info: &[32, 32, 32, 32, 32, 32, 1, 32, 1, 1, 64, 32, 1, 1, 1, 64, 32, 1, 4, 1, 8, 1, 1, 1, 64, 1, 64, 64, 1, 32, 38, 38, 38, 32, 32, 1, 1, 1],
     }),
-    (0, 14, PackedInfoConst {
+    (0, 2, PackedInfoConst {
         is_packed: true,
         num_packed_words: 4,
         unpack_info: &[29, 38, 1, 1, 38, 1, 32, 32, 1, 40, 22, 16, 1],
     }),
-    (0, 15, PackedInfoConst {
+    (0, 3, PackedInfoConst {
         is_packed: true,
         num_packed_words: 3,
         unpack_info: &[29, 38, 1, 1, 16, 16, 16, 16, 1],
     }),
-    (0, 16, PackedInfoConst {
+    (0, 4, PackedInfoConst {
         is_packed: true,
         num_packed_words: 3,
         unpack_info: &[1, 29, 40, 32, 32],
     }),
-    (0, 17, PackedInfoConst {
+    (0, 5, PackedInfoConst {
         is_packed: true,
         num_packed_words: 5,
         unpack_info: &[29, 3, 4, 1, 8, 1, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1, 40, 64, 1, 32, 32],
     }),
-    (0, 18, PackedInfoConst {
+    (0, 6, PackedInfoConst {
         is_packed: true,
         num_packed_words: 5,
         unpack_info: &[1, 1, 1, 32, 32, 32, 8, 16, 8, 8, 29, 40, 1, 32, 32, 8],
     }),
-    (0, 19, PackedInfoConst {
+    (0, 7, PackedInfoConst {
         is_packed: true,
         num_packed_words: 3,
         unpack_info: &[1, 1, 1, 32, 32, 16, 8, 8, 29, 40],
     }),
-    (0, 20, PackedInfoConst {
+    (0, 8, PackedInfoConst {
         is_packed: true,
         num_packed_words: 5,
         unpack_info: &[1, 1, 1, 32, 32, 32, 8, 16, 8, 8, 29, 40, 32, 32],
     }),
-    (0, 21, PackedInfoConst {
+    (0, 9, PackedInfoConst {
         is_packed: true,
         num_packed_words: 17,
         unpack_info: &[64, 64, 64, 64, 64, 64, 64, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 1, 1, 1, 1, 1, 1, 1, 64, 64, 64, 1, 1, 1, 1, 1, 64, 8, 32, 1, 7, 7],
     }),
-    (0, 22, PackedInfoConst {
+    (0, 10, PackedInfoConst {
         is_packed: true,
         num_packed_words: 4,
         unpack_info: &[7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 10, 1],
     }),
-    (0, 23, PackedInfoConst {
+    (0, 11, PackedInfoConst {
         is_packed: true,
         num_packed_words: 4,
         unpack_info: &[32, 32, 32, 32, 16, 16, 16, 16, 1, 1],
     }),
-    (0, 24, PackedInfoConst {
+    (0, 12, PackedInfoConst {
         is_packed: true,
         num_packed_words: 11,
         unpack_info: &[6, 8, 8, 8, 8, 8, 8, 8, 8, 8, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 1, 32, 32],
     }),
-    (0, 25, PackedInfoConst {
+    (0, 13, PackedInfoConst {
         is_packed: true,
         num_packed_words: 15,
         unpack_info: &[32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 1, 1, 1, 1, 1, 1, 1, 1, 32, 32, 32, 32, 40, 1, 1],
     }),
-    (0, 26, PackedInfoConst {
+    (0, 14, PackedInfoConst {
         is_packed: true,
         num_packed_words: 13,
         unpack_info: &[16, 16, 16, 16, 16, 16, 22, 22, 22, 22, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 64, 1, 1, 1, 64, 64, 64, 64, 64, 64, 64, 64, 40],
     }),
-    (0, 27, PackedInfoConst {
+    (0, 15, PackedInfoConst {
         is_packed: true,
         num_packed_words: 13,
         unpack_info: &[16, 16, 16, 16, 16, 16, 22, 22, 22, 22, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 64, 1, 1, 1, 64, 64, 64, 64, 64, 64, 64, 64, 40],
     }),
-    (0, 28, PackedInfoConst {
+    (0, 16, PackedInfoConst {
         is_packed: true,
         num_packed_words: 210,
         unpack_info: &[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 40],
     }),
-    (0, 29, PackedInfoConst {
+    (0, 17, PackedInfoConst {
         is_packed: true,
         num_packed_words: 3,
         unpack_info: &[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 8, 8, 4, 40, 1, 1],
     }),
-    (0, 30, PackedInfoConst {
+    (0, 18, PackedInfoConst {
         is_packed: true,
         num_packed_words: 17,
         unpack_info: &[1, 1, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 40],
     }),
-    (0, 31, PackedInfoConst {
+    (0, 19, PackedInfoConst {
         is_packed: true,
         num_packed_words: 7,
         unpack_info: &[1, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 16, 16, 16, 16, 32, 32, 1, 1, 16, 16, 16, 16, 16, 16, 16, 16, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 40, 1],
+    }),
+    (0, 20, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 7,
+        unpack_info: &[1, 1, 1, 8, 1, 1, 24, 1, 9, 16, 16, 22, 7, 3, 36, 22, 7, 3, 3, 1, 1, 1, 1, 3, 9, 1, 1, 32, 32, 32, 32, 32, 32, 32],
+    }),
+    (0, 21, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 4,
+        unpack_info: &[1, 1, 24, 1, 9, 22, 7, 3, 36, 22, 7, 3, 3, 1, 1, 1, 1, 3, 9, 32, 32, 32],
+    }),
+    (0, 22, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 3,
+        unpack_info: &[1, 1, 24, 1, 9, 22, 7, 3, 36, 1, 1, 1, 3, 9, 32, 32],
+    }),
+    (0, 23, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 7,
+        unpack_info: &[29, 1, 1, 1, 1, 1, 8, 1, 1, 36, 29, 32, 1, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 24, 24, 24, 24, 24, 24, 24, 24, 1, 1, 1, 1],
+    }),
+    (0, 24, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 6,
+        unpack_info: &[1, 1, 1, 36, 29, 32, 1, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 24, 24, 24, 24, 24, 24, 24, 24],
+    }),
+    (0, 25, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 2,
+        unpack_info: &[1, 1, 1, 8, 36, 29, 32, 1, 1, 1, 1, 1, 1, 1],
+    }),
+    (0, 26, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 7,
+        unpack_info: &[29, 1, 1, 1, 1, 1, 8, 1, 36, 29, 32, 1, 1, 1, 32, 32, 32, 32, 32, 32, 32, 32, 1, 1, 1, 1],
+    }),
+    (0, 27, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 11,
+        unpack_info: &[29, 1, 1, 1, 1, 36, 29, 32, 1, 1, 1, 1, 1, 1, 1, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32],
+    }),
+    (0, 28, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 5,
+        unpack_info: &[36, 29, 29, 32, 1, 1, 1, 1, 1, 1, 1, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 1, 32, 32],
+    }),
+    (0, 29, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 11,
+        unpack_info: &[36, 29, 3, 4, 1, 1, 1, 1, 32, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 29, 3, 1, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1, 8, 8, 1, 64, 64, 32, 32, 32, 32, 32, 32],
+    }),
+    (0, 30, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 8,
+        unpack_info: &[36, 29, 3, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 29, 3, 1, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1, 32, 32, 32, 32, 32, 32],
+    }),
+    (0, 31, PackedInfoConst {
+        is_packed: true,
+        num_packed_words: 5,
+        unpack_info: &[36, 29, 3, 4, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1, 32, 32],
     }),
 ];

--- a/pil/zisk.pil
+++ b/pil/zisk.pil
@@ -33,29 +33,25 @@ require "blake2/pil/blake2br.pil"
 
 enable_range_stats();
 
+// Selectors for continuations
 proofval enable_input_data;
-enable_input_data * (1 - enable_input_data);
-
 proofval enable_rom_data;
-enable_rom_data * (1 - enable_rom_data);
-
 proofval enable_dma_64_aligned;
-enable_dma_64_aligned * (1 - enable_dma_64_aligned);
-
 proofval enable_dma_64_aligned_inputcpy;
-enable_dma_64_aligned_inputcpy * (1 - enable_dma_64_aligned_inputcpy);
-
 proofval enable_dma_64_aligned_mem;
-enable_dma_64_aligned_mem * (1 - enable_dma_64_aligned_mem);
-
 proofval enable_dma_64_aligned_memcpy;
-enable_dma_64_aligned_memcpy * (1 - enable_dma_64_aligned_memcpy);
-
 proofval enable_dma_64_aligned_memset;
-enable_dma_64_aligned_memset * (1 - enable_dma_64_aligned_memset);
-
 proofval enable_dma_unaligned;
-enable_dma_unaligned * (1 - enable_dma_unaligned);
+
+// Binary constraints to continuations enable proofvals
+enable_input_data * (1 - enable_input_data) === 0;
+enable_rom_data * (1 - enable_rom_data) === 0;
+enable_dma_64_aligned * (1 - enable_dma_64_aligned) === 0;
+enable_dma_64_aligned_inputcpy * (1 - enable_dma_64_aligned_inputcpy) === 0;
+enable_dma_64_aligned_mem * (1 - enable_dma_64_aligned_mem) === 0;
+enable_dma_64_aligned_memcpy * (1 - enable_dma_64_aligned_memcpy) === 0;
+enable_dma_64_aligned_memset * (1 - enable_dma_64_aligned_memset) === 0; 
+enable_dma_unaligned * (1 - enable_dma_unaligned) === 0;
 
 const int PUBLIC_INPUTS_64_BITS = 32;  // 32 x 64 bits = 2048 bits
 public inputs[PUBLIC_INPUTS_64_BITS * 2]; // 2 x 32-bits = 64 bits
@@ -70,32 +66,9 @@ airgroup Zisk {
     set_max_bits_virtual_tables(21);
     set_num_virtual_tables(2);
 
-    virtual DualRange(id: DUAL_RANGE_7_BITS_ID, min1: 0, max1: P2_7-1, min2: 0, max2: P2_7-1) alias DualRange7Bits;
-    virtual DualRange(id: DUAL_RANGE_BYTE_ID, min1: 0, max1: P2_8-1, min2: 0, max2: P2_8-1) alias DualByte;
-
-    Dma();
-    Dma(enable: E_DMA_MEMCPY) alias DmaMemCpy;
-    Dma(enable: E_DMA_INPUTCPY) alias DmaInputCpy;
-
-    Dma64Aligned(enable_flag: enable_dma_64_aligned);
-    Dma64Aligned(enable: E_DMA_INPUTCPY, enable_flag: enable_dma_64_aligned_inputcpy) alias Dma64AlignedInputCpy;
-    Dma64Aligned(enable: E_DMA_MEMSET, enable_flag: enable_dma_64_aligned_memset, op_x_row: 8) alias Dma64AlignedMemSet;
-    Dma64Aligned(enable: E_DMA_MEMCPY|E_DMA_MEMCMP|E_DMA_MEMSET, enable_flag: enable_dma_64_aligned_mem) alias Dma64AlignedMem;
-    Dma64Aligned(enable: E_DMA_MEMCPY, enable_flag: enable_dma_64_aligned_memcpy, op_x_row: 8) alias Dma64AlignedMemCpy;
-
-    DmaUnaligned(enable_flag: enable_dma_unaligned);
-
-    DmaPrePost();
-    DmaPrePost(enable: E_DMA_MEMCPY) alias DmaPrePostMemCpy;
-    DmaPrePost(enable: E_DMA_INPUTCPY) alias DmaPrePostInputCpy;
-
-    virtual DmaByteCmpTable();
-    virtual DmaRom();
-    virtual DmaPrePostTable();
     // Main Program
     Main(N: 2**22);
     Rom(N: 2**22);
-    
 
     // Memory
     Mem(N: 2**22, base_address: 0xA000_0000, size_mb: 512, large_mem: 1, dual_mem: 1);
@@ -140,6 +113,28 @@ airgroup Zisk {
     Poseidon2(N: 2**17);
 
     Blake2br(N: 2**18);
+
+    Dma();
+    Dma(enable: E_DMA_MEMCPY) alias DmaMemCpy;
+    Dma(enable: E_DMA_INPUTCPY) alias DmaInputCpy;
+
+    Dma64Aligned(enable_flag: enable_dma_64_aligned);
+    Dma64Aligned(enable: E_DMA_INPUTCPY, enable_flag: enable_dma_64_aligned_inputcpy) alias Dma64AlignedInputCpy;
+    Dma64Aligned(enable: E_DMA_MEMSET, enable_flag: enable_dma_64_aligned_memset, op_x_row: 8) alias Dma64AlignedMemSet;
+    Dma64Aligned(enable: E_DMA_MEMCPY|E_DMA_MEMCMP|E_DMA_MEMSET, enable_flag: enable_dma_64_aligned_mem) alias Dma64AlignedMem;
+    Dma64Aligned(enable: E_DMA_MEMCPY, enable_flag: enable_dma_64_aligned_memcpy, op_x_row: 8) alias Dma64AlignedMemCpy;
+
+    DmaUnaligned(enable_flag: enable_dma_unaligned);
+
+    DmaPrePost();
+    DmaPrePost(enable: E_DMA_MEMCPY) alias DmaPrePostMemCpy;
+    DmaPrePost(enable: E_DMA_INPUTCPY) alias DmaPrePostInputCpy;
+
+    virtual DmaByteCmpTable();
+    virtual DmaRom();
+    virtual DmaPrePostTable();
+    virtual DualRange(id: DUAL_RANGE_7_BITS_ID, min1: 0, max1: P2_7-1, min2: 0, max2: P2_7-1) alias DualRange7Bits;
+    virtual DualRange(id: DUAL_RANGE_BYTE_ID, min1: 0, max1: P2_8-1, min2: 0, max2: P2_8-1) alias DualByte;
 
     // Public Inputs
     for (int i = 0; i < PUBLIC_INPUTS_64_BITS; i++) {

--- a/state-machines/arith/pil/arith.pil
+++ b/state-machines/arith/pil/arith.pil
@@ -5,9 +5,6 @@ require "opids.pil"
 require "arith_table.pil"
 require "arith_range_table.pil"
 
-//          full   mul_64  full_32  mul_32
-// TOTAL      88       77       57      44
-
 airtemplate Arith(const int N = 2**18) {
 
     const int CHUNK_SIZE = 2**16;
@@ -64,19 +61,20 @@ airtemplate Arith(const int N = 2**18) {
         sum_all_bs = sum_all_bs + b[i];                 // all b are values of 16 bits (verified by range_check)
     }
 
-    // when div_by_zero, a it's free, with this force a must be 0xFFFF
+    // when div_by_zero = 1, a (quotient) it's free (a * 0), with this force a must be 0xFFFF
     div_by_zero * (a[0] - 0xFFFF) === 0;
     div_by_zero * (a[1] - 0xFFFF) === 0;
     div_by_zero * (a[2] - (1 - m32) * 0xFFFF) === 0;
     div_by_zero * (a[3] - (1 - m32) * 0xFFFF) === 0;
 
-    // when div_by_zero, a it's free, with this force a must be 0xFFFF
+    // overflow => -MAX / -1 = non-representable number because signed integers are asymmetric
+    // when div_overflow = 1 the divisor must be -1 (0xFF...FF)
     div_overflow * (b[0] - 0xFFFF) === 0;
     div_overflow * (b[1] - 0xFFFF) === 0;
     div_overflow * (b[2] - (1 - m32) * 0xFFFF) === 0;
     div_overflow * (b[3] - (1 - m32) * 0xFFFF) === 0;
 
-    // when div_by_zero, a it's free, with this force a must be 0xFFFF
+    // when div_overflow = 1 then dividend must be 0x800..000
     div_overflow * c[0] === 0;
     div_overflow * (c[1] - m32 * 0x8000) === 0;
     div_overflow * c[2] === 0;

--- a/state-machines/main/pil/main.pil
+++ b/state-machines/main/pil/main.pil
@@ -77,8 +77,8 @@ airtemplate Main(int N = 2**21, int RC = 2, int stack_enabled = 0,
     airval segment_last_c[RC];         // Last value stored in current instance.
 
     if (stack_enabled) {
-        airval segment_initial_sp;     // Initial value of `sp`, it matches the `sp` value at row 0.
-        airval segment_next_sp;        // The initial `sp` of next instance.
+        airval air.segment_initial_sp;     // Initial value of `sp`, it matches the `sp` value at row 0.
+        airval air.segment_next_sp;        // The initial `sp` of next instance.
     }
 
     // main_last_segment is a boolean value
@@ -480,16 +480,30 @@ airtemplate Main(int N = 2**21, int RC = 2, int stack_enabled = 0,
     b_src_reg * (1 - b_src_reg) === 0;
     store_reg * (1 - store_reg) === 0;
 
-    const expr rom_flags = 1 + 2 * a_src_imm + 4 * a_src_mem + 8 * is_precompiled + 16 * b_src_imm
-                           + 32 * b_src_mem + 64 * is_external_op + 128 * store_pc + 256 * store_mem
-                           + 512 * store_ind + 1024 * set_pc + 2048 * m32 + 4096 * b_src_ind
-                           + 8192 * a_src_reg + 16384 * b_src_reg + 32768 * store_reg;
+    expr _flags = 1 + 2 * a_src_imm + 2**2 * a_src_mem + 2**3 * is_precompiled + 2**4 * b_src_imm
+                  + 2**5 * b_src_mem + 2**6 * is_external_op + 2**7 * store_pc + 2**8 * store_mem
+                  + 2**9 * store_ind + 2**10 * set_pc + 2**11 * m32 + 2**12 * b_src_ind
+                  + 2**13 * a_src_reg + 2**14 * b_src_reg + 2**15 * store_reg;
+
+    if (stack_enabled) {
+        a_src_sp * (1 - a_src_sp) === 0;
+        store_use_sp * (1 - store_use_sp) === 0;
+        set_sp * (1 - set_sp) === 0;
+
+        _flags = _flags + 2**20 * a_src_sp + 2**21 * store_use_sp + 2**22 * set_sp;
+    }
+
+    const expr rom_flags = _flags;
 
     // Lookup in ROM to ensure that only program instructions are executed.
 
-    lookup_assumes(ROM_BUS_ID, [pc, a_offset_imm0, a_imm1, b_offset_imm0, b_imm1, ind_width,
-                                op, store_offset, jmp_offset1, jmp_offset2, rom_flags]);
-
+    if (stack_enabled) {
+        lookup_assumes(ROM_BUS_ID, [pc, a_offset_imm0, a_use_sp_imm1, b_offset_imm0, b_use_sp_imm1, ind_width,
+                                    op, store_offset, jmp_offset1, jmp_offset2, inc_sp, rom_flags]);
+    } else {
+        lookup_assumes(ROM_BUS_ID, [pc, a_offset_imm0, a_imm1, b_offset_imm0, b_imm1, ind_width,
+                                    op, store_offset, jmp_offset1, jmp_offset2, rom_flags]);
+    }
     // Continuations between segments, we assume initial state and proves the final state.
 
     // The next segment increments the current segment by one, except for the last segment, which

--- a/state-machines/rom/pil/rom.pil
+++ b/state-machines/rom/pil/rom.pil
@@ -2,7 +2,7 @@ require "std_lookup.pil"
 require "opids.pil"
 public rom_root[4];
 
-airtemplate Rom(const int N = 2**21, const int rom_bus_id = ROM_BUS_ID) {
+airtemplate Rom(const int N = 2**21, const int rom_bus_id = ROM_BUS_ID, int stack_enabled = 0) {
     commit stage(0) public(rom_root) rom;
 
                              // CODE            DATA
@@ -18,11 +18,19 @@ airtemplate Rom(const int N = 2**21, const int rom_bus_id = ROM_BUS_ID) {
     col rom jmp_offset1;     // jmp_offset1     value[3][1]
     col rom jmp_offset2;     
     col rom flags;           // flags           mem_op = MEMORY_ROM_INIT_OP|MEMORY_STORE _OP 
+    if (stack_enabled) {
+        col rom air.inc_sp;
+    }
 
     col witness multiplicity;
 
-    lookup_proves(rom_bus_id, [line, a_offset_imm0, a_imm1, b_offset_imm0, b_imm1, ind_width,
-                                op, store_offset, jmp_offset1, jmp_offset2, flags], mul: multiplicity);
+    if (stack_enabled) {
+        lookup_proves(rom_bus_id, [line, a_offset_imm0, a_imm1, b_offset_imm0, b_imm1, ind_width,
+                                    op, store_offset, jmp_offset1, jmp_offset2, inc_sp, flags], mul: multiplicity);
+    } else {
+        lookup_proves(rom_bus_id, [line, a_offset_imm0, a_imm1, b_offset_imm0, b_imm1, ind_width,
+                                    op, store_offset, jmp_offset1, jmp_offset2, flags], mul: multiplicity);
+    }
     
     is_data * multiplicity === 0; // data rows don't use rom program lines multiplicity.
 


### PR DESCRIPTION
## Fixes

- Fixed incorrect constraints used to enable continuations for `input_data`, `rom_data`, and `dma`.
- Fixed latent bug in `main` where `stack_enabled=1` was set on witness binaries that lacked the corresponding binary constraint.
- When `stack_enabled` is not configured, the ROM lookup no longer includes the SP-specific columns that are only relevant when the stack is active.
- Fixed several stale/incorrect comments.
- Reorganized `zisk`: moved DMA machines to the end, placing the main machines at the top.