### PR TITLE
Fix rustflags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "rand 0.9.4",
  "rapidhash",
  "ruint",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "secp256k1",
  "serde",
  "sha3",
@@ -540,9 +540,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asm-runner"
@@ -789,26 +789,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex 1.3.0",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -822,7 +802,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shlex 1.3.0",
  "syn 2.0.118",
 ]
@@ -991,8 +971,7 @@ dependencies = [
 [[package]]
 name = "build-probe-mpi"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78ace2bb02fc18ad937f1599a853fcf3da2327bc1eb3c8e62b1f2fe4573bfd6"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
  "pkg-config",
  "shell-words",
@@ -1032,6 +1011,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "cargo-config2"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -1679,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "fields",
  "num-bigint",
@@ -2144,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "exps-codegen"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "anyhow",
  "rayon",
@@ -2207,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2704,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
@@ -3031,15 +3021,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3191,12 +3172,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "left-right"
@@ -3501,8 +3476,7 @@ dependencies = [
 [[package]]
 name = "mpi"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41457b69d35846af2fec1877a4f3b866a72b6ab2c9500218f115e65e10993b21"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
  "build-probe-mpi",
  "conv",
@@ -3516,10 +3490,9 @@ dependencies = [
 [[package]]
 name = "mpi-sys"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f655543f54b263cbc3d2456bf714bd807d66a33eff8f70136687f0776d34f76"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "build-probe-mpi",
  "cc",
 ]
@@ -3601,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3988,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "colored",
  "fields",
@@ -3998,7 +3971,7 @@ dependencies = [
  "proofman-hints",
  "proofman-util",
  "rayon",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tracing",
@@ -4008,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "pil2-stark-setup"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "anyhow",
  "clap",
@@ -4035,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "pilout"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bytes",
  "prost 0.13.5",
@@ -4446,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "blake3",
@@ -4480,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "borsh",
@@ -4511,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "fields",
  "itoa",
@@ -4524,7 +4497,7 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4534,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -4543,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "colored",
@@ -4554,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "fields",
@@ -4740,7 +4713,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -4761,7 +4734,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4894,9 +4867,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.2"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+checksum = "b1a224897b65b7ce38bf7b0adb569e7d77e11460d0cc3577908b263d8b5a89aa"
 dependencies = [
  "rustversion",
 ]
@@ -5203,15 +5176,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-hex"
@@ -5921,7 +5888,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stark-recurser"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "anyhow",
  "fields",
@@ -7517,7 +7484,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "colored",
  "fields",
@@ -7711,6 +7678,7 @@ version = "1.0.0-beta"
 dependencies = [
  "anyhow",
  "blake3",
+ "cargo-config2",
  "cargo_metadata",
  "clap",
  "rom-setup",
@@ -8138,7 +8106,7 @@ dependencies = [
 name = "zkvm-interface"
 version = "1.0.0-beta"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]

--- a/cli/src/commands/user/build.rs
+++ b/cli/src/commands/user/build.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Context, Result};
-use std::io::Write;
 use std::process::{Command, Stdio};
-use zisk_build::{HELPER_TARGET_SUBDIR, ZISK_LINKER_SCRIPT, ZISK_TARGET, ZISK_VERSION_MESSAGE};
+use zisk_build::{HELPER_TARGET_SUBDIR, ZISK_TARGET, ZISK_VERSION_MESSAGE};
 
 // Structure representing the 'build' subcommand of cargo.
 #[derive(clap::Args)]
@@ -53,28 +52,10 @@ impl BuildCmd {
         let mut command = Command::new("cargo");
         command.args(self.cargo_args(toolchain_name));
 
-        // Write the linker script to a uniquely-named temp file. A predictable
-        // path (`$TMPDIR/zisk.ld`) can race across concurrent invocations and is
-        // exposed to temp-file symlink attacks. Keep the handle alive until cargo
-        // finishes so the file is not removed while the linker still needs it.
-        let mut linker_script = tempfile::Builder::new()
-            .prefix("zisk-")
-            .suffix(".ld")
-            .tempfile()
-            .context("Failed to create temporary Zisk linker script")?;
-        linker_script
-            .write_all(ZISK_LINKER_SCRIPT)
-            .context("Failed to write Zisk linker script to temp file")?;
-
-        // Add linker script flag and zisk_guest cfg to RUSTFLAGS, preserving any existing flags
-        let current_rust_flags = std::env::var("RUSTFLAGS").unwrap_or_default();
-        let rust_flags = format!(
-            "{current_rust_flags} --cfg zisk_guest -C link-arg=-T{}",
-            linker_script.path().display()
-        )
-        .trim()
-        .to_string();
-        command.env("RUSTFLAGS", rust_flags);
+        // Guest rustflags + linker script; keep the temp file alive until cargo
+        // finishes. Env rustflags are inherited: in a direct CLI invocation
+        // they are user-exported and cargo would apply them to the guest.
+        let _linker_script = zisk_build::apply_guest_rustflags(&mut command, None, true)?;
 
         // Set up the command to inherit the parent's stdout and stderr
         command.stdout(Stdio::inherit());

--- a/cli/src/commands/user/run.rs
+++ b/cli/src/commands/user/run.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Context, Result};
-use std::io::Write;
 use std::process::{Command, Stdio};
-use zisk_build::{HELPER_TARGET_SUBDIR, ZISK_LINKER_SCRIPT, ZISK_TARGET, ZISK_VERSION_MESSAGE};
+use zisk_build::{HELPER_TARGET_SUBDIR, ZISK_TARGET, ZISK_VERSION_MESSAGE};
 use zisk_common::io::ZiskStdin;
 use zisk_prover_backend::{GuestProgram, ProfilingMode};
 
@@ -51,28 +50,10 @@ impl RunCmd {
                 let mut command = Command::new("cargo");
                 command.args(self.cargo_build_args());
 
-                // Write the linker script to a uniquely-named temp file. A predictable
-                // path (`$TMPDIR/zisk.ld`) can race across concurrent invocations and is
-                // exposed to temp-file symlink attacks. Keep the handle alive until cargo
-                // finishes so the file is not removed while the linker still needs it.
-                let mut linker_script = tempfile::Builder::new()
-                    .prefix("zisk-")
-                    .suffix(".ld")
-                    .tempfile()
-                    .context("Failed to create temporary Zisk linker script")?;
-                linker_script
-                    .write_all(ZISK_LINKER_SCRIPT)
-                    .context("Failed to write Zisk linker script to temp file")?;
-
-                // Add linker script flag and zisk_guest cfg to RUSTFLAGS, preserving any existing flags
-                let current_rust_flags = std::env::var("RUSTFLAGS").unwrap_or_default();
-                let rust_flags = format!(
-                    "{current_rust_flags} --cfg zisk_guest -C link-arg=-T{}",
-                    linker_script.path().display()
-                )
-                .trim()
-                .to_string();
-                command.env("RUSTFLAGS", rust_flags);
+                // Guest rustflags + linker script; keep the temp file alive
+                // until cargo finishes. Env rustflags are inherited: they are
+                // user-exported in a direct CLI invocation.
+                let _linker_script = zisk_build::apply_guest_rustflags(&mut command, None, true)?;
 
                 command.stdout(Stdio::inherit());
                 command.stderr(Stdio::inherit());

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
  "rand 0.9.4",
  "rapidhash",
  "ruint",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "secp256k1",
  "serde",
  "sha3",
@@ -529,9 +529,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asm-runner"
@@ -738,26 +738,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex 1.3.0",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -771,7 +751,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shlex 1.3.0",
  "syn 2.0.118",
 ]
@@ -926,8 +906,7 @@ dependencies = [
 [[package]]
 name = "build-probe-mpi"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78ace2bb02fc18ad937f1599a853fcf3da2327bc1eb3c8e62b1f2fe4573bfd6"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
  "pkg-config",
  "shell-words",
@@ -990,6 +969,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "cargo-config2"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -1432,7 +1422,7 @@ dependencies = [
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "fields",
  "num-bigint",
@@ -1895,7 +1885,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2584,15 +2574,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2733,12 +2714,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lib-c"
@@ -2961,8 +2936,7 @@ dependencies = [
 [[package]]
 name = "mpi"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41457b69d35846af2fec1877a4f3b866a72b6ab2c9500218f115e65e10993b21"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
  "build-probe-mpi",
  "conv",
@@ -2976,10 +2950,9 @@ dependencies = [
 [[package]]
 name = "mpi-sys"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f655543f54b263cbc3d2456bf714bd807d66a33eff8f70136687f0776d34f76"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "build-probe-mpi",
  "cc",
 ]
@@ -3084,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3343,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "colored",
  "fields",
@@ -3353,7 +3326,7 @@ dependencies = [
  "proofman-hints",
  "proofman-util",
  "rayon",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tracing",
@@ -3715,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "blake3",
@@ -3749,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "borsh",
@@ -3780,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "fields",
  "itoa",
@@ -3793,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3803,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -3812,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "colored",
@@ -3823,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "fields",
@@ -3962,7 +3935,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3983,7 +3956,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4037,9 +4010,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rancor"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
 dependencies = [
  "ptr_meta",
 ]
@@ -4116,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.2"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+checksum = "b1a224897b65b7ce38bf7b0adb569e7d77e11460d0cc3577908b263d8b5a89aa"
 dependencies = [
  "rustversion",
 ]
@@ -4208,9 +4181,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 dependencies = [
  "bytecheck",
 ]
@@ -4267,9 +4240,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -4286,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4363,15 +4336,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-hex"
@@ -4406,7 +4373,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 1.0.69",
- "toml",
+ "toml 0.8.23",
  "toolchain_find",
 ]
 
@@ -4711,6 +4678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5313,9 +5289,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5344,7 +5333,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -6345,7 +6334,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "colored",
  "fields",
@@ -6528,6 +6517,7 @@ version = "1.0.0-beta"
 dependencies = [
  "anyhow",
  "blake3",
+ "cargo-config2",
  "cargo_metadata",
  "clap",
  "rom-setup",
@@ -6813,7 +6803,7 @@ dependencies = [
 name = "zkvm-interface"
 version = "1.0.0-beta"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]

--- a/test-artifacts/Cargo.lock
+++ b/test-artifacts/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "rand 0.9.4",
  "rapidhash",
  "ruint",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "secp256k1",
  "serde",
  "sha3",
@@ -519,9 +519,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asm-runner"
@@ -719,26 +719,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex 1.3.0",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -752,7 +732,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shlex 1.3.0",
  "syn 2.0.118",
 ]
@@ -907,8 +887,7 @@ dependencies = [
 [[package]]
 name = "build-probe-mpi"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78ace2bb02fc18ad937f1599a853fcf3da2327bc1eb3c8e62b1f2fe4573bfd6"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
  "pkg-config",
  "shell-words",
@@ -948,6 +927,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "cargo-config2"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -1358,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "fields",
  "num-bigint",
@@ -1792,7 +1782,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2425,15 +2415,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2574,12 +2555,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lib-c"
@@ -2794,8 +2769,7 @@ dependencies = [
 [[package]]
 name = "mpi"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41457b69d35846af2fec1877a4f3b866a72b6ab2c9500218f115e65e10993b21"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
  "build-probe-mpi",
  "conv",
@@ -2809,10 +2783,9 @@ dependencies = [
 [[package]]
 name = "mpi-sys"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f655543f54b263cbc3d2456bf714bd807d66a33eff8f70136687f0776d34f76"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "build-probe-mpi",
  "cc",
 ]
@@ -2888,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3147,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "colored",
  "fields",
@@ -3157,7 +3130,7 @@ dependencies = [
  "proofman-hints",
  "proofman-util",
  "rayon",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tracing",
@@ -3493,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "blake3",
@@ -3527,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "borsh",
@@ -3558,7 +3531,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "fields",
  "itoa",
@@ -3571,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3581,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -3590,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "colored",
@@ -3601,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "fields",
@@ -3720,7 +3693,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3741,7 +3714,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -3865,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.2"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+checksum = "b1a224897b65b7ce38bf7b0adb569e7d77e11460d0cc3577908b263d8b5a89aa"
 dependencies = [
  "rustversion",
 ]
@@ -4073,15 +4046,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-hex"
@@ -4116,7 +4083,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 1.0.69",
- "toml",
+ "toml 0.8.23",
  "toolchain_find",
 ]
 
@@ -4421,6 +4388,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -4989,9 +4965,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5020,7 +5009,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -6021,7 +6010,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "colored",
  "fields",
@@ -6204,9 +6193,11 @@ version = "1.0.0-beta"
 dependencies = [
  "anyhow",
  "blake3",
+ "cargo-config2",
  "cargo_metadata",
  "clap",
  "rom-setup",
+ "tempfile",
  "vergen-git2",
 ]
 
@@ -6488,7 +6479,7 @@ dependencies = [
 name = "zkvm-interface"
 version = "1.0.0-beta"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]

--- a/test-artifacts/programs/Cargo.lock
+++ b/test-artifacts/programs/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "rand 0.9.4",
  "rapidhash",
  "ruint",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "secp256k1 0.31.1",
  "serde",
  "sha3",
@@ -554,9 +554,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asm-runner"
@@ -768,26 +768,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex 1.3.0",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -801,7 +781,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shlex 1.3.0",
  "syn 2.0.118",
 ]
@@ -1050,8 +1030,7 @@ dependencies = [
 [[package]]
 name = "build-probe-mpi"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78ace2bb02fc18ad937f1599a853fcf3da2327bc1eb3c8e62b1f2fe4573bfd6"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
  "pkg-config",
  "shell-words",
@@ -1091,6 +1070,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "cargo-config2"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -1501,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "fields",
  "num-bigint",
@@ -1957,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2597,15 +2587,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2756,12 +2737,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lib-c"
@@ -2990,8 +2965,7 @@ dependencies = [
 [[package]]
 name = "mpi"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41457b69d35846af2fec1877a4f3b866a72b6ab2c9500218f115e65e10993b21"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
  "build-probe-mpi",
  "conv",
@@ -3005,10 +2979,9 @@ dependencies = [
 [[package]]
 name = "mpi-sys"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f655543f54b263cbc3d2456bf714bd807d66a33eff8f70136687f0776d34f76"
+source = "git+https://github.com/rsmpi/rsmpi?rev=fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6#fa1dc36cb9918fa4dc3a9626bc18c523d2b280a6"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "build-probe-mpi",
  "cc",
 ]
@@ -3084,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3350,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "colored",
  "fields",
@@ -3360,7 +3333,7 @@ dependencies = [
  "proofman-hints",
  "proofman-util",
  "rayon",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tracing",
@@ -3714,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "blake3",
@@ -3748,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "borsh",
@@ -3779,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "fields",
  "itoa",
@@ -3792,7 +3765,7 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3802,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -3811,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "colored",
@@ -3822,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "bincode",
  "fields",
@@ -3941,7 +3914,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3962,7 +3935,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4086,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.2"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+checksum = "b1a224897b65b7ce38bf7b0adb569e7d77e11460d0cc3577908b263d8b5a89aa"
 dependencies = [
  "rustversion",
 ]
@@ -4294,15 +4267,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-hex"
@@ -4337,7 +4304,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 1.0.69",
- "toml",
+ "toml 0.8.23",
  "toolchain_find",
 ]
 
@@ -4684,6 +4651,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5256,9 +5232,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5287,7 +5276,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -6296,7 +6285,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#8bcb442bc172eafa25c12f53e1d79f9681fb99bf"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#32e0758da898254faeac08c97c8114fb822ae63b"
 dependencies = [
  "colored",
  "fields",
@@ -6479,6 +6468,7 @@ version = "1.0.0-beta"
 dependencies = [
  "anyhow",
  "blake3",
+ "cargo-config2",
  "cargo_metadata",
  "clap",
  "rom-setup",
@@ -6764,7 +6754,7 @@ dependencies = [
 name = "zkvm-interface"
 version = "1.0.0-beta"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]

--- a/tools/test-env/test_diagnostic.sh
+++ b/tools/test-env/test_diagnostic.sh
@@ -11,17 +11,12 @@ main() {
 
     PROGRAMS_DIR="$(get_zisk_repo_dir)/test-artifacts/programs"
     ELF_FILE="${PROGRAMS_DIR}/target/elf/riscv64ima-zisk-zkvm-elf/release/diagnostic"
-    ZISK_LINKER_SCRIPT="$(get_zisk_repo_dir)/ziskbuild/zisk_linker_script.ld"
 
     info "Building diagnostic ELF..."
     cd "${PROGRAMS_DIR}" || return 1
-    
-    # Append to any RUSTFLAGS already set in the environment instead of replacing
-    # them. `${RUSTFLAGS:+$RUSTFLAGS }` expands to the existing flags plus a space
-    # only when RUSTFLAGS is non-empty, so there is no stray leading space.
-    ensure env CARGO_TARGET_DIR="${PROGRAMS_DIR}/target/elf" \
-           env RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-T${ZISK_LINKER_SCRIPT}" \
-        cargo +zisk build --release  -p diagnostic --target riscv64ima-zisk-zkvm-elf || return 1
+
+    # cargo-zisk injects the Zisk linker script and preserves config.toml rustflags.
+    ensure cargo-zisk build --release -p diagnostic || return 1
 
     cd "${WORKSPACE_DIR}" || return 1
     DIAGNOSTIC_INPUTS_SINGLE="empty"

--- a/ziskbuild/Cargo.toml
+++ b/ziskbuild/Cargo.toml
@@ -10,6 +10,7 @@ categories.workspace = true
 [dependencies]
 clap = { workspace = true }
 cargo_metadata = "0.23.0"
+cargo-config2 = "0.1"
 anyhow = { workspace = true }
 rom-setup = { workspace = true }
 blake3 = { workspace = true }

--- a/ziskbuild/src/build.rs
+++ b/ziskbuild/src/build.rs
@@ -1,11 +1,11 @@
 use crate::{
     command::create_command, utils::cargo_rerun_if_changed, BuildArgs, HELPER_TARGET_SUBDIR,
-    ZISK_LINKER_SCRIPT, ZISK_TARGET,
+    ZISK_TARGET,
 };
 use cargo_metadata::camino::Utf8PathBuf;
 use rom_setup::{assembly_files_exist, gen_assembly, get_assembly_file_paths, get_output_path};
 use std::{
-    io::{BufRead, BufReader, Write},
+    io::{BufRead, BufReader},
     path::PathBuf,
     process::{exit, Command, Stdio},
     thread,
@@ -56,7 +56,7 @@ pub(crate) fn build_program_internal(path: &str, args: Option<BuildArgs>) {
         execute_build_program(&default_args, Some(program_dir.to_path_buf()))
     };
     if let Err(err) = path_output {
-        panic!("Failed to build ZisK program: {err}.");
+        panic!("Failed to build ZisK program: {err:#}.");
     }
 }
 
@@ -85,30 +85,11 @@ pub fn execute_build_program(
     // Get the command corresponding to Docker or local build.
     let mut cmd = create_command(args, &program_dir, &program_metadata)?;
 
-    // Zisk linker script injection
-
-    // Write the linker script to a uniquely-named temp file. A predictable
-    // path (`$TMPDIR/zisk.ld`) can race across concurrent invocations and is
-    // exposed to temp-file symlink attacks. Keep the handle alive until cargo
-    // finishes so the file is not removed while the linker still needs it.
-    let mut linker_script = tempfile::Builder::new()
-        .prefix("zisk-")
-        .suffix(".ld")
-        .tempfile()
-        .context("Failed to create temporary Zisk linker script")?;
-    linker_script
-        .write_all(ZISK_LINKER_SCRIPT)
-        .context("Failed to write Zisk linker script to temp file")?;
-
-    // Add linker script flag and zisk_guest cfg to RUSTFLAGS, preserving any existing flags
-    let current_rust_flags = std::env::var("RUSTFLAGS").unwrap_or_default();
-    let rust_flags = format!(
-        "{current_rust_flags} --cfg zisk_guest -C link-arg=-T{}",
-        linker_script.path().display()
-    )
-    .trim()
-    .to_string();
-    cmd.env("RUSTFLAGS", rust_flags);
+    // Guest rustflags + linker script; keep the temp file alive until cargo
+    // finishes. Env rustflags are NOT inherited: in this build-script context
+    // they are the host build's flags, injected by the outer cargo.
+    let _linker_script =
+        crate::apply_guest_rustflags(&mut cmd, Some(program_dir.as_std_path()), false)?;
 
     let target_elf_paths = generate_elf_paths(&program_metadata, Some(args))?;
 

--- a/ziskbuild/src/command.rs
+++ b/ziskbuild/src/command.rs
@@ -46,40 +46,9 @@ pub(crate) fn create_command(
     //     return Err(anyhow!("Cargo run command failed with status {}", status));
     // }
 
-    let rustc_bin = {
-        let output = Command::new("rustc")
-            .env("RUSTUP_TOOLCHAIN", crate::RUSTUP_TOOLCHAIN_NAME)
-            .arg("--print")
-            .arg("sysroot")
-            .output()
-            .map_err(|_| {
-                anyhow::anyhow!(
-                    "ZisK toolchain '{}' is not installed or rustup is not available.\n\
-                     Run `cargo zisk toolchain install` to install it.",
-                    crate::RUSTUP_TOOLCHAIN_NAME
-                )
-            })?;
+    let rustc_bin = zisk_rustc()?;
 
-        if !output.status.success() {
-            anyhow::bail!(
-                "ZisK toolchain '{}' is not installed.\n\
-                 Run `cargo zisk toolchain install` to install it.",
-                crate::RUSTUP_TOOLCHAIN_NAME
-            );
-        }
-
-        let stdout_string =
-            String::from_utf8(output.stdout).context("Can't parse rustc --print sysroot stdout")?;
-
-        PathBuf::from(stdout_string.trim()).join("bin/rustc")
-    };
-
-    command
-        .env_remove("RUSTC")
-        .env("RUSTC", rustc_bin.display().to_string())
-        .env_remove("RUSTFLAGS")
-        .env_remove("RUSTC_WORKSPACE_WRAPPER")
-        .env_remove("CARGO_ENCODED_RUSTFLAGS");
+    command.env("RUSTC", rustc_bin.display().to_string()).env_remove("RUSTC_WORKSPACE_WRAPPER");
 
     let canonicalized_program_dir =
         program_dir.canonicalize().context("Failed to canonicalize program directory")?;
@@ -89,4 +58,44 @@ pub(crate) fn create_command(
     command.env("CARGO_TARGET_DIR", program_metadata.target_directory.join(HELPER_TARGET_SUBDIR));
 
     Ok(command)
+}
+
+/// Path to the ZisK toolchain's rustc (`<sysroot>/bin/rustc`) — the only rustc
+/// that can load the custom guest target spec. Cached: both `create_command`
+/// and `guest_rustflags` need it, and the sysroot cannot change mid-process.
+pub(crate) fn zisk_rustc() -> Result<PathBuf> {
+    static ZISK_RUSTC: std::sync::OnceLock<std::result::Result<PathBuf, String>> =
+        std::sync::OnceLock::new();
+    ZISK_RUSTC
+        .get_or_init(|| zisk_rustc_lookup().map_err(|err| format!("{err:#}")))
+        .clone()
+        .map_err(|err| anyhow::anyhow!(err))
+}
+
+fn zisk_rustc_lookup() -> Result<PathBuf> {
+    let output = Command::new("rustc")
+        .env("RUSTUP_TOOLCHAIN", crate::RUSTUP_TOOLCHAIN_NAME)
+        .arg("--print")
+        .arg("sysroot")
+        .output()
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "ZisK toolchain '{}' is not installed or rustup is not available.\n\
+                 Run `cargo zisk toolchain install` to install it.",
+                crate::RUSTUP_TOOLCHAIN_NAME
+            )
+        })?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "ZisK toolchain '{}' is not installed.\n\
+             Run `cargo zisk toolchain install` to install it.",
+            crate::RUSTUP_TOOLCHAIN_NAME
+        );
+    }
+
+    let stdout_string =
+        String::from_utf8(output.stdout).context("Can't parse rustc --print sysroot stdout")?;
+
+    Ok(PathBuf::from(stdout_string.trim()).join("bin/rustc"))
 }

--- a/ziskbuild/src/lib.rs
+++ b/ziskbuild/src/lib.rs
@@ -26,6 +26,48 @@ pub const ZISK_TARGET: &str = "riscv64ima-zisk-zkvm-elf";
 
 pub const HELPER_TARGET_SUBDIR: &str = "elf";
 
+/// Global rustflags env vars, in cargo's precedence order. In a build script
+/// (or a shell targeting the host) they describe the HOST build, so they must
+/// never reach guest flag resolution — see `guest_rustflags`.
+pub(crate) const HOST_RUSTFLAGS_VARS: &[&str] =
+    &["CARGO_ENCODED_RUSTFLAGS", "RUSTFLAGS", "CARGO_BUILD_RUSTFLAGS"];
+
+/// Cargo's per-target rustflags env var for the guest
+/// (`CARGO_TARGET_RISCV64IMA_ZISK_ZKVM_ELF_RUSTFLAGS`).
+fn guest_target_rustflags_var() -> String {
+    format!("CARGO_TARGET_{}_RUSTFLAGS", ZISK_TARGET.to_uppercase().replace(['-', '.'], "_"))
+}
+
+/// Every rustflags env var cargo would consult for the guest target — the
+/// single source of truth for the set that must be filtered from config
+/// resolution and scrubbed from a child cargo. Callers apply their own filter.
+fn all_rustflags_vars() -> impl Iterator<Item = String> {
+    HOST_RUSTFLAGS_VARS.iter().map(|v| v.to_string()).chain([guest_target_rustflags_var()])
+}
+
+/// The rustflags cargo would take from the environment for the guest, honoring
+/// cargo's precedence: exactly one source wins, first set of
+/// `CARGO_ENCODED_RUSTFLAGS` (`\x1f`) > `RUSTFLAGS` (spaces) > the per-target
+/// var (spaces) > `CARGO_BUILD_RUSTFLAGS` (spaces). Cargo treats these as
+/// mutually exclusive — a set global source *overrides* the per-target var
+/// rather than combining with it — so we must not append lower tiers on top.
+fn env_rustflags() -> Vec<String> {
+    use cargo_config2::Flags;
+    // `to_string_lossy` at the boundary matches cargo-config2, whose `Flags`
+    // parsers take `&str`; a non-UTF8 byte becomes U+FFFD either way.
+    if let Some(encoded) = std::env::var_os("CARGO_ENCODED_RUSTFLAGS") {
+        Flags::from_encoded(&encoded.to_string_lossy()).flags
+    } else if let Some(rustflags) = std::env::var_os("RUSTFLAGS") {
+        Flags::from_space_separated(&rustflags.to_string_lossy()).flags
+    } else if let Some(target_flags) = std::env::var_os(guest_target_rustflags_var()) {
+        Flags::from_space_separated(&target_flags.to_string_lossy()).flags
+    } else if let Some(build_flags) = std::env::var_os("CARGO_BUILD_RUSTFLAGS") {
+        Flags::from_space_separated(&build_flags.to_string_lossy()).flags
+    } else {
+        Vec::new()
+    }
+}
+
 /// Arguments for building a ZisK program.
 #[derive(Default, Clone, Parser, Debug)]
 #[command(author, about, long_about = None, version = ZISK_VERSION_MESSAGE)]
@@ -61,6 +103,119 @@ pub struct BuildArgs {
     pub binaries: Vec<String>,
 }
 
+/// Rustflags environment for compiling a Zisk guest: the flags
+/// `.cargo/config.toml` declares for the guest target (resolved from
+/// `program_dir`, defaulting to the current directory) plus `--cfg zisk_guest`
+/// and the Zisk linker script. Returns the script's temp file — keep it alive
+/// until cargo finishes — and the `CARGO_ENCODED_RUSTFLAGS` value.
+///
+/// Config rustflags are always preserved (e.g. the reth guest's
+/// `--inline-threshold` tuning): since we set `CARGO_ENCODED_RUSTFLAGS`
+/// ourselves, cargo would otherwise ignore them.
+///
+/// `inherit_env_rustflags` controls whether the winning env rustflags source
+/// (see `env_rustflags`) is folded in too, appended after config. Pass `true`
+/// from direct CLI invocations (`cargo-zisk build`/`run`), where cargo would
+/// apply the user's exported vars to the guest; pass `false` from build
+/// scripts, where the outer cargo sets `CARGO_ENCODED_RUSTFLAGS` to HOST flags
+/// whose link args (e.g. `-Wl,--export-dynamic`) break the guest link.
+pub fn guest_rustflags(
+    program_dir: Option<&std::path::Path>,
+    inherit_env_rustflags: bool,
+) -> anyhow::Result<(tempfile::NamedTempFile, String)> {
+    use anyhow::Context;
+    use std::io::Write;
+
+    // Write the linker script to a uniquely-named temp file. A predictable
+    // path (`$TMPDIR/zisk.ld`) can race across concurrent invocations and is
+    // exposed to temp-file symlink attacks. The caller keeps the handle alive
+    // until cargo finishes so the file is not removed while the linker still
+    // needs it.
+    let mut linker_script = tempfile::Builder::new()
+        .prefix("zisk-")
+        .suffix(".ld")
+        .tempfile()
+        .context("Failed to create temporary Zisk linker script")?;
+    linker_script
+        .write_all(ZISK_LINKER_SCRIPT)
+        .context("Failed to write Zisk linker script to temp file")?;
+
+    // Resolve config rustflags with every rustflags env var filtered out: cargo
+    // would otherwise let them override or shadow the program's config flags. We
+    // fold them back in below (in inherit mode) so no source is lost.
+    let ignored: Vec<std::ffi::OsString> =
+        all_rustflags_vars().map(std::ffi::OsString::from).collect();
+    let env = std::env::vars_os().filter(|(key, _)| !ignored.contains(key));
+    let mut options = cargo_config2::ResolveOptions::default().env(env);
+    // `[target.'cfg(...)']` sections must be evaluated with the ZisK rustc —
+    // the host rustc cannot load the guest target spec. Resolution needs
+    // rustc only for such sections, so a missing toolchain is not fatal here;
+    // it is attached as context if resolution does fail.
+    let zisk_rustc = command::zisk_rustc();
+    if let Ok(rustc) = &zisk_rustc {
+        options = options.rustc(cargo_config2::PathAndArgs::new(rustc));
+    }
+    // Canonicalized so the config walk covers the real ancestor chain — build
+    // scripts pass relative dirs like "../guest", whose lexical ancestors
+    // stop short of the directories cargo itself would consult.
+    let cwd = match program_dir {
+        Some(dir) => dir.canonicalize().with_context(|| {
+            format!("Failed to canonicalize program directory {}", dir.display())
+        })?,
+        None => std::env::current_dir().context("Failed to get current directory")?,
+    };
+    // A config cargo would reject fails the build here too, instead of
+    // silently dropping the program's flags.
+    let mut flags = cargo_config2::Config::load_with_options(cwd, options)
+        .and_then(|config| config.rustflags(ZISK_TARGET))
+        .map(|flags| flags.map(|f| f.flags).unwrap_or_default())
+        .map_err(|err| match zisk_rustc {
+            Err(toolchain_err) => anyhow::Error::from(err).context(toolchain_err),
+            Ok(_) => anyhow::Error::from(err),
+        })
+        .with_context(|| format!("Failed to resolve cargo rustflags for target {ZISK_TARGET}"))?;
+    // Drop empty elements: encoded, they decode to an empty rustc argument,
+    // which rustc rejects as an extra input filename.
+    flags.retain(|f| !f.is_empty());
+    // Append env rustflags after config so env wins (later rustc args win).
+    if inherit_env_rustflags {
+        flags.extend(env_rustflags());
+    }
+    flags.extend([
+        "--cfg".to_string(),
+        "zisk_guest".to_string(),
+        "-C".to_string(),
+        format!("link-arg=-T{}", linker_script.path().display()),
+    ]);
+    // `Flags::encode` `\x1f`-joins (wins over plain RUSTFLAGS, survives spaces)
+    // and errors if a flag itself contains `\x1f` rather than silently
+    // producing a value cargo would mis-split.
+    let encoded =
+        cargo_config2::Flags::from(flags).encode().context("Failed to encode guest rustflags")?;
+    Ok((linker_script, encoded))
+}
+
+/// Configures `command` (a child `cargo` invocation) to build the guest with
+/// the correct rustflags: sets `CARGO_ENCODED_RUSTFLAGS` from `guest_rustflags`
+/// and scrubs the other rustflags env vars so cargo cannot re-apply them on top
+/// or shift precedence. Returns the linker-script temp file — the caller MUST
+/// keep it alive until `cargo` finishes. Pairing the set and scrub in one place
+/// keeps them from drifting apart across call sites. See `guest_rustflags` for
+/// `program_dir` / `inherit_env_rustflags`.
+pub fn apply_guest_rustflags(
+    command: &mut std::process::Command,
+    program_dir: Option<&std::path::Path>,
+    inherit_env_rustflags: bool,
+) -> anyhow::Result<tempfile::NamedTempFile> {
+    let (linker_script, encoded_rustflags) = guest_rustflags(program_dir, inherit_env_rustflags)?;
+    command.env("CARGO_ENCODED_RUSTFLAGS", encoded_rustflags);
+    // `CARGO_ENCODED_RUSTFLAGS` is the value we just set; scrub the rest.
+    for var in all_rustflags_vars().filter(|v| v != "CARGO_ENCODED_RUSTFLAGS") {
+        command.env_remove(var);
+    }
+    Ok(linker_script)
+}
+
 pub fn build_program(path: &str) {
     build_program_internal(path, None)
 }
@@ -72,4 +227,248 @@ pub fn build_program_asm(path: &str) {
 
 pub fn build_program_with_args(path: &str, args: BuildArgs) {
     build_program_internal(path, Some(args))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serializes tests that touch process-global env vars (tests run in
+    /// parallel threads by default).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Unsets env vars for the test's duration and restores their original
+    /// values on drop (also on panic), so parallel tests aren't contaminated.
+    struct EnvVarGuard {
+        saved: Vec<(String, Option<std::ffi::OsString>)>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvVarGuard {
+        /// Unsets the host and per-target rustflags vars and points CARGO_HOME
+        /// at an empty dir under `dir`, so the machine's ~/.cargo/config.toml
+        /// cannot inject flags into the test; restores everything on drop.
+        fn hermetic(dir: &std::path::Path) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let cleared: Vec<String> = all_rustflags_vars().collect();
+            let mut saved: Vec<(String, Option<std::ffi::OsString>)> =
+                cleared.iter().map(|k| (k.clone(), std::env::var_os(k))).collect();
+            saved.push(("CARGO_HOME".to_string(), std::env::var_os("CARGO_HOME")));
+            for k in &cleared {
+                std::env::remove_var(k);
+            }
+            let cargo_home = dir.join("cargo-home");
+            std::fs::create_dir_all(&cargo_home).unwrap();
+            std::env::set_var("CARGO_HOME", cargo_home);
+            Self { saved, _lock: lock }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    /// The program's `.cargo/config.toml` rustflags must survive the injection:
+    /// setting the rustflags env makes cargo ignore config files, so dropping
+    /// them here silently de-optimizes guests (see `guest_rustflags`).
+    #[test]
+    fn guest_rustflags_keeps_config_and_appends_zisk_flags() {
+        let dir = tempfile::tempdir().unwrap();
+        // Env rustflags would shadow the config file (cargo precedence).
+        let _env = EnvVarGuard::hermetic(dir.path());
+        std::fs::create_dir(dir.path().join(".cargo")).unwrap();
+        std::fs::write(
+            dir.path().join(".cargo/config.toml"),
+            format!(
+                "[target.{ZISK_TARGET}]\nrustflags = [\"-C\", \"llvm-args=--inline-threshold=1234\"]\n"
+            ),
+        )
+        .unwrap();
+
+        let (script, encoded) = guest_rustflags(Some(dir.path()), false).unwrap();
+        let flags: Vec<&str> = encoded.split('\u{1f}').collect();
+
+        let config_flag = flags
+            .iter()
+            .position(|f| *f == "llvm-args=--inline-threshold=1234")
+            .expect("config rustflags dropped");
+        let cfg_flag =
+            flags.iter().position(|f| *f == "zisk_guest").expect("missing --cfg zisk_guest");
+        let t_flag = format!("link-arg=-T{}", script.path().display());
+        assert!(flags.contains(&t_flag.as_str()), "missing linker-script flag");
+        // Zisk additions come after the program's own flags.
+        assert!(config_flag < cfg_flag);
+        // The temp file holds the Zisk linker script.
+        assert_eq!(std::fs::read(script.path()).unwrap(), ZISK_LINKER_SCRIPT);
+    }
+
+    /// An empty encoded-rustflags element decodes to an empty rustc argument,
+    /// which rustc rejects as an extra input filename.
+    #[test]
+    fn guest_rustflags_drops_empty_flags() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvVarGuard::hermetic(dir.path());
+        std::fs::create_dir(dir.path().join(".cargo")).unwrap();
+        std::fs::write(
+            dir.path().join(".cargo/config.toml"),
+            format!("[target.{ZISK_TARGET}]\nrustflags = [\"\"]\n"),
+        )
+        .unwrap();
+
+        let (_script, encoded) = guest_rustflags(Some(dir.path()), false).unwrap();
+        assert!(
+            encoded.split('\u{1f}').all(|f| !f.is_empty()),
+            "empty flag element in {encoded:?}"
+        );
+    }
+
+    /// Build scripts run with `CARGO_ENCODED_RUSTFLAGS` set by the outer cargo
+    /// to the HOST build's flags (and possibly a user-exported `RUSTFLAGS`).
+    /// Those must not reach the guest: host link args such as
+    /// `-Wl,--export-dynamic` are rejected by the guest's rust-lld.
+    #[test]
+    fn guest_rustflags_ignores_host_env_rustflags() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvVarGuard::hermetic(dir.path());
+        std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "-C\u{1f}link-arg=-Wl,--export-dynamic");
+        std::env::set_var("RUSTFLAGS", "-C target-cpu=native");
+        std::env::set_var("CARGO_BUILD_RUSTFLAGS", "-C link-arg=--host-only-marker");
+
+        let (_script, encoded) = guest_rustflags(Some(dir.path()), false).unwrap();
+        assert!(
+            !encoded.contains("export-dynamic"),
+            "host CARGO_ENCODED_RUSTFLAGS leaked into guest flags: {encoded:?}"
+        );
+        assert!(
+            !encoded.contains("target-cpu"),
+            "host RUSTFLAGS leaked into guest flags: {encoded:?}"
+        );
+        assert!(
+            !encoded.contains("host-only-marker"),
+            "host CARGO_BUILD_RUSTFLAGS leaked into guest flags: {encoded:?}"
+        );
+    }
+
+    /// Direct CLI invocations (`cargo-zisk build`/`run`) inherit user-exported
+    /// rustflags env vars, matching what cargo itself would apply to the guest.
+    #[test]
+    fn guest_rustflags_inherits_env_rustflags_when_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvVarGuard::hermetic(dir.path());
+        std::env::set_var("RUSTFLAGS", "--cfg my_guest_feature");
+
+        let (_script, encoded) = guest_rustflags(Some(dir.path()), true).unwrap();
+        let flags: Vec<&str> = encoded.split('\u{1f}').collect();
+        assert!(
+            flags.contains(&"my_guest_feature"),
+            "user RUSTFLAGS dropped in inherit mode: {encoded:?}"
+        );
+    }
+
+    /// Cargo makes env and config rustflags mutually exclusive, but in inherit
+    /// mode the guest must keep both — config tuning and the user's env flags —
+    /// with env after config so it keeps precedence.
+    #[test]
+    fn guest_rustflags_keeps_both_config_and_env_in_inherit_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvVarGuard::hermetic(dir.path());
+        std::fs::create_dir(dir.path().join(".cargo")).unwrap();
+        std::fs::write(
+            dir.path().join(".cargo/config.toml"),
+            format!(
+                "[target.{ZISK_TARGET}]\nrustflags = [\"-C\", \"llvm-args=--inline-threshold=1234\"]\n"
+            ),
+        )
+        .unwrap();
+        std::env::set_var("RUSTFLAGS", "--cfg my_guest_feature");
+
+        let (_script, encoded) = guest_rustflags(Some(dir.path()), true).unwrap();
+        let flags: Vec<&str> = encoded.split('\u{1f}').collect();
+
+        let config_flag = flags
+            .iter()
+            .position(|f| *f == "llvm-args=--inline-threshold=1234")
+            .expect("config rustflags dropped in inherit mode");
+        let env_flag = flags
+            .iter()
+            .position(|f| *f == "my_guest_feature")
+            .expect("env RUSTFLAGS dropped in inherit mode");
+        // Env flags come after config so env keeps cargo's precedence.
+        assert!(config_flag < env_flag, "env rustflags must follow config: {encoded:?}");
+    }
+
+    /// Cargo's per-target `CARGO_TARGET_<TRIPLE>_RUSTFLAGS` var applies to the
+    /// guest target: it must not suppress config resolution, and in inherit
+    /// mode its flags must be folded in after config.
+    #[test]
+    fn guest_rustflags_handles_per_target_env_var() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvVarGuard::hermetic(dir.path());
+        std::fs::create_dir(dir.path().join(".cargo")).unwrap();
+        std::fs::write(
+            dir.path().join(".cargo/config.toml"),
+            format!(
+                "[target.{ZISK_TARGET}]\nrustflags = [\"-C\", \"llvm-args=--inline-threshold=1234\"]\n"
+            ),
+        )
+        .unwrap();
+        std::env::set_var(guest_target_rustflags_var(), "--cfg per_target_feature");
+
+        let (_script, encoded) = guest_rustflags(Some(dir.path()), true).unwrap();
+        let flags: Vec<&str> = encoded.split('\u{1f}').collect();
+
+        let config_flag = flags
+            .iter()
+            .position(|f| *f == "llvm-args=--inline-threshold=1234")
+            .expect("config rustflags dropped by per-target env var");
+        let env_flag = flags
+            .iter()
+            .position(|f| *f == "per_target_feature")
+            .expect("per-target env rustflags dropped in inherit mode");
+        assert!(config_flag < env_flag, "per-target env rustflags must follow config: {encoded:?}");
+    }
+
+    /// Cargo's env rustflags sources are mutually exclusive: when a global
+    /// source (`RUSTFLAGS`/`CARGO_ENCODED_RUSTFLAGS`) is set, the per-target var
+    /// is dropped, not combined. Folding both in would apply flags cargo never
+    /// would and let the wrong one win at rustc's last-flag-wins.
+    #[test]
+    fn guest_rustflags_env_sources_are_mutually_exclusive() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvVarGuard::hermetic(dir.path());
+        std::env::set_var("RUSTFLAGS", "--cfg global_source");
+        std::env::set_var(guest_target_rustflags_var(), "--cfg per_target_source");
+
+        let (_script, encoded) = guest_rustflags(Some(dir.path()), true).unwrap();
+        let flags: Vec<&str> = encoded.split('\u{1f}').collect();
+        assert!(flags.contains(&"global_source"), "global RUSTFLAGS dropped: {encoded:?}");
+        assert!(
+            !flags.contains(&"per_target_source"),
+            "per-target var must be dropped when a global source is set: {encoded:?}"
+        );
+    }
+
+    /// `CARGO_BUILD_RUSTFLAGS` is cargo's lowest-precedence env source. When it
+    /// is the only source set (inherit mode), it must still reach the guest —
+    /// cargo would apply it via `build.rustflags`.
+    #[test]
+    fn guest_rustflags_applies_sole_cargo_build_rustflags() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvVarGuard::hermetic(dir.path());
+        std::env::set_var("CARGO_BUILD_RUSTFLAGS", "--cfg build_source");
+
+        let (_script, encoded) = guest_rustflags(Some(dir.path()), true).unwrap();
+        let flags: Vec<&str> = encoded.split('\u{1f}').collect();
+        assert!(
+            flags.contains(&"build_source"),
+            "sole CARGO_BUILD_RUSTFLAGS dropped in inherit mode: {encoded:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

When building a ZisK guest, `cargo-zisk` sets `CARGO_ENCODED_RUSTFLAGS` itself to inject `--cfg zisk_guest` and the Zisk linker script. But cargo treats its rustflags sources as **mutually exclusive** — the moment `CARGO_ENCODED_RUSTFLAGS`/`RUSTFLAGS` is set, cargo *ignores* the guest's `.cargo/config.toml` `target.*.rustflags`. So the previous approach silently dropped a guest's own tuning (e.g. the reth guest's `--inline-threshold`) whenever any rustflags env var was present.

Previously the linker script was also injected ad-hoc by callers (see the old `RUSTFLAGS=...-C link-arg=-T...` in `test_diagnostic.sh`), which was fragile and did not preserve config.

## Solution

`ziskbuild` now centralizes guest rustflags resolution in `guest_rustflags()`:

- Resolves the guest's `.cargo/config.toml` rustflags via [`cargo-config2`](https://crates.io/crates/cargo-config2), with the rustflags env vars filtered out so cargo's mutual-exclusion can't suppress config.
- Re-folds the env rustflags back in afterward (in inherit mode) so **both** the program's config tuning and the user's env flags survive, with env keeping cargo's precedence.
- Appends `--cfg zisk_guest` and the linker script (written to a unique temp file, not a predictable path — avoids cross-invocation races and temp-file symlink attacks).

A single `apply_guest_rustflags(&mut Command, …)` helper owns the "set `CARGO_ENCODED_RUSTFLAGS` + scrub the other rustflags env vars" pairing, so the two halves can't drift apart. The CLI `build`/`run` paths and the build-script path all funnel through it.

## Correctness details (matching cargo semantics)

Verified against `cargo-config2`'s resolution source so guest builds match what cargo would do:

- **Mutual exclusion honored.** `env_rustflags()` returns exactly one winning source in cargo's precedence order: `CARGO_ENCODED_RUSTFLAGS` > `RUSTFLAGS` > per-target `CARGO_TARGET_<TRIPLE>_RUSTFLAGS` > `CARGO_BUILD_RUSTFLAGS`. The per-target var is dropped (not combined) when a global source is set — mirroring cargo's `override_target_rustflags`.
- **`CARGO_BUILD_RUSTFLAGS` preserved** as the lowest-precedence env source, so a user's sole `CARGO_BUILD_RUSTFLAGS` still reaches the guest in a direct CLI invocation.
- **Build-script vs CLI split.** Build scripts pass `inherit_env_rustflags=false` (their env vars describe the HOST build, e.g. `-Wl,--export-dynamic`, which would break the guest link); direct CLI invocations pass `true`.
- Uses `cargo_config2::Flags::encode()` for the final value, which validates against `\x1f`-injection instead of silently producing a value cargo would mis-split.

## Testing

- 8 unit tests in `ziskbuild/src/lib.rs` cover: config preservation, empty-flag dropping, host-env isolation in build scripts, inherit-mode env folding, per-target var handling, env-source mutual exclusion, and sole `CARGO_BUILD_RUSTFLAGS`.
- `test_diagnostic.sh` now builds via `cargo-zisk build` instead of open-coding the linker-script `RUSTFLAGS`.
- `cargo clippy` clean on `zisk-build` and `cargo-zisk`.
