### PR TITLE
feat: extend ram usage for profiling all allocators

### DIFF
--- a/book/developer/profiling.md
+++ b/book/developer/profiling.md
@@ -224,7 +224,7 @@ The cost is broken down into these categories:
 
 These frequent operations are analyzed, detected, and **pre-calculated**, becoming part of the BASE cost but representing significant savings. In this example, FROPS show 8.42% - this is the cost the program would have if these optimizations were not applied. The actual savings are already reflected in the lower costs of the affected operations.
 
-**RAM USAGE**: The amount of memory used out of the total available. This information is **only available with the default allocator (bump allocator)**, which:
+**RAM USAGE**: The highest address any allocation has reached. The default allocator is bump allocator, which:
 - Never frees memory - always allocates new memory
 - Avoids the CPU cycles needed to manage the entire heap (typically >10% overhead)
 - Is recommended as long as sufficient memory is available

--- a/emulator/src/stats/stats.rs
+++ b/emulator/src/stats/stats.rs
@@ -903,7 +903,7 @@ impl Stats {
         report.sdk_report_summary_line("STEPS", self.costs.steps);
         report.sdk_report_summary_line("COST", total_cost);
         report.sdk_report_summary_data_line(
-            "RAM",
+            "RAM (peak heap address)",
             &format!(
                 "{:>6.2} MB / {:>6.2} MB",
                 self.ram_monitor.ram_used as f64 / (1024.0 * 1024.0),
@@ -1085,7 +1085,7 @@ impl Stats {
         report.set_total_cost(total_cost - base_cost);
         report.add_cost_perc("FROPS", self.costs.frops_cost());
         if self.ram_monitor.ram_size > 0 {
-            report.add_perc("RAM USAGE", self.ram_monitor.ram_used, self.ram_monitor.ram_size);
+            report.add_perc("RAM USAGE (peak heap address)", self.ram_monitor.ram_used, self.ram_monitor.ram_size);
         }
 
         if show_opcodes {

--- a/ziskos/entrypoint/src/alloc/alloc.rs
+++ b/ziskos/entrypoint/src/alloc/alloc.rs
@@ -1,10 +1,10 @@
 #[used]
 #[export_name = "ZISK_BUMP_HEAP_POS"]
-static mut HEAP_POS: usize = 0;
+pub(super) static mut HEAP_POS: usize = 0;
 
 #[used]
 #[export_name = "ZISK_BUMP_HEAP_TOP"]
-static mut HEAP_TOP: usize = 0;
+pub(super) static mut HEAP_TOP: usize = 0;
 
 #[cfg(all(target_os = "zkvm", target_vendor = "zisk"))]
 #[no_mangle]

--- a/ziskos/entrypoint/src/alloc/embedded_dlmalloc.rs
+++ b/ziskos/entrypoint/src/alloc/embedded_dlmalloc.rs
@@ -13,10 +13,10 @@ unsafe impl DlAllocator for ZiskSystem {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
         unsafe {
             // Return a block from your reserved heap
-            let ptr = BUMP_PTR;
+            let ptr = super::HEAP_POS;
             let aligned = (ptr + 7) & !7;
-            BUMP_PTR = aligned + size;
-            if BUMP_PTR > BUMP_END {
+            super::HEAP_POS = aligned + size;
+            if super::HEAP_POS > super::HEAP_TOP {
                 return (core::ptr::null_mut(), 0, 0);
             }
             (aligned as *mut u8, size, 0)
@@ -48,9 +48,6 @@ unsafe impl DlAllocator for ZiskSystem {
     }
 }
 
-static mut BUMP_PTR: usize = 0;
-static mut BUMP_END: usize = 0;
-
 static mut DLMALLOC: Dlmalloc<ZiskSystem> = Dlmalloc::new_with_allocator(ZiskSystem);
 
 struct Allocator;
@@ -78,9 +75,7 @@ unsafe impl core::alloc::GlobalAlloc for Allocator {
 
 pub fn init() {
     unsafe {
-        let heap_start = &_kernel_heap_bottom as *const u8 as usize;
-        let heap_end = &_kernel_heap_top as *const u8 as usize;
-        BUMP_PTR = heap_start;
-        BUMP_END = heap_end;
+        super::HEAP_POS = &_kernel_heap_bottom as *const u8 as usize;
+        super::HEAP_TOP = &_kernel_heap_top as *const u8 as usize;
     }
 }

--- a/ziskos/entrypoint/src/alloc/embedded_talc.rs
+++ b/ziskos/entrypoint/src/alloc/embedded_talc.rs
@@ -2,14 +2,37 @@ use super::kernel_heap::*;
 use core::alloc::{GlobalAlloc, Layout};
 use talc::{ErrOnOom, Talc, Talck};
 
+static INNER_HEAP: Talck<talc::locking::AssumeUnlockable, ErrOnOom> = Talc::new(ErrOnOom).lock();
+
 #[global_allocator]
-static HEAP: Talck<talc::locking::AssumeUnlockable, ErrOnOom> = Talc::new(ErrOnOom).lock();
+static HEAP: TalcAlloc = TalcAlloc;
+
+struct TalcAlloc;
+
+unsafe impl GlobalAlloc for TalcAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = INNER_HEAP.alloc(layout);
+        if !ptr.is_null() {
+            let end = ptr as usize + layout.size();
+            if end > super::HEAP_POS {
+                super::HEAP_POS = end;
+            }
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        INNER_HEAP.dealloc(ptr, layout)
+    }
+}
 
 pub fn init() {
     unsafe {
         let heap_start = &_kernel_heap_bottom as *const u8 as usize;
         let heap_size = &_kernel_heap_size as *const u8 as usize;
         let heap_span = talc::Span::from_base_size(heap_start as *mut u8, heap_size);
-        HEAP.lock().claim(heap_span).unwrap();
+        INNER_HEAP.lock().claim(heap_span).unwrap();
+        super::HEAP_POS = heap_start;
+        super::HEAP_TOP = heap_start + heap_size;
     }
 }

--- a/ziskos/entrypoint/src/alloc/embedded_tlfs.rs
+++ b/ziskos/entrypoint/src/alloc/embedded_tlfs.rs
@@ -22,6 +22,8 @@ pub fn init() {
         let heap_start = &_kernel_heap_bottom as *const u8 as usize;
         let heap_size = &_kernel_heap_size as *const u8 as usize;
         INNER_HEAP.init(heap_start, heap_size);
+        super::HEAP_POS = heap_start;
+        super::HEAP_TOP = heap_start + heap_size;
     }
 }
 
@@ -29,7 +31,14 @@ struct EmbeddedAlloc;
 
 unsafe impl GlobalAlloc for EmbeddedAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        INNER_HEAP.alloc(layout)
+        let ptr = INNER_HEAP.alloc(layout);
+        if !ptr.is_null() {
+            let end = ptr as usize + layout.size();
+            if end > super::HEAP_POS {
+                super::HEAP_POS = end;
+            }
+        }
+        ptr
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {


### PR DESCRIPTION
**Motivation**                                                                                                                                                                                
The emulator reads the `ZISK_BUMP_HEAP_POS` ELF symbol to report heap usage during profiling. The documentation mentions that only the bump allocator shows the "RAM USAGE" metric. When running other allocators (dlmalloc, talc, tlfs) using [zkevm-benchmark-workload](https://github.com/eth-act/zkevm-benchmark-workload) on a guest program compiled with [ere-guests](https://github.com/eth-act/ere-guests/), the report contains corrupted numbers for RAM USAGE:

```sh
COST DISTRIBUTION                   COST       %
------------------------------------------------
BASE                         293,601,280   0.91%
MAIN                      19,528,071,836  60.59%
OPCODES                    5,032,873,375  15.62%
PRECOMPILES                5,074,964,664  15.75%
MEMORY                     2,301,338,830   7.14%

TOTAL                     32,230,849,985 100.00%

FROPS                      3,260,670,684  10.12%
RAM USAGE                18,446,744,071,020,769,784 3464970465994.37%
```

**Description**

All of the alternative allocators now use the ELF symbol defined in `alloc.rs`. For dlmalloc, this is straightforward. The allocators `tlfs` and `talc` work differently. They claim the whole memory and then manage allocators internally. The changes add a `GlobalAlloc` wrapper that tracks peak memory usage. 
