### PR TITLE
repro: add RV64 AUIPC overflow fixture

### DIFF
--- a/build-elf
+++ b/build-elf
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Build a RISC-V assembly file into a Zisk-compatible ELF.
+# Usage: ./build-elf <source.s> [output.elf]
+#
+# Uses riscv64-elf-as / riscv64-elf-ld from PATH.
+# Default link: -Ttext=0x80000000 (no linker script).
+# To use a linker script, place a .ld file next to the source; it will be picked up automatically.
+
+set -euo pipefail
+
+SRC="${1:?Usage: $0 <source.s> [output.elf]}"
+OUT="${2:-${SRC%.s}.elf}"
+OBJ="$(mktemp /tmp/zisk-XXXXXX.o)"
+trap 'rm -f "$OBJ"' EXIT
+
+riscv64-elf-as -march=rv64ima "$SRC" -o "$OBJ"
+
+LD_SCRIPT="$(dirname "$SRC")/$(basename "$SRC" .s).ld"
+if [ ! -f "$LD_SCRIPT" ]; then
+    LD_SCRIPT="$(find "$(dirname "$SRC")" -maxdepth 1 -name '*.ld' | head -1)"
+fi
+
+if [ -n "$LD_SCRIPT" ] && [ -f "$LD_SCRIPT" ]; then
+    riscv64-elf-ld -T "$LD_SCRIPT" "$OBJ" -o "$OUT"
+else
+    riscv64-elf-ld -Ttext=0x80000000 "$OBJ" -o "$OUT"
+fi
+
+echo "Built: $OUT"
+riscv64-elf-objdump -d "$OUT" | head -20 || true

--- a/demo-auipc-rom-setup
+++ b/demo-auipc-rom-setup
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Build the AUIPC overflow fixture and show that ROM setup accepts it.
+# Usage: ./demo-auipc-rom-setup [program-setup args...]
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$ROOT/elf-regressions/auipc_rv64_overflow/test.s"
+ELF="$ROOT/elf-regressions/auipc_rv64_overflow/test.elf"
+
+"$ROOT/build-elf" "$SRC" "$ELF"
+
+echo
+echo "Running ROM setup for AUIPC overflow fixture..."
+"$ROOT/rom-setup-elf" "$ELF" "$@"
+
+echo
+echo "ROM setup accepted the AUIPC overflow fixture."
+echo "This demonstrates the AUIPC failure is not caught during ROM setup."

--- a/elf-regressions/auipc_rv64_overflow/README.md
+++ b/elf-regressions/auipc_rv64_overflow/README.md
@@ -38,6 +38,19 @@ current `store_pc` expression instead supplies `[0x100000000, 0]`, which does
 not match the 64-bit value emitted by the executor/transpiler path and causes
 `VerifyGlobalConstraints` to fail.
 
+## ROM setup check
+
+Run this helper to build the overflow fixture and demonstrate that ROM setup
+accepts it:
+
+```
+./demo-auipc-rom-setup
+```
+
+The expected result is a zero exit with `ROM setup successfully completed`.
+This shows the failure is not caught while decoding/transpiling the ELF or
+generating ROM setup artifacts.
+
 ## Why this is a spec violation
 
 RV64 AUIPC writes an XLEN-wide `pc + sext(imm20 << 12)` result to `rd`.

--- a/elf-regressions/auipc_rv64_overflow/README.md
+++ b/elf-regressions/auipc_rv64_overflow/README.md
@@ -1,11 +1,12 @@
-# auipc_rv64_overflow — RV64 AUIPC circuit bug
+# auipc_rv64_overflow - RV64 AUIPC circuit bug
 
-Two tests, same instruction (`auipc a0, 0x7ffff`), same standard Zisk linker script.
-The only difference is where in ROM the instruction executes.
+Two tests, same instruction (`auipc a0, 0x7ffff`), different instruction
+addresses.  The only relevant difference is whether `pc + imm` crosses the
+32-bit limb boundary.
 
 ```
-auipc_rv64_safe/     auipc at PC = 0x80000000   →   a0 = 0xFFFFFF00   (fits 32 bits, proving OK)
-auipc_rv64_overflow/ auipc at PC = 0x80001000   →   a0 = 0x100000000  (= 2^32, proving FAILS)
+auipc_rv64_safe/     auipc at PC = 0x80000000  ->  a0 = 0xFFFFFF00   (high limb 0, proving OK)
+auipc_rv64_overflow/ auipc at PC = 0x80001000  ->  a0 = 0x100000000  (high limb 1, proving FAILS)
 ```
 
 The overflow case uses `.balign 4096` in the assembly to place `auipc_test` at a
@@ -18,38 +19,28 @@ next page boundary.
 auipc a0, 0x7ffff
   offset = 0x7FFFF << 12 = 0x7FFFF000   (largest positive 20-bit AUIPC immediate, bit 19 = 0)
 
-At PC = 0x80000000:  0x80000000 + 0x7FFFF000 = 0xFFFFFF00          ← fits in 32 bits ✓
-At PC = 0x80001000:  0x80001000 + 0x7FFFF000 = 0x100000000 = 2^32  ← does not fit ✗
+At PC = 0x80000000:  0x80000000 + 0x7FFFF000 = 0xFFFFFF00          -> high limb 0
+At PC = 0x80001000:  0x80001000 + 0x7FFFF000 = 0x100000000 = 2^32  -> high limb 1
 ```
 
 ## Why proving fails
 
-`mem.pil` constrains every stored register value to 32 bits:
-
-```
-col witness bits(32) air.value[RC];
-value[i] = value_word[i*2] + 65536 * value_word[i*2+1]
-range_check(value_word[...], 0, 65535)   // two 16-bit halves → max 2^32 - 1
-```
-
-`main.pil` computes the value to store for AUIPC:
+The Main/Mem bus represents register and memory values as two 32-bit limbs.
+`main.pil` computes the value to store for AUIPC as:
 
 ```
 store_value[0] = pc + jmp_offset2    // = PC + (imm << 12)
 store_value[1] = 0                   // carry out of bit 31 is hardcoded to zero
 ```
 
-When `store_value[0] = 0x100000000 > 2^32 − 1`, no valid decomposition into two
-16-bit halves exists.  The constraint is unsatisfiable and `VerifyGlobalConstraints`
-fails.
+For `0x100000000`, the correct two-limb representation is `[0, 1]`.  The
+current `store_pc` expression instead supplies `[0x100000000, 0]`, which does
+not match the 64-bit value emitted by the executor/transpiler path and causes
+`VerifyGlobalConstraints` to fail.
 
 ## Why this is a spec violation
 
-RV64I Unprivileged Spec §2.4:
-
-> "AUIPC … sign-extends the result to 64 bits, adds it to the address of the
-> AUIPC instruction, then places the result in register rd."
-
-The result is a **64-bit value**.  It is not required to fit in 32 bits.
-`store_value[1]` must receive the carry out of bit 31 rather than being
-hardcoded to zero.
+RV64 AUIPC writes an XLEN-wide `pc + sext(imm20 << 12)` result to `rd`.
+On RV64, that result is not required to fit in 32 bits.  `store_value[1]`
+must receive the high limb of the 64-bit result rather than being hardcoded
+to zero.

--- a/elf-regressions/auipc_rv64_overflow/README.md
+++ b/elf-regressions/auipc_rv64_overflow/README.md
@@ -1,0 +1,55 @@
+# auipc_rv64_overflow — RV64 AUIPC circuit bug
+
+Two tests, same instruction (`auipc a0, 0x7ffff`), same standard Zisk linker script.
+The only difference is where in ROM the instruction executes.
+
+```
+auipc_rv64_safe/     auipc at PC = 0x80000000   →   a0 = 0xFFFFFF00   (fits 32 bits, proving OK)
+auipc_rv64_overflow/ auipc at PC = 0x80001000   →   a0 = 0x100000000  (= 2^32, proving FAILS)
+```
+
+The overflow case uses `.balign 4096` in the assembly to place `auipc_test` at a
+4 KB-aligned address, mirroring what happens when a linker places a section at the
+next page boundary.
+
+## The arithmetic
+
+```
+auipc a0, 0x7ffff
+  offset = 0x7FFFF << 12 = 0x7FFFF000   (largest positive 20-bit AUIPC immediate, bit 19 = 0)
+
+At PC = 0x80000000:  0x80000000 + 0x7FFFF000 = 0xFFFFFF00          ← fits in 32 bits ✓
+At PC = 0x80001000:  0x80001000 + 0x7FFFF000 = 0x100000000 = 2^32  ← does not fit ✗
+```
+
+## Why proving fails
+
+`mem.pil` constrains every stored register value to 32 bits:
+
+```
+col witness bits(32) air.value[RC];
+value[i] = value_word[i*2] + 65536 * value_word[i*2+1]
+range_check(value_word[...], 0, 65535)   // two 16-bit halves → max 2^32 - 1
+```
+
+`main.pil` computes the value to store for AUIPC:
+
+```
+store_value[0] = pc + jmp_offset2    // = PC + (imm << 12)
+store_value[1] = 0                   // carry out of bit 31 is hardcoded to zero
+```
+
+When `store_value[0] = 0x100000000 > 2^32 − 1`, no valid decomposition into two
+16-bit halves exists.  The constraint is unsatisfiable and `VerifyGlobalConstraints`
+fails.
+
+## Why this is a spec violation
+
+RV64I Unprivileged Spec §2.4:
+
+> "AUIPC … sign-extends the result to 64 bits, adds it to the address of the
+> AUIPC instruction, then places the result in register rd."
+
+The result is a **64-bit value**.  It is not required to fit in 32 bits.
+`store_value[1]` must receive the carry out of bit 31 rather than being
+hardcoded to zero.

--- a/elf-regressions/auipc_rv64_overflow/test.s
+++ b/elf-regressions/auipc_rv64_overflow/test.s
@@ -1,0 +1,14 @@
+# auipc_rv64_overflow: auipc rd, 0x7ffff at PC=0x80001000 → rd=0x100000000 (= 2^32, proving FAILS)
+# .balign 4096 places auipc_test at the next 4 KB boundary, as a linker does for a new section.
+# See README.md for the circuit analysis.
+
+.section .text.init
+.global _start
+_start:
+    j auipc_test
+.balign 4096            # → auipc_test at 0x80001000
+auipc_test:
+    auipc a0, 0x7ffff   # 0x80001000 + 0x7FFFF000 = 0x100000000 (overflows 32-bit Mem AIR constraint)
+    li a7, 93
+    ecall
+1:  j 1b

--- a/elf-regressions/auipc_rv64_safe/test.s
+++ b/elf-regressions/auipc_rv64_safe/test.s
@@ -1,0 +1,10 @@
+# auipc_rv64_safe: auipc rd, 0x7ffff at PC=0x80000000 → rd=0xFFFFFF00 (fits 32 bits, proving OK)
+# Compare: auipc_rv64_overflow/ — same instruction 4 KB later, result overflows 32 bits.
+
+.section .text.init
+.global _start
+_start:
+    auipc a0, 0x7ffff   # 0x80000000 + 0x7FFFF000 = 0xFFFFFF00
+    li a7, 93
+    ecall
+1:  j 1b

--- a/prove-elf
+++ b/prove-elf
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Run Zisk proving on an ELF and verify the result.
+# Usage: ./prove-elf <program.elf>
+#
+# Override binary locations via env vars:
+#   MONITOR      — path to zkevm-test-monitor checkout (default: ~/zkevm-test-monitor)
+#   CARGO_ZISK   — path to cargo-zisk binary
+#   WITNESS_LIB  — path to libzisk_witness.so
+#   ZISK_LIB     — path to directory containing bundled shared libs (libsodium etc.)
+
+set -euo pipefail
+
+ELF="${1:?Usage: $0 <program.elf>}"
+
+MONITOR="${MONITOR:-$HOME/zkevm-test-monitor}"
+CARGO_ZISK="${CARGO_ZISK:-$MONITOR/binaries/cargo-zisk}"
+ZISK_LIB="${ZISK_LIB:-$MONITOR/binaries/zisk-lib}"
+
+export LD_LIBRARY_PATH="$ZISK_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+"$CARGO_ZISK" prove \
+    --elf "$ELF" \
+    --emulator \
+    --verify-proofs

--- a/prove-elf
+++ b/prove-elf
@@ -18,7 +18,18 @@ ZISK_LIB="${ZISK_LIB:-$MONITOR/binaries/zisk-lib}"
 
 export LD_LIBRARY_PATH="$ZISK_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-"$CARGO_ZISK" prove \
-    --elf "$ELF" \
-    --emulator \
-    --verify-proofs
+HELP="$("$CARGO_ZISK" prove --help 2>&1 || true)"
+
+ARGS=(prove --elf "$ELF")
+
+if grep -q -- "--emulator" <<< "$HELP"; then
+    ARGS+=(--emulator)
+fi
+
+if grep -q -- "--verify-proofs" <<< "$HELP"; then
+    ARGS+=(--verify-proofs)
+elif grep -q -- "--verify-proof" <<< "$HELP"; then
+    ARGS+=(--verify-proof)
+fi
+
+"$CARGO_ZISK" "${ARGS[@]}"

--- a/rom-setup-elf
+++ b/rom-setup-elf
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Run Zisk ROM setup on an ELF.
+# Usage: ./rom-setup-elf <program.elf> [output-dir] [program-setup args...]
+#
+# Override binary locations via env vars:
+#   MONITOR     - path to zkevm-test-monitor checkout (default: ~/zkevm-test-monitor)
+#   CARGO_ZISK  - path to cargo-zisk binary
+#   ZISK_LIB    - path to directory containing bundled shared libs (libsodium etc.)
+#
+# If output-dir is omitted, a temporary directory is used and removed on exit.
+# Run setup jobs sequentially: installed emulator-asm uses a shared build dir.
+
+set -euo pipefail
+
+ELF="${1:?Usage: $0 <program.elf> [output-dir] [program-setup args...]}"
+shift
+
+MONITOR="${MONITOR:-$HOME/zkevm-test-monitor}"
+CARGO_ZISK="${CARGO_ZISK:-$MONITOR/binaries/cargo-zisk}"
+ZISK_LIB="${ZISK_LIB:-$MONITOR/binaries/zisk-lib}"
+
+cleanup_output=1
+if [ "$#" -gt 0 ] && [[ "$1" != -* ]]; then
+    OUT="$1"
+    cleanup_output=0
+    shift
+else
+    OUT="$(mktemp -d /tmp/zisk-rom-setup-XXXXXX)"
+fi
+
+cleanup() {
+    if [ "$cleanup_output" -eq 1 ]; then
+        rm -rf "$OUT"
+    fi
+}
+trap cleanup EXIT
+
+export LD_LIBRARY_PATH="$ZISK_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+if ! "$CARGO_ZISK" program-setup --help >/dev/null 2>&1; then
+    echo "error: $CARGO_ZISK does not support the program-setup command" >&2
+    exit 2
+fi
+
+mkdir -p "$OUT"
+
+"$CARGO_ZISK" program-setup --elf "$ELF" -o "$OUT" "$@"
+
+echo "ROM setup succeeded for: $ELF"
+if [ "$cleanup_output" -eq 1 ]; then
+    echo "Temporary setup output directory: $OUT (removed on exit)"
+else
+    echo "Setup output directory: $OUT"
+fi

--- a/state-machines/main/pil/main.pil
+++ b/state-machines/main/pil/main.pil
@@ -309,6 +309,11 @@ airtemplate Main(int N = 2**21, int RC = 2, int stack_enabled = 0,
     const expr store_value[2];
 
     store_value[0] = store_pc*(pc + jmp_offset2 - c[0]) + c[0];
+    // BUG(rv64-auipc): when store_pc=1 (AUIPC), store_value[1] is forced to 0, dropping the
+    // carry out of bit 31 of (pc + jmp_offset2).  For pc + jmp_offset2 >= 2^32 — valid in RV64I,
+    // e.g. auipc rd, 0x7ffff at PC >= 0x80001000 — store_value[0] exceeds the bits(32) constraint
+    // in mem.pil and VerifyGlobalConstraints fails.  store_value[1] should carry the high bit.
+    // Reproducer: elf-regressions/auipc_rv64_overflow/
     store_value[1] = (1 - store_pc) * c[1];
 
     // Memory function to prove that previous register store_offset access.

--- a/state-machines/main/pil/main.pil
+++ b/state-machines/main/pil/main.pil
@@ -310,9 +310,9 @@ airtemplate Main(int N = 2**21, int RC = 2, int stack_enabled = 0,
 
     store_value[0] = store_pc*(pc + jmp_offset2 - c[0]) + c[0];
     // BUG(rv64-auipc): when store_pc=1 (AUIPC), store_value[1] is forced to 0, dropping the
-    // carry out of bit 31 of (pc + jmp_offset2).  For pc + jmp_offset2 >= 2^32 — valid in RV64I,
-    // e.g. auipc rd, 0x7ffff at PC >= 0x80001000 — store_value[0] exceeds the bits(32) constraint
-    // in mem.pil and VerifyGlobalConstraints fails.  store_value[1] should carry the high bit.
+    // carry out of bit 31 of (pc + jmp_offset2).  For pc + jmp_offset2 >= 2^32 - valid in RV64I,
+    // e.g. auipc rd, 0x7ffff at PC >= 0x80001000 - this no longer matches the 64-bit value
+    // that the memory/register bus represents as two 32-bit limbs.
     // Reproducer: elf-regressions/auipc_rv64_overflow/
     store_value[1] = (1 - store_pc) * c[1];
 


### PR DESCRIPTION
## Summary

Demonstrates an AUIPC non-compliance bug. The failing fixture is accepted through ROM setup, but proof generation fails because the AUIPC `store_pc` path does not correctly represent valid RV64 register results whose high 32-bit limb is nonzero.

## Bug

RV64 AUIPC writes `pc + sext(imm20 << 12)` to `rd` as an XLEN-wide result. In the failing fixture, `auipc a0, 0x7ffff` is placed at PC `0x80001000`, so the architectural result is:

```text
0x80001000 + 0x7ffff000 = 0x100000000
```

This is a register result, not a static jump target. The fixture jumps to `0x80001000` first, then executes AUIPC and writes the result to `a0`.

ZisK represents register/memory values as two 32-bit limbs on the Main/Mem bus, but the Main AIR `store_pc` path currently computes:

```pil
store_value[0] = store_pc*(pc + jmp_offset2 - c[0]) + c[0];
store_value[1] = (1 - store_pc) * c[1];
```

For AUIPC, `store_pc=1`, so this writes the value as `[pc + imm, 0]`. The high limb is forced to zero instead of being `high32(pc + imm)`. This works only when the AUIPC result is below `2^32`.

## Fixtures and helpers

- `elf-regressions/auipc_rv64_overflow/test.s`: failing case, with AUIPC at PC `0x80001000` producing `0x100000000`.
- `elf-regressions/auipc_rv64_safe/test.s`: contrast case where the same immediate at PC `0x80000000` stays below `2^32`.
- `elf-regressions/auipc_rv64_overflow/README.md`: documents the arithmetic, circuit mismatch, and ROM setup check.
- `build-elf`: builds a fixture assembly file into a ZisK-compatible ELF.
- `rom-setup-elf`: runs `cargo-zisk program-setup` on an ELF.
- `demo-auipc-rom-setup`: builds the overflow fixture and demonstrates that ROM setup accepts it.
- `prove-elf`: runs proof generation for a fixture ELF.

## Verification

Target base: `pre-develop-1.0.0-beta`.

- `./build-elf elf-regressions/auipc_rv64_safe/test.s elf-regressions/auipc_rv64_safe/test.elf`: succeeds; AUIPC is at PC `0x80000000`.
- `./build-elf elf-regressions/auipc_rv64_overflow/test.s elf-regressions/auipc_rv64_overflow/test.elf`: succeeds; AUIPC is at PC `0x80001000`.
- `./demo-auipc-rom-setup`: succeeds; ROM setup completes for the overflow fixture and prints `ROM setup successfully completed`.
- `./prove-elf elf-regressions/auipc_rv64_safe/test.elf`: proves and verifies successfully.
- `./prove-elf elf-regressions/auipc_rv64_overflow/test.elf`: fails during witness/proof generation with a `VerifyGlobalConstraints` / `VadcopFinal` assertion failure.