### PR TITLE
docs: clarify timeout behavior of run_sync()

### DIFF
--- a/sdk/src/execute.rs
+++ b/sdk/src/execute.rs
@@ -87,6 +87,9 @@ impl<'a, C: Client> ExecuteRequest<'a, C> {
     }
 
     /// Set a timeout for the execution.
+    ///
+    /// The timeout is applied by [`run`](Self::run). Calls to
+    /// [`run_sync`](Self::run_sync) do not currently use this value.
     #[must_use]
     pub fn timeout(mut self, duration: Duration) -> Self {
         self.timeout = Some(duration);

--- a/sdk/src/prove.rs
+++ b/sdk/src/prove.rs
@@ -116,6 +116,9 @@ impl<'a, C: Client> ProveRequest<'a, C> {
     }
 
     /// Set a timeout for proof generation.
+    ///
+    /// The timeout is applied by [`run`](Self::run). Calls to
+    /// [`run_sync`](Self::run_sync) do not currently use this value.
     #[must_use]
     pub fn timeout(mut self, duration: Duration) -> Self {
         self.timeout = Some(duration);

--- a/sdk/src/setup.rs
+++ b/sdk/src/setup.rs
@@ -62,6 +62,9 @@ impl<'a, C: Client> SetupRequest<'a, C> {
     }
 
     /// Set a timeout for the setup job.
+    ///
+    /// The timeout is applied by [`run`](Self::run). Calls to
+    /// [`run_sync`](Self::run_sync) do not currently use this value.
     #[must_use]
     pub fn timeout(mut self, duration: Duration) -> Self {
         self.timeout = Some(duration);

--- a/sdk/src/wrap.rs
+++ b/sdk/src/wrap.rs
@@ -47,6 +47,9 @@ impl<'a, C: Client> WrapRequest<'a, C> {
     }
 
     /// Set a timeout for the wrap job.
+    ///
+    /// The timeout is applied by [`run`](Self::run). Calls to
+    /// [`run_sync`](Self::run_sync) do not currently use this value.
     #[must_use]
     pub fn timeout(mut self, duration: Duration) -> Self {
         self.timeout = Some(duration);


### PR DESCRIPTION
This PR clarifies the behavior of .timeout(...) on synchronous request builders. While reviewing the SDK, I noticed that the timeout value is passed through the asynchronous run() path but is not used by run_sync(). This change adds a short note to the documentation for all request builders so users know what to expect when using the synchronous API. It is a documentation-only change and does not modify any runtime behavior.
