### PR TITLE
Fix: enforce c[1] == 0 when set_pc is active (jump destination soundness)

### DIFF
--- a/pil/src/pil_helpers/traces.rs
+++ b/pil/src/pil_helpers/traces.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[allow(dead_code)]
 type FieldExtension<F> = [F; 3];
 
-pub const PILOUT_HASH: &str = "3615b752dac12c3dd5dc2d1b28541808d7da77acca86159f5c2dade9edfdc366";
+pub const PILOUT_HASH: &str = "8ada3a280a9af7a09fbf614eab1706090d85c3e2da3a39941857d4c778022ddc";
 
 pub const MERKLE_TREE_ARITY: u64 = 4;
 

--- a/state-machines/main/pil/main.pil
+++ b/state-machines/main/pil/main.pil
@@ -411,6 +411,17 @@ airtemplate Main(int N = 2**21, int RC = 2, int stack_enabled = 0,
     // The selectors flag an set_pc are disjoint, meaning they cannot be active simultaneously.
     flag * set_pc === 0;
 
+    // A user program lives in [0x8000_0000, 0x8000_0000 + 128MB), so any valid address plus a
+    // valid 12-bit (or 32-bit) offset is guaranteed to fit within a Goldilocks field element.
+    // If the result is "negative" or falls outside this range, proof generation will fail,
+    // because the program will have jumped to a non-existent address and the ROM lookup will fail.
+    // This constraint addresses a soundness issue: without it, if c[1] were non-zero,
+    // the jump destination would be computed using only c[0] + jmp_offset1 — ignoring the upper
+    // part of the address — which could silently land on a different but valid address, producing
+    // a valid proof for an incorrect jump target.
+    // To prevent this, c[1] is assumed to be zero, and this constraint enforces it.
+    set_pc * c[1] === 0;
+
     const expr expected_current_pc = 'set_pc * ('c[0] + 'jmp_offset1) + (1 - 'set_pc) * ('pc + 'jmp_offset2) + 'flag * ('jmp_offset1 - 'jmp_offset2);
     (1 - SEGMENT_L1) * (pc - expected_current_pc) === 0;
 


### PR DESCRIPTION
## Summary

Adds a soundness constraint to the `Main` AIR enforcing that the upper word of the jump destination address (`c[1]`) is zero whenever `set_pc` is active.

## Motivation

The jump destination is computed as:

    expected_current_pc = set_pc * (c[0] + jmp_offset1) + ...

This expression only uses `c[0]` (the lower word) and ignores `c[1]` (the upper word). Without an explicit constraint, a non-zero `c[1]` would be silently dropped from the computation. This is a soundness issue: a prover could land on a different — but still valid — address and produce a valid proof for an incorrect jump target.

## Why `c[1] === 0` is safe

A user program lives in the range `[0x8000_0000, 0x8000_0000 + 128MB)`. Any valid address plus a valid 12-bit (or 32-bit) offset always fits within a single Goldilocks field element, so the upper word `c[1]` is expected to be zero. If a result falls outside this range, proof generation fails anyway because the jump targets a non-existent address and the ROM lookup fails.

## Change

```pil
set_pc * c[1] === 0;
This closes the gap where the upper part of the address was ignored, ensuring
the jump destination is fully validated.