### PR TITLE
fix(mem-align): soundness in non-aligned op

### DIFF
--- a/pil/src/pil_helpers/traces.rs
+++ b/pil/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "e0eba363372313c7ee099cdbaa73f41d219eac982f53ab31d9edf87b4644a44e";
+pub const PILOUT_HASH: &str = "e2db26c7ce7b878516a8d3a3286915481538d3249a4a172c9c3cc8af4b34a164";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 
@@ -197,7 +197,7 @@ trace_row!(MemAlignFixedRow<F> {
 pub type MemAlignFixed<F> = GenericTrace<MemAlignFixedRow<F>, 2097152, 0, 5>;
 
 trace_row!(MemAlignTraceRow<F> {
- addr:ubit(29), offset:ubit(3), width:ubit(4), wr:bit, pc:u8, reset:bit, sel_up_to_down:bit, sel_down_to_up:bit, reg:[u8; 8], sel:[bit; 8], step:ubit(40), delta_addr:u64, sel_prove:bit, value:[u32; 2],
+ addr:ubit(29), offset:ubit(3), width:ubit(4), wr:bit, pc:u8, reset:bit, sel_up_to_down:bit, sel_down_to_up:bit, is_non_aligned_op:bit, reg:[u8; 8], sel:[bit; 8], step:ubit(40), delta_addr:u64, value:[u32; 2],
 });
 
 pub type MemAlignTrace<R> = GenericTrace<R, 2097152, 0, 5>;
@@ -740,7 +740,7 @@ pub const PACKED_INFO: &[(usize, usize, PackedInfoConst)] = &[
     (0, 5, PackedInfoConst {
         is_packed: true,
         num_packed_words: 5,
-        unpack_info: &[29, 3, 4, 1, 8, 1, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1, 40, 64, 1, 32, 32],
+        unpack_info: &[29, 3, 4, 1, 8, 1, 1, 1, 1, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1, 40, 64, 32, 32],
     }),
     (0, 6, PackedInfoConst {
         is_packed: true,

--- a/state-machines/mem/pil/mem_align.pil
+++ b/state-machines/mem/pil/mem_align.pil
@@ -178,12 +178,12 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     // Width should be 8 in aligned memory accesses, but this is ensured by the rom
 
     // On assume rows, we reconstruct the value from the registers directly
-    expr assume_val[RC];
+    expr aligned_val[RC];
     for (int rc_index = 0; rc_index < RC; rc_index++) {
-        assume_val[rc_index] = 0;
+        aligned_val[rc_index] = 0;
         int base = 1;
         for (int _offset = 0; _offset < CHUNKS_BY_RC; _offset++) {
-            assume_val[rc_index] += reg[_offset + rc_index * CHUNKS_BY_RC] * base;
+            aligned_val[rc_index] += reg[_offset + rc_index * CHUNKS_BY_RC] * base;
             base *= 256;
         }
     }
@@ -191,9 +191,9 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     // 3] Prove unaligned memory accesses against the Main component
 
     // On prove rows, we reconstruct the value in the correct manner chosen by the selectors
-    expr prove_val[RC];
+    expr non_aligned_val[RC];
     for (int rc_index = 0; rc_index < RC; rc_index++) {
-        prove_val[rc_index] = 0;
+        non_aligned_val[rc_index] = 0;
     }
     for (int _offset = 0; _offset < CHUNK_NUM; _offset++) {
         for (int rc_index = 0; rc_index < RC; rc_index++) {
@@ -203,14 +203,14 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
                 _tmp += reg[(_offset + rc_index * CHUNKS_BY_RC + ichunk) % CHUNK_NUM] * base;
                 base *= 256;
             }
-            prove_val[rc_index] += sel[_offset] * _tmp;
+            non_aligned_val[rc_index] += sel[_offset] * _tmp;
         }
     }
 
     // We prove and assume with the same permutation check but with disjoint and different sign selectors
     col witness bits(32) value[RC];
     for (int i = 0; i < RC; i++) {
-        value[i] === is_aligned_op * (assume_val[i] - prove_val[i]) + prove_val[i];
+        value[i] === is_non_aligned_op * non_aligned_val[i] + is_aligned_op * aligned_val[i];
     }
     permutation(MEMORY_ID, expressions: [wr * (MEMORY_STORE_OP - MEMORY_LOAD_OP) + MEMORY_LOAD_OP, addr * CHUNK_NUM + offset, step, width, ...value], sel: is_non_aligned_op - is_aligned_op, sel_is_ternary: 1);
 }

--- a/state-machines/mem/pil/mem_align.pil
+++ b/state-machines/mem/pil/mem_align.pil
@@ -100,6 +100,7 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     col witness bits(1) reset;
     col witness bits(1) sel_up_to_down;
     col witness bits(1) sel_down_to_up;
+    col witness bits(1) is_non_aligned_op;
     col witness bits(8) reg[CHUNK_NUM];
     col witness bits(1) sel[CHUNK_NUM];
     col witness bits(40) step;
@@ -153,12 +154,15 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     reset * (1 - reset) === 0;
     sel_up_to_down * (1 - sel_up_to_down) === 0;
     sel_down_to_up * (1 - sel_down_to_up) === 0;
+    is_non_aligned_op * (1 - is_non_aligned_op) === 0;
 
     expr flags = 0;
     for (int i = 0; i < CHUNK_NUM; i++) {
         flags += sel[i] * 2**i;
     }
-    flags += wr * 2**CHUNK_NUM + reset * 2**(CHUNK_NUM + 1) + sel_up_to_down * 2**(CHUNK_NUM + 2) + sel_down_to_up * 2**(CHUNK_NUM + 3);
+    flags += wr * 2**CHUNK_NUM + reset * 2**(CHUNK_NUM + 1) + 
+             sel_up_to_down * 2**(CHUNK_NUM + 2) + sel_down_to_up * 2**(CHUNK_NUM + 3) + 
+             is_non_aligned_op * 2**(CHUNK_NUM + 4);
 
     // Perform the lookup against the program
     expr delta_pc;
@@ -168,7 +172,7 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     lookup_assumes(MEMORY_ALIGN_ROM_ID, [pc, delta_pc, delta_addr, offset, width, flags]);
 
     // 2] Assume aligned memory accesses against the Memory component
-    const expr sel_assume = sel_up_to_down + sel_down_to_up;
+    const expr is_aligned_op = sel_up_to_down + sel_down_to_up;
 
     // Offset should be 0 in aligned memory accesses, but this is ensured by the rom
     // Width should be 8 in aligned memory accesses, but this is ensured by the rom
@@ -185,10 +189,6 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     }
 
     // 3] Prove unaligned memory accesses against the Main component
-    col witness bits(1) sel_prove;
-
-    sel_prove * (sel_prove - 1) === 0; // Binary selector
-    sel_prove * sel_assume === 0; // Disjoint from the assume selector
 
     // On prove rows, we reconstruct the value in the correct manner chosen by the selectors
     expr prove_val[RC];
@@ -210,7 +210,7 @@ airtemplate MemAlign(const int N = 2**10, const int RC = 2, const int CHUNK_NUM 
     // We prove and assume with the same permutation check but with disjoint and different sign selectors
     col witness bits(32) value[RC];
     for (int i = 0; i < RC; i++) {
-        value[i] === sel_prove * prove_val[i] + sel_assume * assume_val[i];
-    } 
-    permutation(MEMORY_ID, expressions: [wr * (MEMORY_STORE_OP - MEMORY_LOAD_OP) + MEMORY_LOAD_OP, addr * CHUNK_NUM + offset, step, width, ...value], sel: sel_prove - sel_assume, sel_is_ternary: 1);
+        value[i] === is_aligned_op * (assume_val[i] - prove_val[i]) + prove_val[i];
+    }
+    permutation(MEMORY_ID, expressions: [wr * (MEMORY_STORE_OP - MEMORY_LOAD_OP) + MEMORY_LOAD_OP, addr * CHUNK_NUM + offset, step, width, ...value], sel: is_non_aligned_op - is_aligned_op, sel_is_ternary: 1);
 }

--- a/state-machines/mem/pil/mem_align_rom.pil
+++ b/state-machines/mem/pil/mem_align_rom.pil
@@ -98,6 +98,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
         }
         int sel_up_to_down = 0;
         int sel_down_to_up = 0;
+        int is_non_aligned_op = 0;
 
         const int prev_line = i == 0 ? 0 : i-1;
         const int line = i;
@@ -127,6 +128,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 sel_up_to_down = 1;
                 // sel_down_to_up = 0;
+                // is_non_aligned_op = 0;
             } else {
                 pc = prev_line;
                 delta_pc = -pc;
@@ -140,6 +142,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 // sel_up_to_down = 0;
                 // sel_down_to_up = 0;
+                is_non_aligned_op = 1;
             }
         }
         else if (line < 1+tsize[0]+tsize[1])  // RWV
@@ -157,6 +160,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 sel_up_to_down = 1;
                 // sel_down_to_up = 0;
+                // is_non_aligned_op = 0;
             } else if (line % 3 == 0) {
                 pc = prev_line;
                 delta_pc = 1;
@@ -170,6 +174,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 sel_up_to_down = 1;
                 // sel_down_to_up = 0;
+                // is_non_aligned_op = 0;
             } else {
                 pc = prev_line;
                 delta_pc = -pc;
@@ -183,6 +188,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 // sel_up_to_down = 0;
                 // sel_down_to_up = 0;
+                is_non_aligned_op = 1;
             }
         }
         else if (line < 1+tsize[0]+tsize[1]+tsize[2]) // RVR
@@ -200,6 +206,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 sel_up_to_down = 1;
                 // sel_down_to_up = 0;
+                // is_non_aligned_op = 0;
             } else if (line % 3 == 0) {
                 pc = prev_line;
                 delta_pc = 1;
@@ -213,6 +220,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 // sel_up_to_down = 0;
                 // sel_down_to_up = 0;
+                is_non_aligned_op = 1;
             } else {
                 pc = prev_line;
                 delta_pc = -pc;
@@ -226,6 +234,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 // sel_up_to_down = 0;
                 sel_down_to_up = 1;
+                // is_non_aligned_op = 0;
             }
         }
         else if (line < 1+tsize[0]+tsize[1]+tsize[2]+tsize[3]) // RWVWR
@@ -243,6 +252,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 sel_up_to_down = 1;
                 // sel_down_to_up = 0;
+                // is_non_aligned_op = 0;
             } else if (line % 5 == 0) {
                 pc = prev_line;
                 delta_pc = 1;
@@ -256,6 +266,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 sel_up_to_down = 1;
                 // sel_down_to_up = 0;
+                // is_non_aligned_op = 0;
             } else if (line % 5 == 1) {
                 pc = prev_line;
                 delta_pc = 1;
@@ -269,6 +280,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 // sel_up_to_down = 0;
                 // sel_down_to_up = 0;
+                is_non_aligned_op = 1;
             } else if (line % 5 == 2) {
                 pc = prev_line;
                 delta_pc = 1;
@@ -282,6 +294,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 // sel_up_to_down = 0;
                 sel_down_to_up = 1;
+                // is_non_aligned_op = 0;
             } else {
                 pc = prev_line;
                 delta_pc = -pc;
@@ -295,6 +308,7 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
                 }
                 // sel_up_to_down = 0;
                 sel_down_to_up = 1;
+                // is_non_aligned_op = 0;
             }
         }
         PC[i] = pc;
@@ -304,7 +318,9 @@ airtemplate MemAlignRom(const int N = MEM_ALIGN_ROM_SIZE, const int CHUNK_NUM = 
         for (int j = 0; j < CHUNK_NUM; j++) {
             flags += sel[j] * 2**j;
         }
-        flags += is_write * 2**CHUNK_NUM + reset * 2**(CHUNK_NUM + 1) + sel_up_to_down * 2**(CHUNK_NUM + 2) + sel_down_to_up * 2**(CHUNK_NUM + 3);
+        flags += is_write * 2**CHUNK_NUM + reset * 2**(CHUNK_NUM + 1) + 
+                 sel_up_to_down * 2**(CHUNK_NUM + 2) + sel_down_to_up * 2**(CHUNK_NUM + 3) +
+                 is_non_aligned_op * 2**(CHUNK_NUM + 4);
         FLAGS[i] = flags;
     }
 

--- a/state-machines/mem/src/mem_align_sm.rs
+++ b/state-machines/mem/src/mem_align_sm.rs
@@ -144,7 +144,7 @@ impl<F: PrimeField64> MemAlignSM<F> {
                 value_row.set_offset(offset as u8);
                 value_row.set_width(width as u8);
                 value_row.set_pc(next_pc as u8);
-                value_row.set_sel_prove(true);
+                value_row.set_is_non_aligned_op(true);
 
                 // Compute reg and sel arrays for read_row
                 let mut read_reg_values = [0u8; CHUNK_NUM];
@@ -288,7 +288,7 @@ impl<F: PrimeField64> MemAlignSM<F> {
                 value_row.set_width(width as u8);
                 value_row.set_wr(true);
                 value_row.set_pc(next_pc as u8 + 1);
-                value_row.set_sel_prove(true);
+                value_row.set_is_non_aligned_op(true);
 
                 // Compute arrays for read_row
                 let mut read_reg_values = [0u8; CHUNK_NUM];
@@ -442,7 +442,7 @@ impl<F: PrimeField64> MemAlignSM<F> {
                 value_row.set_offset(offset as u8);
                 value_row.set_width(width as u8);
                 value_row.set_pc(next_pc as u8);
-                value_row.set_sel_prove(true);
+                value_row.set_is_non_aligned_op(true);
 
                 let mut second_read_row: R = Default::default();
                 second_read_row.set_step(step);
@@ -652,7 +652,7 @@ impl<F: PrimeField64> MemAlignSM<F> {
                 value_row.set_width(width as u8);
                 value_row.set_wr(true);
                 value_row.set_pc(next_pc as u8 + 1);
-                value_row.set_sel_prove(true);
+                value_row.set_is_non_aligned_op(true);
 
                 let mut second_write_row: R = Default::default();
                 second_write_row.set_step(step + 1);


### PR DESCRIPTION
> Found by @eduadiez.
>
>   The MemAlign component links to the Main SM (the anchor that ties an aligned memory sub-access to a real instruction step) only through the V-row "prove", which is gated by a free witness column sel_prove. No constraint forces sel_prove = 1 on the V row of a program. A malicious prover can therefore emit a structurally-valid program with sel_prove = 0 (an inactive V row), whose R/W rows still consume aligned LOAD/STORE tuples from the memory bus with a free step and a free value. By also adding the matching permutation_proves on the Memory SM side (which the prover controls), the global bus stays balanced — so the only guard that would catch a missing prove never fires. The net effect is a memory write that corresponds to no instruction, at an attacker-chosen address/step/value.

## Summary

The MemAlign state machine reconciles unaligned memory accesses with the aligned-only Memory component. It does this with a single `permutation` against `MEMORY_ID` whose sign selects the direction:

- **assume** rows (sign `-1`): aligned accesses pulled *from* the Memory component.
- **prove** rows (sign `+1`): the reconstructed unaligned value pushed *to* the Main component.

Previously the prove direction was driven by `sel_prove`, a **free witness column** only constrained to be binary and disjoint from the assume selector (`sel_assume = sel_up_to_down + sel_down_to_up`):

```pil
col witness bits(1) sel_prove;
sel_prove * (sel_prove - 1) === 0; // binary
sel_prove * sel_assume   === 0;    // disjoint from assume
...
value[i] === sel_prove * prove_val[i] + sel_assume * assume_val[i];
permutation(MEMORY_ID, [...], sel: sel_prove - sel_assume, sel_is_ternary: 1);
```

Because `sel_prove` was unconstrained on the unaligned "value" rows (where `sel_assume = 0`), a malicious prover could set it to `0`. That row would then be omitted from the permutation (selector `0`) and its `value[i]` would collapse to `0`, so the reconstructed value for an unaligned load/store was never enforced against the Main component. This breaks the consistency guarantee between Main's claimed memory values and the MemAlign computation.

## Fix

Replace the free `sel_prove` witness with `is_non_aligned_op`, a column that is committed but bound by the ROM lookup: it is now part of the flags word checked against MemAlignRom, so its value on every row is forced by the deterministic ROM program for the given pc/line and can no longer be chosen by the prover.
- `mem_align_rom.pil` sets `is_non_aligned_op = 1` exactly on the unaligned value rows (the middle rows of the RWV / RVR / RWVWR access patterns) and packs it into `flags` at bit `CHUNK_NUM + 4`.
- `mem_align.pil` adds the matching `is_non_aligned_op` witness + binary constraint, packs it into flags (matching the ROM), renames `sel_assume` → `is_aligned_op` for clarity, and rewrites the value reconstruction to no longer depend on a free selector:
  ```pil
  value[i] === is_non_aligned_op * non_aligned_val[i] + is_aligned_op * aligned_val[i];
  permutation(MEMORY_ID, [...], sel: is_non_aligned_op - is_aligned_op, sel_is_ternary: 1);
  ```

## Impact

Soundness fix. Closes a gap that allowed a prover to skip the Main-component check for unaligned memory accesses. No change to honest-prover behavior; the PILOUT hash changes, so verifier keys/setup must be regenerated.