### PR TITLE
fix(zisklib): zisklib bls12 381 msm

### DIFF
--- a/test-artifacts/programs/bls12_381/src/main.rs
+++ b/test-artifacts/programs/bls12_381/src/main.rs
@@ -9,6 +9,7 @@ mod fp12;
 mod fp2;
 mod fp6;
 mod hash_to_curve;
+mod msm;
 mod pairing;
 mod twist;
 
@@ -19,6 +20,7 @@ use fp12::fp12_tests;
 use fp2::fp2_tests;
 use fp6::fp6_tests;
 use hash_to_curve::hash_to_curve_tests;
+use msm::msm_tests;
 use pairing::pairing_valid_tests;
 use twist::twist_tests;
 
@@ -50,4 +52,7 @@ fn main() {
     // Pairing
     pairing_valid_tests();
     // pairing_invalid_tests();
+
+    // MSM
+    msm_tests();
 }

--- a/test-artifacts/programs/bls12_381/src/msm.rs
+++ b/test-artifacts/programs/bls12_381/src/msm.rs
@@ -1,0 +1,19 @@
+use ziskos::zisklib::{msm_complete_safe_bls12_381, msm_complete_safe_twist_bls12_381};
+
+use crate::constants::P;
+
+pub fn msm_tests() {
+    // Point validation runs before the zero-scalar skip
+
+    // P not in range
+    let mut bad_g1 = [0; 12];
+    bad_g1[0..6].copy_from_slice(&P);
+    let res = msm_complete_safe_bls12_381(&[bad_g1], &[[0; 4]]);
+    assert_eq!(res.unwrap_err(), 2);
+
+    // Q not in range
+    let mut bad_g2 = [0; 24];
+    bad_g2[0..6].copy_from_slice(&P);
+    let res = msm_complete_safe_twist_bls12_381(&[bad_g2], &[[0; 4]]);
+    assert_eq!(res.unwrap_err(), 2);
+}

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
@@ -676,8 +676,8 @@ pub fn msm_complete_safe_bls12_381(
             continue;
         }
 
-        // NOTE: Validation must precede the scalar-zero skip below, since EIP-2537 mandates
-        // rejecting an invalid input point regardless of its scalar.
+        // NOTE: Validation must precede the scalar-zero skip below, since we should reject an
+        // invalid input point regardless of its scalar.
 
         // Verify point coordinates are in the field
         let x: [u64; 6] = point[0..6].try_into().unwrap();

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/curve.rs
@@ -676,15 +676,8 @@ pub fn msm_complete_safe_bls12_381(
             continue;
         }
 
-        // Reduce the scalar modulo the group order, and skip if the result is zero
-        let scalar = reduce_fr_bls12_381(
-            scalar,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        if is_zero(&scalar) {
-            continue;
-        }
+        // NOTE: Validation must precede the scalar-zero skip below, since EIP-2537 mandates
+        // rejecting an invalid input point regardless of its scalar.
 
         // Verify point coordinates are in the field
         let x: [u64; 6] = point[0..6].try_into().unwrap();
@@ -709,6 +702,16 @@ pub fn msm_complete_safe_bls12_381(
             hints,
         ) {
             return Err(G1_MSM_ERR_NOT_IN_SUBGROUP);
+        }
+
+        // Reduce the scalar modulo the group order, and skip if the result is zero
+        let scalar = reduce_fr_bls12_381(
+            scalar,
+            #[cfg(feature = "hints")]
+            hints,
+        );
+        if is_zero(&scalar) {
+            continue;
         }
 
         // Compute P * k

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
@@ -999,15 +999,8 @@ pub fn msm_complete_safe_twist_bls12_381(
             continue;
         }
 
-        // Reduce the scalar modulo the group order, and skip if the result is zero
-        let scalar = reduce_fr_bls12_381(
-            scalar,
-            #[cfg(feature = "hints")]
-            hints,
-        );
-        if is_zero(&scalar) {
-            continue;
-        }
+        // NOTE: Validation must precede the scalar-zero skip below, since EIP-2537 mandates
+        // rejecting an invalid input point regardless of its scalar.
 
         // Verify point coordinates are in the field
         let x_0: [u64; 6] = point[0..6].try_into().unwrap();
@@ -1034,6 +1027,16 @@ pub fn msm_complete_safe_twist_bls12_381(
             hints,
         ) {
             return Err(G2_MSM_ERR_NOT_IN_SUBGROUP);
+        }
+
+        // Reduce the scalar modulo the group order, and skip if the result is zero
+        let scalar = reduce_fr_bls12_381(
+            scalar,
+            #[cfg(feature = "hints")]
+            hints,
+        );
+        if is_zero(&scalar) {
+            continue;
         }
 
         // Compute P * k

--- a/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
+++ b/ziskos/entrypoint/src/zisklib/lib/bls12_381/twist.rs
@@ -999,8 +999,8 @@ pub fn msm_complete_safe_twist_bls12_381(
             continue;
         }
 
-        // NOTE: Validation must precede the scalar-zero skip below, since EIP-2537 mandates
-        // rejecting an invalid input point regardless of its scalar.
+        // NOTE: Validation must precede the scalar-zero skip below, since we should reject an
+        // invalid input point regardless of its scalar.
 
         // Verify point coordinates are in the field
         let x_0: [u64; 6] = point[0..6].try_into().unwrap();


### PR DESCRIPTION
Updated `msm_complete_safe_bls12_381` and `msm_complete_safe_twist_bls12_381` to do the point membership validation before zero-scalar skip, to be EIP-2537 compliant. Also added the regression test case.
