### PR TITLE
fix(blake2): bind message permutation to the call's step and fix round_idx padding-boundary fail

### DIFF
--- a/pil/src/pil_helpers/traces.rs
+++ b/pil/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "e2db26c7ce7b878516a8d3a3286915481538d3249a4a172c9c3cc8af4b34a164";
+pub const PILOUT_HASH: &str = "3615b752dac12c3dd5dc2d1b28541808d7da77acca86159f5c2dade9edfdc366";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 

--- a/pil/src/pil_helpers/traces.rs
+++ b/pil/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "b779ac1d306d55d23de7009a652de914b1e17b8be7c86e5c75bb9fea1ef662c4";
+pub const PILOUT_HASH: &str = "802c6c935624191134a89ea26082c91f3d417181307c0f553d738b5fb5a2c22d";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 

--- a/pil/src/pil_helpers/traces.rs
+++ b/pil/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "e0eba363372313c7ee099cdbaa73f41d219eac982f53ab31d9edf87b4644a44e";
+pub const PILOUT_HASH: &str = "b779ac1d306d55d23de7009a652de914b1e17b8be7c86e5c75bb9fea1ef662c4";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 
@@ -351,7 +351,7 @@ trace_row!(Blake2brFixedRow<F> {
 pub type Blake2brFixed<F> = GenericTrace<Blake2brFixedRow<F>, 262144, 0, 19>;
 
 trace_row!(Blake2brTraceRow<F> {
- in_use:bit, round_idx:ubit(4), round_idx_sel:[bit; 10], sigma_idx:ubit(4), m_limbs:[[u16; 2]; 2], ms:[u32; 2], perm_active:bit, g_active:bit, va_limbs:[[u16; 2]; 2], vc_limbs:[[u16; 2]; 2], vb:[[bit; 32]; 2], vd:[[bit; 32]; 2], step_addr:ubit(40), in_use_clk_0:bit,
+ in_use:bit, round_idx:ubit(4), round_idx_sel:[bit; 10], sigma_idx:ubit(4), m_limbs:[[u16; 2]; 2], ms:[u32; 2], perm_active:bit, step_addr:ubit(40), op_step:ubit(40), g_active:bit, va_limbs:[[u16; 2]; 2], vc_limbs:[[u16; 2]; 2], vb:[[bit; 32]; 2], vd:[[bit; 32]; 2], in_use_clk_0:bit,
 });
 
 pub type Blake2brTrace<R> = GenericTrace<R, 262144, 0, 19>;
@@ -809,8 +809,8 @@ pub const PACKED_INFO: &[(usize, usize, PackedInfoConst)] = &[
     }),
     (0, 19, PackedInfoConst {
         is_packed: true,
-        num_packed_words: 7,
-        unpack_info: &[1, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 16, 16, 16, 16, 32, 32, 1, 1, 16, 16, 16, 16, 16, 16, 16, 16, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 40, 1],
+        num_packed_words: 8,
+        unpack_info: &[1, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 16, 16, 16, 16, 32, 32, 1, 40, 40, 1, 16, 16, 16, 16, 16, 16, 16, 16, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
     }),
     (0, 20, PackedInfoConst {
         is_packed: true,

--- a/precompiles/blake2/pil/blake2br.pil
+++ b/precompiles/blake2/pil/blake2br.pil
@@ -210,8 +210,22 @@ airtemplate Blake2br(const int N = 2**20) {
     const expr perm_active_expr = clock_set(in_use, start: 0, end: CLOCKS - NUM_G_FUNCTIONS, step: 2, skip: 1);
     perm_active <== perm_active_expr;
 
-    permutation_assumes(opid: BLAKE2BR_PERMUTATION_ID, expressions: [MSG_IDX, m[0], m[1]], sel: perm_active, sel_is_binary: 1);
-    permutation_proves(opid: BLAKE2BR_PERMUTATION_ID, expressions: [sigma_idx, ms[0], ms[1]], sel: perm_active, sel_is_binary: 1);
+    // Clocks where perm_active == 1
+    const int MSG_CLOCKS[16] = [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16, 18, 19, 21, 22];
+
+    // Operation step and address
+    col witness bits(40) step_addr;
+
+    const int STEP_MAIN = 0;
+    const int ADDR_OP = STEP_MAIN + 1;
+
+    // Per-call discriminator
+    col witness bits(40) op_step;
+    const expr op_step_expr = clock_shift_with_seq(step_addr, STEP_MAIN, seq: MSG_CLOCKS);
+    op_step <== op_step_expr;
+
+    permutation_assumes(opid: BLAKE2BR_PERMUTATION_ID, expressions: [MSG_IDX + 16 * op_step, m[0], m[1]], sel: perm_active, sel_is_binary: 1);
+    permutation_proves(opid: BLAKE2BR_PERMUTATION_ID, expressions: [sigma_idx + 16 * op_step, ms[0], ms[1]], sel: perm_active, sel_is_binary: 1);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // G-FUNCTION STATE VARIABLES
@@ -373,10 +387,6 @@ airtemplate Blake2br(const int N = 2**20) {
     //   - addr_input is read from addr_op + 16
     //   - Both must match the actual memory addresses used
 
-    col witness bits(40) step_addr;
-
-    const int STEP_MAIN = 0;
-    const int ADDR_OP = STEP_MAIN + 1;
     const int ADDR_STATE = ADDR_OP + 1;
     const int ADDR_INPUT = ADDR_STATE + 1;
     const int ADDR_IND_0 = ADDR_INPUT + 1;

--- a/precompiles/blake2/pil/blake2br.pil
+++ b/precompiles/blake2/pil/blake2br.pil
@@ -142,7 +142,7 @@ airtemplate Blake2br(const int N = 2**20) {
     col witness bits(4) round_idx;
     
     // Round index is constant within a round
-    (1 - CLK_0) * (round_idx - 'round_idx) === 0;
+    in_use * (1 - CLK_0) * (round_idx - 'round_idx) === 0;
 
     // One-hot encoding for round index selection
     col witness bits(1) round_idx_sel[10];


### PR DESCRIPTION
> Found by @eduadiez.
> 
> Summary
>   The Blake2b round AIR ties the permuted message ms (consumed by the G-functions) to the natural-order message m (bound to the call's input memory) only through a permutation argument that carries no per-instance discriminator:
>   // blake2br.pil:213-214
>   permutation_assumes(opid: BLAKE2BR_PERMUTATION_ID, expressions: [MSG_IDX,   m[0],  m[1]],  sel: perm_active, ...);
>   permutation_proves (opid: BLAKE2BR_PERMUTATION_ID, expressions: [sigma_idx, ms[0], ms[1]], sel: perm_active, ...);
>   MSG_IDX is a fixed column repeating identically for every call; opid 127 is used only by this AIR. The check is therefore a single global multiset equality over all Blake2 calls packed into the AIR table — it does not force each call's ms to be the SIGMA permutation of that call's m. The G-functions consume ms (blake2br.pil:299, :313), so a prover who balances the global multiset can feed one call's round function the message words of another call.

## Summary

Two related fixes to the BLAKE2b round AIR (`blake2br.pil`).

### 1. Soundness: tie the message permutation to a per-call discriminator

The round function consumes the SIGMA-permuted message words `ms`, which were bound to the natural-order, memory-bound words `m` **only** through an internal permutation argument carrying no per-instance tag:

```pil
permutation_assumes(opid: BLAKE2BR_PERMUTATION_ID, expressions: [MSG_IDX,   m[0],  m[1]],  sel: perm_active, ...);
permutation_proves (opid: BLAKE2BR_PERMUTATION_ID, expressions: [sigma_idx, ms[0], ms[1]], sel: perm_active, ...);
```

`MSG_IDX` repeats identically for every call and the opid is used only by this AIR, so the check was a single global multiset equality over all BLAKE2 calls packed into the table. It did not force each call's `ms` to be the SIGMA permutation of that call's `m`. Because the G-functions consume `ms`, a prover who balances the global multiset could feed one call's round function the message words of another call at the same index — exploitable by any program doing ≥2 compressions on different data.

**Fix**: tag every `(index, value)` pair with the call's main step, which is unique per call (steps strictly increase) and constant across the 24-row cycle. It is projected onto every message row via `clock_shift_with_seq(step_addr, STEP_MAIN, seq: MSG_CLOCKS)`. The step is folded into the index limb (`idx < 16`, so `16*op_step + idx` is injective and overflow-free), keeping the permutation bus width unchanged. The multiset can now only balance within a single call.

###  2. Completeness: round_idx constancy across the used→padding boundary

```pil
(1 - CLK_0) * (round_idx - 'round_idx) === 0;
```

`CLK_0` only fires at the start of the usable cycles. At the first padding row (row 262104 = 24·10921 with 10921 inputs, the maximum), `CLK_0 = 0`, so the constraint reduced to `round_idx[262104] == round_idx[262103]` — tying the padding row's round_idx to the last real round of the previous cycle and failing for any program that fills capacity.

**Fix**: gate by `in_use`:
```pil
in_use * (1 - CLK_0) * (round_idx - 'round_idx) === 0;
```
`in_use` is 0 on padding rows, making the constraint vacuous there, while within-cycle constancy is enforced exactly as before (`in_use = 1` on all 24 rows of a used cycle). Sound because `round_idx` only matters when `in_use = 1`, and all used cycles are contiguous at the start so there is no padding→used transition. This matches the `in_use`-gating idiom already used for `g_active`, `perm_active`, and `mem_sel`.

## Impact

Soundness fix plus a completeness fix that was blocking full-capacity inputs. No change to honest-prover behavior beyond enabling max-capacity proofs. The PILOUT hash changes, so setup/proving keys must be regenerated.
