### PR TITLE
fix(mem-align): constrain step across sub-program rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,6 +1756,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derivative"
@@ -6157,11 +6160,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.48"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1aa89044e7786ffb2ec017acb22cb7de5b0be46d0f21aea2b224b8561e5db2"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -6173,15 +6177,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.28"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3bfe86347f0cc659f586f01e26303ccd32418f26f30c7b0309b3ca3a07d695"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ categories = ["cryptography"]
 [workspace.metadata]
 gha_package_setup_version = "pre-develop-1.0.0-beta"
 gha_zisk_testvectors_branch = "develop-0.3.0"
-gha_zisk_ethproofs_branch = "pre-develop-1.0.0-beta"
-gha_zisk_eth_client_branch = "pre-develop-1.0.0-beta"
+gha_zisk_ethproofs_branch = "develop-0.10.0"
+gha_zisk_eth_client_branch = "develop-0.10.0"
 gha_zisk_template_branch = "pre-develop-1.0.0-beta"
 
 [workspace]

--- a/pil/src/pil_helpers/traces.rs
+++ b/pil/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "7345862427a49630e80074810890e2cd62f6435fa30b09357c930e98ceab0f8d";
+pub const PILOUT_HASH: &str = "e0eba363372313c7ee099cdbaa73f41d219eac982f53ab31d9edf87b4644a44e";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 

--- a/state-machines/mem/pil/mem_align.pil
+++ b/state-machines/mem/pil/mem_align.pil
@@ -106,16 +106,41 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
 
     // 1] Ensure the MemAlign follows the program
 
-    // Registers should be bytes and be shuch that:
+    // Registers should be bytes and be such that:
     //  - reg' == reg in transitions R -> V, R -> W, W -> V,
-    //  - 'reg == reg in transitions V <- W, W <- R,
-    // in any case, sel_up_to_down,sel_down_to_up are 0 in [V] steps.
+    //  - 'reg == reg in transitions V <- R, W <- R, V <- W,
+    // in any case, sel_up_to_down and sel_down_to_up must be 0 in [V] rows.
     for (int i = 0; i < CHUNK_NUM; i++) {
         range_check(reg[i], 0, 2**CHUNK_BITS-1);
 
         (reg[i]' - reg[i]) * sel[i] * sel_up_to_down === 0;
         ('reg[i] - reg[i]) * sel[i] * sel_down_to_up === 0;
     }
+
+
+    // The step is constant within a sub-program except on the two,
+    // aligned-write rows which sit one step above it:
+    //  - step == 'step     in transitions R -> V, V <- R,
+    //  - step == 'step + 1 in transitions R -> W, V <- W,
+    //  - step == 'step - 1 in transitions W -> V, W <- R,
+    //
+    //  | Program | Row | reset | wr | U2D | D2U |     constraint    |
+    //  |---------|-----|-------|----|-----|-----|-------------------|
+    //  |  RV     |  R  |   1   |  0 | 1   | 0   |    0 == 0         |
+    //  |  RV     |  V  |   0   |  0 | 0   | 0   | step == 'step     |
+    //  |  RWV    |  R  |   1   |  0 | 1   | 0   |    0 == 0         |
+    //  |  RWV    |  W  |   0   |  1 | 1   | 0   | step == 'step + 1 |
+    //  |  RWV    |  V  |   0   |  1 | 0   | 0   | step == 'step - 1 |
+    //  |  RVR    |  R  |   1   |  0 | 1   | 0   |    0 == 0         |
+    //  |  RVR    |  V  |   0   |  0 | 0   | 0   | step == 'step     |
+    //  |  RVR    |  R  |   0   |  0 | 0   | 1   | step == 'step     |
+    //  |  RWVWR  |  R  |   1   |  0 | 1   | 0   |    0 == 0         |
+    //  |  RWVWR  |  W  |   0   |  1 | 1   | 0   | step == 'step + 1 |
+    //  |  RWVWR  |  V  |   0   |  1 | 0   | 0   | step == 'step - 1 |
+    //  |  RWVWR  |  W  |   0   |  1 | 0   | 1   | step == 'step + 1 |
+    //  |  RWVWR  |  R  |   0   |  0 | 0   | 1   | step == 'step - 1 |
+    const expr aligned_wr = wr * (sel_up_to_down + sel_down_to_up);
+    (1 - reset) * ((step - aligned_wr) - ('step - 'aligned_wr)) === 0;
 
     col fixed L1 = [1,0...];
     L1 * pc === 0; // The program should start at the first line
@@ -148,7 +173,7 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     // Offset should be 0 in aligned memory accesses, but this is ensured by the rom
     // Width should be 8 in aligned memory accesses, but this is ensured by the rom
 
-    // On assume steps, we reconstruct the value from the registers directly
+    // On assume rows, we reconstruct the value from the registers directly
     expr assume_val[RC];
     for (int rc_index = 0; rc_index < RC; rc_index++) {
         assume_val[rc_index] = 0;
@@ -165,7 +190,7 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     sel_prove * (sel_prove - 1) === 0; // Binary selector
     sel_prove * sel_assume === 0; // Disjoint from the assume selector
 
-    // On prove steps, we reconstruct the value in the correct manner chosen by the selectors
+    // On prove rows, we reconstruct the value in the correct manner chosen by the selectors
     expr prove_val[RC];
     for (int rc_index = 0; rc_index < RC; rc_index++) {
         prove_val[rc_index] = 0;

--- a/test-artifacts/programs/Cargo.lock
+++ b/test-artifacts/programs/Cargo.lock
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "fields",
  "num-bigint",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -3333,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "colored",
  "fields",
@@ -3697,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "bincode",
  "blake3",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "bincode",
  "borsh",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "fields",
  "itoa",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "bincode",
  "colored",
@@ -3805,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "bincode",
  "fields",
@@ -6385,7 +6385,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Fadd_poseidon1#1897a228cf6fa6a6c9681c9fe5813ffb0c415df4"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
 dependencies = [
  "colored",
  "fields",


### PR DESCRIPTION
## Summary

Fixes a soundness gap in the `MemAlign` air template: the `step` column was never linked across the rows of a sub-program, letting a malicious prover desynchronize the aligned memory accesses from the unaligned operation they implement.

## The bug

`MemAlign` decomposes a non-aligned / sub-word access into one or more aligned 8-byte accesses against the `Mem` SM (the R/W rows) and reconstructs the value returned to Main (the V row). Every other inter-row quantity was tied together — `pc`/`delta_pc` via the ROM, `addr` via `delta_addr`, and `reg` via the `sel * sel_up_to_down` / `sel * sel_down_to_up` transitions — but `step` was a free witness column used only inside the `MEMORY_ID` permutation tuple. It had no transition constraint, no ROM column, and no row-offset reference.

Each aligned access is matched to `Mem` at exactly `(addr, step)`. With the read row's `step` free and decoupled from the value row's `step` (the step Main consumes), a prover could source the aligned word from **any timestamp where `Mem` holds an entry for that address**, not the timestamp of the actual op:

- One-word read at op step `S`, address `X` holding `A` early and `B` after an intervening write: set the read row's step to some `s' < S` where `Mem` legitimately has `(X, s') -> A`. The `Mem` permutation balances, the register
  transitions carry `A`'s bytes into the value row, and the value row proves a stale value to Main at step `S`. The proof verifies.
- Two-word accesses: the two words could be read at unrelated steps; write-back steps were unconstrained relative to the operation.

Neither bus partner can catch this: `Mem` treats each row as an independent access, and Main only sees the value row's step. The linkage has to live in `MemAlign`.

## The fix

Tie `step` across rows so the read/write rows are pinned to the same base step as the value row:

```pil
const expr aligned_wr = wr * (sel_up_to_down + sel_down_to_up);
(1 - reset) * ((step - aligned_wr) - ('step - 'aligned_wr)) === 0;
```

`aligned_wr` is 1 exactly on the two aligned-write rows (a write that is also an assume against `Mem`), which sit one step above the base; it is 0 on read rows and on the value row (which carries `wr=1` in write programs but is a prove row, `sel_up_to_down = sel_down_to_up = 0`). So `base = step - aligned_wr` is invariant within a sub-program, and the constraint enforces `base == 'base` on non-reset rows. `(1 - reset)` starts a fresh base per operation and gates off the cyclic `'step` wrap on row 0.

Completeness is preserved: honest witnesses already follow this layout (read/ value rows at `S`, aligned writes at `S+1`), so no valid trace is rejected — verified row-by-row across all four sub-programs (RV, RWV, RVR, RWVWR); see the truth table added in the comment above the constraint.