### PR TITLE
Extended remote client with opt-in job metadata for dev uses

### DIFF
--- a/distributed/crates/cluster-api/proto/zisk_cluster_api.proto
+++ b/distributed/crates/cluster-api/proto/zisk_cluster_api.proto
@@ -180,6 +180,7 @@ message ExecuteTaskRequest {
     ContributionParams execution_params = 7; // Same params as contribution, but only executes without proof generation
     WrapParams wrap_params = 8;
   }
+  optional string metadata = 9;
 }
 
 enum TaskType {

--- a/distributed/crates/cluster-api/src/conversions.rs
+++ b/distributed/crates/cluster-api/src/conversions.rs
@@ -306,8 +306,9 @@ impl From<ExecuteTaskRequestDto> for ExecuteTaskRequest {
             job_id: dto.job_id.into(),
             task_type: task_type as i32,
             params: Some(params),
-            // Domain's ordered map into the proto `map<string, string>` (a HashMap).
-            metadata: dto.metadata.into_iter().collect(),
+            // Domain's ordered map into the proto `map<string, string>` (a HashMap);
+            // absence (`None`) collapses to an empty map on the wire.
+            metadata: dto.metadata.unwrap_or_default().into_iter().collect(),
         }
     }
 }

--- a/distributed/crates/cluster-api/src/conversions.rs
+++ b/distributed/crates/cluster-api/src/conversions.rs
@@ -306,6 +306,7 @@ impl From<ExecuteTaskRequestDto> for ExecuteTaskRequest {
             job_id: dto.job_id.into(),
             task_type: task_type as i32,
             params: Some(params),
+            metadata: dto.metadata,
         }
     }
 }

--- a/distributed/crates/cluster-common/src/dto.rs
+++ b/distributed/crates/cluster-common/src/dto.rs
@@ -56,7 +56,7 @@ pub struct LaunchProofRequestDto {
     pub hints_mode: HintsModeDto,
     /// Simulated worker count, if running in simulation mode.
     pub simulated_node: Option<u32>,
-    /// Arbitrary client metadata (`None` when the caller supplied none).
+    /// Arbitrary client metadata.
     pub metadata: Option<std::collections::BTreeMap<String, String>>,
     /// Whether to execute only (no proof).
     pub execution_only: bool,
@@ -315,7 +315,7 @@ pub struct ExecuteTaskRequestDto {
     pub job_id: JobId,
     /// The phase-specific parameters.
     pub params: ExecuteTaskRequestTypeDto,
-    /// Job-level metadata propagated to the worker (`None` when there is none).
+    /// Job-level metadata propagated to the worker.
     pub metadata: Option<std::collections::BTreeMap<String, String>>,
 }
 

--- a/distributed/crates/cluster-common/src/dto.rs
+++ b/distributed/crates/cluster-common/src/dto.rs
@@ -56,8 +56,8 @@ pub struct LaunchProofRequestDto {
     pub hints_mode: HintsModeDto,
     /// Simulated worker count, if running in simulation mode.
     pub simulated_node: Option<u32>,
-    /// Arbitrary client metadata.
-    pub metadata: std::collections::BTreeMap<String, String>,
+    /// Arbitrary client metadata (`None` when the caller supplied none).
+    pub metadata: Option<std::collections::BTreeMap<String, String>>,
     /// Whether to execute only (no proof).
     pub execution_only: bool,
     /// The kind of proof requested.
@@ -315,8 +315,8 @@ pub struct ExecuteTaskRequestDto {
     pub job_id: JobId,
     /// The phase-specific parameters.
     pub params: ExecuteTaskRequestTypeDto,
-    /// Job-level metadata propagated to the worker (empty map means none).
-    pub metadata: std::collections::BTreeMap<String, String>,
+    /// Job-level metadata propagated to the worker (`None` when there is none).
+    pub metadata: Option<std::collections::BTreeMap<String, String>>,
 }
 
 /// Phase-specific parameters for an execute-task request.

--- a/distributed/crates/cluster-common/src/dto.rs
+++ b/distributed/crates/cluster-common/src/dto.rs
@@ -46,7 +46,7 @@ pub struct LaunchProofRequestDto {
     pub inputs_mode: InputsModeDto,
     pub hints_mode: HintsModeDto,
     pub simulated_node: Option<u32>,
-    pub metadata: std::collections::BTreeMap<String, String>,
+    pub metadata: Option<String>,
     pub execution_only: bool,
     pub proof_type: ProofKind,
 }
@@ -213,6 +213,7 @@ pub struct ExecuteTaskRequestDto {
     pub worker_id: WorkerId,
     pub job_id: JobId,
     pub params: ExecuteTaskRequestTypeDto,
+    pub metadata: Option<String>,
 }
 
 pub enum ExecuteTaskRequestTypeDto {

--- a/distributed/crates/cluster-common/src/types.rs
+++ b/distributed/crates/cluster-common/src/types.rs
@@ -336,7 +336,7 @@ pub struct Job {
     pub executed_steps: Option<u64>,
     /// Number of AIR instances, once known.
     pub instances: Option<u64>,
-    /// Arbitrary client-supplied metadata (`None` when the caller supplied none).
+    /// Arbitrary client-supplied metadata.
     pub metadata: Option<BTreeMap<String, String>>,
     /// Whether this is an execute-only job (no proof).
     pub execution_only: bool,

--- a/distributed/crates/cluster-common/src/types.rs
+++ b/distributed/crates/cluster-common/src/types.rs
@@ -10,7 +10,7 @@ use proofman::{ContributionsInfo, ProvePhaseInputs, WitnessInfo};
 use proofman_common::ProofOptions;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{HashMap, VecDeque},
     fmt::{self, Debug, Display},
     ops::Range,
 };
@@ -292,7 +292,7 @@ pub struct Job {
     pub proof: Option<Proof>,
     pub executed_steps: Option<u64>,
     pub instances: Option<u64>,
-    pub metadata: BTreeMap<String, String>,
+    pub metadata: Option<String>,
     pub execution_only: bool,
     pub proof_type: ProofKind,
     /// Aggregation task currently in-flight to the recurser (sent, not yet acked).
@@ -314,7 +314,7 @@ impl Job {
         selected_workers: Vec<WorkerId>,
         partitions: Vec<Vec<u32>>,
         execution_mode: JobExecutionMode,
-        metadata: BTreeMap<String, String>,
+        metadata: Option<String>,
         execution_only: bool,
         proof_type: ProofKind,
     ) -> Self {
@@ -605,7 +605,7 @@ mod tests {
             vec![],
             vec![],
             JobExecutionMode::Standard,
-            BTreeMap::new(),
+            None,
             false,
             crate::ProofKind::VadcopFinal,
         )

--- a/distributed/crates/cluster-common/src/types.rs
+++ b/distributed/crates/cluster-common/src/types.rs
@@ -336,8 +336,8 @@ pub struct Job {
     pub executed_steps: Option<u64>,
     /// Number of AIR instances, once known.
     pub instances: Option<u64>,
-    /// Arbitrary client-supplied metadata.
-    pub metadata: BTreeMap<String, String>,
+    /// Arbitrary client-supplied metadata (`None` when the caller supplied none).
+    pub metadata: Option<BTreeMap<String, String>>,
     /// Whether this is an execute-only job (no proof).
     pub execution_only: bool,
     /// The kind of proof requested.
@@ -363,7 +363,7 @@ impl Job {
         selected_workers: Vec<WorkerId>,
         partitions: Vec<Vec<u32>>,
         execution_mode: JobExecutionMode,
-        metadata: BTreeMap<String, String>,
+        metadata: Option<BTreeMap<String, String>>,
         execution_only: bool,
         proof_type: ProofKind,
     ) -> Self {
@@ -735,7 +735,7 @@ mod tests {
             vec![],
             vec![],
             JobExecutionMode::Standard,
-            BTreeMap::new(),
+            None,
             false,
             crate::ProofKind::VadcopFinal,
         )

--- a/distributed/crates/coordinator-api/build.rs
+++ b/distributed/crates/coordinator-api/build.rs
@@ -10,8 +10,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .extern_path(".google.protobuf.Timestamp", "::prost_types::Timestamp")
         .extern_path(".google.protobuf.Duration", "::prost_types::Duration")
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile_protos(&["proto/zisk_coordinator_api.proto"], &["proto/"])?;
+        .compile_protos(
+            &["proto/zisk_coordinator_api.proto", "proto/zisk_coordinator_api_ext.proto"],
+            &["proto/"],
+        )?;
 
     println!("cargo:rerun-if-changed=proto/zisk_coordinator_api.proto");
+    println!("cargo:rerun-if-changed=proto/zisk_coordinator_api_ext.proto");
     Ok(())
 }

--- a/distributed/crates/coordinator-api/proto/zisk_coordinator_api_ext.proto
+++ b/distributed/crates/coordinator-api/proto/zisk_coordinator_api_ext.proto
@@ -23,9 +23,9 @@ service ZiskCoordinatorApiExt {
 
 message JobRequestExtMessage {
   JobKindExt job_kind = 1;
-  // Opaque, caller-defined blob (e.g. serde-serialized). Applies to the whole
-  // job. The coordinator parses it to a UTF-8 string.
-  bytes      metadata = 2;
+  // Caller-defined job-level metadata (e.g. a tag or a JSON string). Empty
+  // means no metadata.
+  string     metadata = 2;
 }
 
 // Restricted job-kind set for the extended API: only jobs that can carry

--- a/distributed/crates/coordinator-api/proto/zisk_coordinator_api_ext.proto
+++ b/distributed/crates/coordinator-api/proto/zisk_coordinator_api_ext.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package zisk.coordinator.v1;
+
+import "zisk_coordinator_api.proto";
+
+// ============================================================================
+// ZisK Coordinator Extended API
+//
+// Opt-in companion service carrying job-level metadata alongside the standard
+// job submission. Reuses the core `JobKind`/`JobResponse` types from
+// `zisk_coordinator_api.proto` (same package) so the base contract stays
+// untouched. Clients that don't need metadata use `ZiskCoordinatorApi`.
+// ============================================================================
+
+service ZiskCoordinatorApiExt {
+  // Submit a job with attached job-level metadata. Behaves exactly like
+  // `ZiskCoordinatorApi.JobRequest` for the enclosed `job_kind`; the
+  // `metadata` is opaque and currently ignored by the coordinator.
+  rpc JobRequestExt(JobRequestExtMessage)
+      returns (JobResponse);
+}
+
+message JobRequestExtMessage {
+  JobKind job_kind = 1;
+  // Opaque, caller-defined blob (e.g. serde-serialized). Applies to the whole
+  // job regardless of kind. Currently ignored by the coordinator.
+  bytes   metadata = 2;
+}

--- a/distributed/crates/coordinator-api/proto/zisk_coordinator_api_ext.proto
+++ b/distributed/crates/coordinator-api/proto/zisk_coordinator_api_ext.proto
@@ -8,7 +8,7 @@ import "zisk_coordinator_api.proto";
 // ZisK Coordinator Extended API
 //
 // Opt-in companion service carrying job-level metadata alongside the standard
-// job submission. Reuses the core `JobKind`/`JobResponse` types from
+// job submission. Reuses the core request/response types from
 // `zisk_coordinator_api.proto` (same package) so the base contract stays
 // untouched. Clients that don't need metadata use `ZiskCoordinatorApi`.
 // ============================================================================
@@ -16,14 +16,23 @@ import "zisk_coordinator_api.proto";
 service ZiskCoordinatorApiExt {
   // Submit a job with attached job-level metadata. Behaves exactly like
   // `ZiskCoordinatorApi.JobRequest` for the enclosed `job_kind`; the
-  // `metadata` is opaque and currently ignored by the coordinator.
+  // `metadata` is opaque to the wire (parsed to a string by the coordinator).
   rpc JobRequestExt(JobRequestExtMessage)
       returns (JobResponse);
 }
 
 message JobRequestExtMessage {
-  JobKind job_kind = 1;
+  JobKindExt job_kind = 1;
   // Opaque, caller-defined blob (e.g. serde-serialized). Applies to the whole
-  // job regardless of kind. Currently ignored by the coordinator.
-  bytes   metadata = 2;
+  // job. The coordinator parses it to a UTF-8 string.
+  bytes      metadata = 2;
+}
+
+// Restricted job-kind set for the extended API: only jobs that can carry
+// job-level metadata (prove, execute). Reuses the base request messages.
+message JobKindExt {
+  oneof kind {
+    ProveRequest   prove   = 1;
+    ExecuteRequest execute = 2;
+  }
 }

--- a/distributed/crates/coordinator-api/src/grpc.rs
+++ b/distributed/crates/coordinator-api/src/grpc.rs
@@ -9,6 +9,10 @@ pub mod proto {
     tonic::include_proto!("zisk.coordinator.v1");
 }
 
+pub use proto::zisk_coordinator_api_ext_client::ZiskCoordinatorApiExtClient;
+pub use proto::zisk_coordinator_api_ext_server::{
+    ZiskCoordinatorApiExt, ZiskCoordinatorApiExtServer,
+};
 pub use proto::zisk_coordinator_api_client::ZiskCoordinatorApiClient;
 pub use proto::zisk_coordinator_api_server::{ZiskCoordinatorApi, ZiskCoordinatorApiServer};
 

--- a/distributed/crates/coordinator-api/src/grpc.rs
+++ b/distributed/crates/coordinator-api/src/grpc.rs
@@ -9,11 +9,11 @@ pub mod proto {
     tonic::include_proto!("zisk.coordinator.v1");
 }
 
+pub use proto::zisk_coordinator_api_client::ZiskCoordinatorApiClient;
 pub use proto::zisk_coordinator_api_ext_client::ZiskCoordinatorApiExtClient;
 pub use proto::zisk_coordinator_api_ext_server::{
     ZiskCoordinatorApiExt, ZiskCoordinatorApiExtServer,
 };
-pub use proto::zisk_coordinator_api_client::ZiskCoordinatorApiClient;
 pub use proto::zisk_coordinator_api_server::{ZiskCoordinatorApi, ZiskCoordinatorApiServer};
 
 use crate::dto::{

--- a/distributed/crates/coordinator-api/src/grpc.rs
+++ b/distributed/crates/coordinator-api/src/grpc.rs
@@ -288,24 +288,7 @@ impl TryFrom<JobKind> for DomainJobKind {
                 with_hints: r.with_hints,
                 emulator_only: r.emulator_only,
             })),
-            job_kind::Kind::Prove(r) => {
-                let input = r
-                    .input
-                    .ok_or_else(|| "input must be set".to_string())?
-                    .try_into()
-                    .map_err(|e: String| e)?;
-                let proof_timeout = r.proof_timeout.and_then(ts_to_datetime);
-                let proof_dest =
-                    DomainProofKind::try_from(r.proof_dest).unwrap_or(DomainProofKind::Stark);
-                let hints = r.hints.map(|h| h.try_into()).transpose().map_err(|e: String| e)?;
-                Ok(DomainJobKind::Prove(DomainProveRequest {
-                    hash_id: r.hash_id,
-                    input,
-                    hints,
-                    proof_timeout,
-                    proof_dest,
-                }))
-            }
+            job_kind::Kind::Prove(r) => Ok(DomainJobKind::Prove(r.try_into()?)),
             job_kind::Kind::Wrap(r) => {
                 let proof = DomainProof::try_from(
                     r.proof.ok_or_else(|| "wrap.proof must be set".to_string())?,
@@ -316,21 +299,7 @@ impl TryFrom<JobKind> for DomainJobKind {
                 let wrap_timeout = r.wrap_timeout.and_then(ts_to_datetime);
                 Ok(DomainJobKind::Wrap(DomainWrapRequest { proof, proof_dest, wrap_timeout }))
             }
-            job_kind::Kind::Execute(r) => {
-                let input = r
-                    .input
-                    .ok_or_else(|| "input must be set".to_string())?
-                    .try_into()
-                    .map_err(|e: String| e)?;
-                let execute_timeout = r.execute_timeout.and_then(ts_to_datetime);
-                let hints = r.hints.map(|h| h.try_into()).transpose().map_err(|e: String| e)?;
-                Ok(DomainJobKind::Execute(DomainExecuteRequest {
-                    hash_id: r.hash_id,
-                    input,
-                    hints,
-                    execute_timeout,
-                }))
-            }
+            job_kind::Kind::Execute(r) => Ok(DomainJobKind::Execute(r.try_into()?)),
             job_kind::Kind::SetupAggregationProgram(r) => {
                 Ok(DomainJobKind::SetupAggregationProgram(DomainSetupAggregationProgramRequest {
                     recurser_id: r.recurser_id,
@@ -375,24 +344,13 @@ impl From<DomainJobKind> for JobKind {
                 with_hints: r.with_hints,
                 emulator_only: r.emulator_only,
             }),
-            DomainJobKind::Prove(r) => Kind::Prove(ProveRequest {
-                hash_id: r.hash_id,
-                input: Some(InputKind::from(r.input)),
-                proof_timeout: r.proof_timeout.map(datetime_to_ts),
-                proof_dest: ProofKind::from(r.proof_dest).into(),
-                hints: r.hints.map(InputKind::from),
-            }),
+            DomainJobKind::Prove(r) => Kind::Prove(r.into()),
             DomainJobKind::Wrap(r) => Kind::Wrap(WrapRequest {
                 proof: Some(r.proof.into()),
                 proof_dest: ProofKind::from(r.proof_dest).into(),
                 wrap_timeout: r.wrap_timeout.map(datetime_to_ts),
             }),
-            DomainJobKind::Execute(r) => Kind::Execute(ExecuteRequest {
-                hash_id: r.hash_id,
-                input: Some(InputKind::from(r.input)),
-                execute_timeout: r.execute_timeout.map(datetime_to_ts),
-                hints: r.hints.map(InputKind::from),
-            }),
+            DomainJobKind::Execute(r) => Kind::Execute(r.into()),
             DomainJobKind::SetupAggregationProgram(r) => {
                 Kind::SetupAggregationProgram(SetupAggregationProgramRequest {
                     recurser_id: r.recurser_id,
@@ -408,6 +366,78 @@ impl From<DomainJobKind> for JobKind {
             }),
         };
         JobKind { kind: Some(kind) }
+    }
+}
+
+impl From<DomainProveRequest> for ProveRequest {
+    fn from(r: DomainProveRequest) -> Self {
+        ProveRequest {
+            hash_id: r.hash_id,
+            input: Some(InputKind::from(r.input)),
+            proof_timeout: r.proof_timeout.map(datetime_to_ts),
+            proof_dest: ProofKind::from(r.proof_dest).into(),
+            hints: r.hints.map(InputKind::from),
+        }
+    }
+}
+
+impl TryFrom<ProveRequest> for DomainProveRequest {
+    type Error = String;
+
+    fn try_from(r: ProveRequest) -> std::result::Result<Self, Self::Error> {
+        let input = r.input.ok_or_else(|| "input must be set".to_string())?.try_into()?;
+        let proof_timeout = r.proof_timeout.and_then(ts_to_datetime);
+        let proof_dest = DomainProofKind::try_from(r.proof_dest).unwrap_or(DomainProofKind::Stark);
+        let hints = r.hints.map(|h| h.try_into()).transpose()?;
+        Ok(DomainProveRequest { hash_id: r.hash_id, input, hints, proof_timeout, proof_dest })
+    }
+}
+
+impl From<DomainExecuteRequest> for ExecuteRequest {
+    fn from(r: DomainExecuteRequest) -> Self {
+        ExecuteRequest {
+            hash_id: r.hash_id,
+            input: Some(InputKind::from(r.input)),
+            execute_timeout: r.execute_timeout.map(datetime_to_ts),
+            hints: r.hints.map(InputKind::from),
+        }
+    }
+}
+
+impl TryFrom<ExecuteRequest> for DomainExecuteRequest {
+    type Error = String;
+
+    fn try_from(r: ExecuteRequest) -> std::result::Result<Self, Self::Error> {
+        let input = r.input.ok_or_else(|| "input must be set".to_string())?.try_into()?;
+        let execute_timeout = r.execute_timeout.and_then(ts_to_datetime);
+        let hints = r.hints.map(|h| h.try_into()).transpose()?;
+        Ok(DomainExecuteRequest { hash_id: r.hash_id, input, hints, execute_timeout })
+    }
+}
+
+impl TryFrom<DomainJobKind> for JobKindExt {
+    type Error = String;
+
+    fn try_from(domain: DomainJobKind) -> std::result::Result<Self, Self::Error> {
+        use job_kind_ext::Kind;
+        let kind = match domain {
+            DomainJobKind::Prove(r) => Kind::Prove(r.into()),
+            DomainJobKind::Execute(r) => Kind::Execute(r.into()),
+            _ => return Err("extended API accepts only prove or execute jobs".to_string()),
+        };
+        Ok(JobKindExt { kind: Some(kind) })
+    }
+}
+
+impl TryFrom<JobKindExt> for DomainJobKind {
+    type Error = String;
+
+    fn try_from(ext: JobKindExt) -> std::result::Result<Self, Self::Error> {
+        use job_kind_ext::Kind;
+        match ext.kind.ok_or_else(|| "job_kind must be set".to_string())? {
+            Kind::Prove(r) => Ok(DomainJobKind::Prove(r.try_into()?)),
+            Kind::Execute(r) => Ok(DomainJobKind::Execute(r.try_into()?)),
+        }
     }
 }
 

--- a/distributed/crates/coordinator-client/src/client.rs
+++ b/distributed/crates/coordinator-client/src/client.rs
@@ -82,7 +82,7 @@ impl CoordinatorClient {
     }
 
     /// Submit an extended job
-    pub fn submit_job_ext(&self, kind: DomainJobKind, metadata: Vec<u8>) -> Result<Job> {
+    pub fn submit_job_ext(&self, kind: DomainJobKind, metadata: String) -> Result<Job> {
         let job_kind = JobKindExt::try_from(kind).map_err(|e| anyhow::anyhow!(e))?;
         let resp = block_on(async {
             let mut gw = self.ext.clone();

--- a/distributed/crates/coordinator-client/src/client.rs
+++ b/distributed/crates/coordinator-client/src/client.rs
@@ -7,7 +7,7 @@ use zisk_coordinator_api::dto::{
     DomainAggregationProgramSpec, DomainJobKind, RegisterAggregationProgramRequestDto,
     RegisterGuestProgramRequestDto,
 };
-use zisk_coordinator_api::grpc::proto::{CancelJobRequest, JobKind, JobRequestExtMessage};
+use zisk_coordinator_api::grpc::proto::{CancelJobRequest, JobKindExt, JobRequestExtMessage};
 use zisk_coordinator_api::grpc::{ZiskCoordinatorApiClient, ZiskCoordinatorApiExtClient};
 
 use crate::input_sender::InputSender;
@@ -83,9 +83,10 @@ impl CoordinatorClient {
 
     /// Submit an extended job
     pub fn submit_job_ext(&self, kind: DomainJobKind, metadata: Vec<u8>) -> Result<Job> {
+        let job_kind = JobKindExt::try_from(kind).map_err(|e| anyhow::anyhow!(e))?;
         let resp = block_on(async {
             let mut gw = self.ext.clone();
-            let req = JobRequestExtMessage { job_kind: Some(JobKind::from(kind)), metadata };
+            let req = JobRequestExtMessage { job_kind: Some(job_kind), metadata };
             let resp = gw.job_request_ext(req).await.context("JobRequestExt RPC failed")?;
             Ok::<_, anyhow::Error>(resp.into_inner())
         })?;

--- a/distributed/crates/coordinator-client/src/client.rs
+++ b/distributed/crates/coordinator-client/src/client.rs
@@ -7,8 +7,8 @@ use zisk_coordinator_api::dto::{
     DomainAggregationProgramSpec, DomainJobKind, RegisterAggregationProgramRequestDto,
     RegisterGuestProgramRequestDto,
 };
-use zisk_coordinator_api::grpc::proto::CancelJobRequest;
-use zisk_coordinator_api::grpc::ZiskCoordinatorApiClient;
+use zisk_coordinator_api::grpc::proto::{CancelJobRequest, JobKind, JobRequestExtMessage};
+use zisk_coordinator_api::grpc::{ZiskCoordinatorApiClient, ZiskCoordinatorApiExtClient};
 
 use crate::input_sender::InputSender;
 use crate::job::Job;
@@ -16,6 +16,7 @@ use crate::job::Job;
 #[derive(Clone)]
 pub struct CoordinatorClient {
     inner: ZiskCoordinatorApiClient<Channel>,
+    ext: ZiskCoordinatorApiExtClient<Channel>,
 }
 
 impl CoordinatorClient {
@@ -34,7 +35,10 @@ impl CoordinatorClient {
                 .context("Failed to connect to coordinator")
         })?;
         Ok(Self {
-            inner: ZiskCoordinatorApiClient::new(channel)
+            inner: ZiskCoordinatorApiClient::new(channel.clone())
+                .max_decoding_message_size(128 * 1024 * 1024)
+                .max_encoding_message_size(128 * 1024 * 1024),
+            ext: ZiskCoordinatorApiExtClient::new(channel)
                 .max_decoding_message_size(128 * 1024 * 1024)
                 .max_encoding_message_size(128 * 1024 * 1024),
         })
@@ -72,6 +76,17 @@ impl CoordinatorClient {
         let resp = block_on(async {
             let mut gw = self.inner.clone();
             let resp = gw.job_request(kind).await.context("JobRequest RPC failed")?;
+            Ok::<_, anyhow::Error>(resp.into_inner())
+        })?;
+        Job::new(resp.job_id, self.clone())
+    }
+
+    /// Submit an extended job
+    pub fn submit_job_ext(&self, kind: DomainJobKind, metadata: Vec<u8>) -> Result<Job> {
+        let resp = block_on(async {
+            let mut gw = self.ext.clone();
+            let req = JobRequestExtMessage { job_kind: Some(JobKind::from(kind)), metadata };
+            let resp = gw.job_request_ext(req).await.context("JobRequestExt RPC failed")?;
             Ok::<_, anyhow::Error>(resp.into_inner())
         })?;
         Job::new(resp.job_id, self.clone())

--- a/distributed/crates/coordinator-server/src/backend/coordinator.rs
+++ b/distributed/crates/coordinator-server/src/backend/coordinator.rs
@@ -304,7 +304,11 @@ impl BackendService for CoordinatorBackend {
         Ok(recurser_id)
     }
 
-    async fn submit_job(&self, kind: DomainJobKind) -> ApiResult<SubmitJobResult> {
+    async fn submit_job(
+        &self,
+        kind: DomainJobKind,
+        metadata: Option<String>,
+    ) -> ApiResult<SubmitJobResult> {
         match kind {
             DomainJobKind::Setup(r) => {
                 let job_id_internal = self
@@ -334,7 +338,7 @@ impl BackendService for CoordinatorBackend {
                         inputs_mode: domain_input_to_dto(&r.input),
                         hints_mode,
                         simulated_node: None,
-                        metadata: Default::default(),
+                        metadata,
                         execution_only: false,
                         proof_type,
                     })
@@ -358,7 +362,7 @@ impl BackendService for CoordinatorBackend {
                         inputs_mode: domain_input_to_dto(&r.input),
                         hints_mode,
                         simulated_node: None,
-                        metadata: Default::default(),
+                        metadata,
                         execution_only: true,
                         proof_type: ProofKind::VadcopFinal,
                     })

--- a/distributed/crates/coordinator-server/src/backend/coordinator.rs
+++ b/distributed/crates/coordinator-server/src/backend/coordinator.rs
@@ -309,10 +309,10 @@ impl BackendService for CoordinatorBackend {
         Ok(recurser_id)
     }
 
-    async fn submit_job(
+    async fn submit_job_with_metadata(
         &self,
         kind: DomainJobKind,
-        metadata: std::collections::BTreeMap<String, String>,
+        metadata: Option<std::collections::BTreeMap<String, String>>,
     ) -> ApiResult<SubmitJobResult> {
         match kind {
             DomainJobKind::Setup(r) => {

--- a/distributed/crates/coordinator-server/src/backend/mock.rs
+++ b/distributed/crates/coordinator-server/src/backend/mock.rs
@@ -58,7 +58,8 @@ struct MockState {
     received_chunks: HashMap<Uuid, Vec<Vec<u8>>>,
     /// Chunks received via `push_job_hints_input`, keyed by job_id. For test assertions.
     received_hints_chunks: HashMap<Uuid, Vec<Vec<u8>>>,
-    /// Metadata passed to `submit_job`, keyed by job_id. For test assertions.
+    /// Metadata recorded at job submission (base or extended), keyed by job_id.
+    /// For test assertions.
     submit_metadata: HashMap<Uuid, std::collections::BTreeMap<String, String>>,
 }
 
@@ -99,7 +100,8 @@ impl MockBackend {
         self.state.lock().await.received_hints_chunks.get(&job_id).cloned().unwrap_or_default()
     }
 
-    /// Return the metadata `submit_job` received for `job_id`. For test assertions.
+    /// Return the metadata recorded at submission for `job_id` (empty for a
+    /// base job, the supplied map for an extended one). For test assertions.
     pub async fn submit_metadata(
         &self,
         job_id: Uuid,

--- a/distributed/crates/coordinator-server/src/backend/mock.rs
+++ b/distributed/crates/coordinator-server/src/backend/mock.rs
@@ -345,7 +345,11 @@ impl BackendService for MockBackend {
         Ok(recurser_id) // echoes id back without storing
     }
 
-    async fn submit_job(&self, kind: DomainJobKind) -> ApiResult<SubmitJobResult> {
+    async fn submit_job(
+        &self,
+        kind: DomainJobKind,
+        _metadata: Option<String>,
+    ) -> ApiResult<SubmitJobResult> {
         // Validate program exists for kinds that reference a hash_id
         {
             let s = self.state.lock().await;
@@ -730,12 +734,15 @@ mod tests {
         let b = MockBackend::default();
         let hash_id = b.register_guest_program(vec![0u8; 8]).await.unwrap();
         let job_id = b
-            .submit_job(DomainJobKind::Setup(DomainSetupRequest {
-                hash_id: hash_id.clone(),
-                program_name: hash_id,
-                with_hints: false,
-                emulator_only: false,
-            }))
+            .submit_job(
+                DomainJobKind::Setup(DomainSetupRequest {
+                    hash_id: hash_id.clone(),
+                    program_name: hash_id,
+                    with_hints: false,
+                    emulator_only: false,
+                }),
+                None,
+            )
             .await
             .unwrap()
             .job_id;
@@ -749,13 +756,16 @@ mod tests {
         let b = MockBackend::default();
         let hash_id = b.register_guest_program(vec![0u8; 8]).await.unwrap();
         let job_id = b
-            .submit_job(DomainJobKind::Prove(DomainProveRequest {
-                hash_id,
-                input: DomainInputKind::Inline(DomainInputChunk { data: vec![] }),
-                hints: None,
-                proof_timeout: None,
-                proof_dest: DomainProofKind::Stark,
-            }))
+            .submit_job(
+                DomainJobKind::Prove(DomainProveRequest {
+                    hash_id,
+                    input: DomainInputKind::Inline(DomainInputChunk { data: vec![] }),
+                    hints: None,
+                    proof_timeout: None,
+                    proof_dest: DomainProofKind::Stark,
+                }),
+                None,
+            )
             .await
             .unwrap()
             .job_id;
@@ -774,12 +784,15 @@ mod tests {
         let b = MockBackend::default();
         let hash_id = b.register_guest_program(vec![0u8; 8]).await.unwrap();
         let job_id = b
-            .submit_job(DomainJobKind::Execute(DomainExecuteRequest {
-                hash_id,
-                input: DomainInputKind::Inline(DomainInputChunk { data: vec![] }),
-                hints: None,
-                execute_timeout: None,
-            }))
+            .submit_job(
+                DomainJobKind::Execute(DomainExecuteRequest {
+                    hash_id,
+                    input: DomainInputKind::Inline(DomainInputChunk { data: vec![] }),
+                    hints: None,
+                    execute_timeout: None,
+                }),
+                None,
+            )
             .await
             .unwrap()
             .job_id;
@@ -795,12 +808,15 @@ mod tests {
     async fn program_not_found_error() {
         let b = MockBackend::default();
         let err = b
-            .submit_job(DomainJobKind::Setup(DomainSetupRequest {
-                hash_id: "nonexistent".into(),
-                program_name: "nonexistent".into(),
-                with_hints: false,
-                emulator_only: false,
-            }))
+            .submit_job(
+                DomainJobKind::Setup(DomainSetupRequest {
+                    hash_id: "nonexistent".into(),
+                    program_name: "nonexistent".into(),
+                    with_hints: false,
+                    emulator_only: false,
+                }),
+                None,
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, ApiError::ProgramNotFound(_)));
@@ -829,11 +845,14 @@ mod tests {
             completed_at: Some(Utc::now()),
         };
         let job_id = b
-            .submit_job(DomainJobKind::Wrap(DomainWrapRequest {
-                proof: src_proof,
-                proof_dest: DomainProofKind::Plonk,
-                wrap_timeout: None,
-            }))
+            .submit_job(
+                DomainJobKind::Wrap(DomainWrapRequest {
+                    proof: src_proof,
+                    proof_dest: DomainProofKind::Plonk,
+                    wrap_timeout: None,
+                }),
+                None,
+            )
             .await
             .unwrap()
             .job_id;

--- a/distributed/crates/coordinator-server/src/backend/mock.rs
+++ b/distributed/crates/coordinator-server/src/backend/mock.rs
@@ -358,10 +358,10 @@ impl BackendService for MockBackend {
         Ok(recurser_id) // echoes id back without storing
     }
 
-    async fn submit_job(
+    async fn submit_job_with_metadata(
         &self,
         kind: DomainJobKind,
-        metadata: std::collections::BTreeMap<String, String>,
+        metadata: Option<std::collections::BTreeMap<String, String>>,
     ) -> ApiResult<SubmitJobResult> {
         // Validate program exists for kinds that reference a hash_id
         {
@@ -399,7 +399,7 @@ impl BackendService for MockBackend {
             let mut s = self.state.lock().await;
             s.jobs.insert(job_id, record);
             s.event_txs.insert(job_id, event_tx);
-            s.submit_metadata.insert(job_id, metadata);
+            s.submit_metadata.insert(job_id, metadata.unwrap_or_default());
         }
 
         Self::spawn_job_task(Arc::clone(&self.state), self.cancel.clone(), job_id, kind);
@@ -748,15 +748,12 @@ mod tests {
         let b = MockBackend::default();
         let hash_id = b.register_guest_program(vec![0u8; 8]).await.unwrap();
         let job_id = b
-            .submit_job(
-                DomainJobKind::Setup(DomainSetupRequest {
-                    hash_id: hash_id.clone(),
-                    program_name: hash_id,
-                    with_hints: false,
-                    emulator_only: false,
-                }),
-                std::collections::BTreeMap::new(),
-            )
+            .submit_job(DomainJobKind::Setup(DomainSetupRequest {
+                hash_id: hash_id.clone(),
+                program_name: hash_id,
+                with_hints: false,
+                emulator_only: false,
+            }))
             .await
             .unwrap()
             .job_id;
@@ -770,16 +767,13 @@ mod tests {
         let b = MockBackend::default();
         let hash_id = b.register_guest_program(vec![0u8; 8]).await.unwrap();
         let job_id = b
-            .submit_job(
-                DomainJobKind::Prove(DomainProveRequest {
-                    hash_id,
-                    input: DomainInputKind::Inline(DomainInputChunk { data: vec![] }),
-                    hints: None,
-                    proof_timeout: None,
-                    proof_dest: DomainProofKind::Stark,
-                }),
-                std::collections::BTreeMap::new(),
-            )
+            .submit_job(DomainJobKind::Prove(DomainProveRequest {
+                hash_id,
+                input: DomainInputKind::Inline(DomainInputChunk { data: vec![] }),
+                hints: None,
+                proof_timeout: None,
+                proof_dest: DomainProofKind::Stark,
+            }))
             .await
             .unwrap()
             .job_id;
@@ -798,15 +792,12 @@ mod tests {
         let b = MockBackend::default();
         let hash_id = b.register_guest_program(vec![0u8; 8]).await.unwrap();
         let job_id = b
-            .submit_job(
-                DomainJobKind::Execute(DomainExecuteRequest {
-                    hash_id,
-                    input: DomainInputKind::Inline(DomainInputChunk { data: vec![] }),
-                    hints: None,
-                    execute_timeout: None,
-                }),
-                std::collections::BTreeMap::new(),
-            )
+            .submit_job(DomainJobKind::Execute(DomainExecuteRequest {
+                hash_id,
+                input: DomainInputKind::Inline(DomainInputChunk { data: vec![] }),
+                hints: None,
+                execute_timeout: None,
+            }))
             .await
             .unwrap()
             .job_id;
@@ -822,15 +813,12 @@ mod tests {
     async fn program_not_found_error() {
         let b = MockBackend::default();
         let err = b
-            .submit_job(
-                DomainJobKind::Setup(DomainSetupRequest {
-                    hash_id: "nonexistent".into(),
-                    program_name: "nonexistent".into(),
-                    with_hints: false,
-                    emulator_only: false,
-                }),
-                std::collections::BTreeMap::new(),
-            )
+            .submit_job(DomainJobKind::Setup(DomainSetupRequest {
+                hash_id: "nonexistent".into(),
+                program_name: "nonexistent".into(),
+                with_hints: false,
+                emulator_only: false,
+            }))
             .await
             .unwrap_err();
         assert!(matches!(err, ApiError::ProgramNotFound(_)));
@@ -859,14 +847,11 @@ mod tests {
             completed_at: Some(Utc::now()),
         };
         let job_id = b
-            .submit_job(
-                DomainJobKind::Wrap(DomainWrapRequest {
-                    proof: src_proof,
-                    proof_dest: DomainProofKind::Plonk,
-                    wrap_timeout: None,
-                }),
-                std::collections::BTreeMap::new(),
-            )
+            .submit_job(DomainJobKind::Wrap(DomainWrapRequest {
+                proof: src_proof,
+                proof_dest: DomainProofKind::Plonk,
+                wrap_timeout: None,
+            }))
             .await
             .unwrap()
             .job_id;

--- a/distributed/crates/coordinator-server/src/backend/mock.rs
+++ b/distributed/crates/coordinator-server/src/backend/mock.rs
@@ -58,8 +58,8 @@ struct MockState {
     received_chunks: HashMap<Uuid, Vec<Vec<u8>>>,
     /// Chunks received via `push_job_hints_input`, keyed by job_id. For test assertions.
     received_hints_chunks: HashMap<Uuid, Vec<Vec<u8>>>,
-    /// Metadata passed to the most recent `submit_job`. For test assertions.
-    last_submit_metadata: std::collections::BTreeMap<String, String>,
+    /// Metadata passed to `submit_job`, keyed by job_id. For test assertions.
+    submit_metadata: HashMap<Uuid, std::collections::BTreeMap<String, String>>,
 }
 
 impl MockState {
@@ -71,7 +71,7 @@ impl MockState {
             event_txs: HashMap::new(),
             received_chunks: HashMap::new(),
             received_hints_chunks: HashMap::new(),
-            last_submit_metadata: std::collections::BTreeMap::new(),
+            submit_metadata: HashMap::new(),
         }
     }
 }
@@ -99,9 +99,12 @@ impl MockBackend {
         self.state.lock().await.received_hints_chunks.get(&job_id).cloned().unwrap_or_default()
     }
 
-    /// Return the metadata passed to the most recent `submit_job`. For test assertions.
-    pub async fn last_submit_metadata(&self) -> std::collections::BTreeMap<String, String> {
-        self.state.lock().await.last_submit_metadata.clone()
+    /// Return the metadata `submit_job` received for `job_id`. For test assertions.
+    pub async fn submit_metadata(
+        &self,
+        job_id: Uuid,
+    ) -> std::collections::BTreeMap<String, String> {
+        self.state.lock().await.submit_metadata.get(&job_id).cloned().unwrap_or_default()
     }
 
     // ── internal helpers ─────────────────────────────────────────────────────
@@ -362,13 +365,12 @@ impl BackendService for MockBackend {
     ) -> ApiResult<SubmitJobResult> {
         // Validate program exists for kinds that reference a hash_id
         {
-            let mut s = self.state.lock().await;
+            let s = self.state.lock().await;
             if let Some(hash_id) = kind.hash_id() {
                 if !s.programs.contains(hash_id) {
                     return Err(ApiError::ProgramNotFound(hash_id.to_owned()));
                 }
             }
-            s.last_submit_metadata = metadata;
         }
 
         // Track setup jobs so list_active_setups can return them.
@@ -397,6 +399,7 @@ impl BackendService for MockBackend {
             let mut s = self.state.lock().await;
             s.jobs.insert(job_id, record);
             s.event_txs.insert(job_id, event_tx);
+            s.submit_metadata.insert(job_id, metadata);
         }
 
         Self::spawn_job_task(Arc::clone(&self.state), self.cancel.clone(), job_id, kind);

--- a/distributed/crates/coordinator-server/src/backend/mock.rs
+++ b/distributed/crates/coordinator-server/src/backend/mock.rs
@@ -58,6 +58,8 @@ struct MockState {
     received_chunks: HashMap<Uuid, Vec<Vec<u8>>>,
     /// Chunks received via `push_job_hints_input`, keyed by job_id. For test assertions.
     received_hints_chunks: HashMap<Uuid, Vec<Vec<u8>>>,
+    /// Metadata passed to the most recent `submit_job`. For test assertions.
+    last_submit_metadata: std::collections::BTreeMap<String, String>,
 }
 
 impl MockState {
@@ -69,6 +71,7 @@ impl MockState {
             event_txs: HashMap::new(),
             received_chunks: HashMap::new(),
             received_hints_chunks: HashMap::new(),
+            last_submit_metadata: std::collections::BTreeMap::new(),
         }
     }
 }
@@ -94,6 +97,11 @@ impl MockBackend {
     /// Return all hints chunks received for `job_id` via `push_job_hints_input`.
     pub async fn received_hints_chunks(&self, job_id: Uuid) -> Vec<Vec<u8>> {
         self.state.lock().await.received_hints_chunks.get(&job_id).cloned().unwrap_or_default()
+    }
+
+    /// Return the metadata passed to the most recent `submit_job`. For test assertions.
+    pub async fn last_submit_metadata(&self) -> std::collections::BTreeMap<String, String> {
+        self.state.lock().await.last_submit_metadata.clone()
     }
 
     // ── internal helpers ─────────────────────────────────────────────────────
@@ -350,16 +358,17 @@ impl BackendService for MockBackend {
     async fn submit_job(
         &self,
         kind: DomainJobKind,
-        _metadata: std::collections::BTreeMap<String, String>,
+        metadata: std::collections::BTreeMap<String, String>,
     ) -> ApiResult<SubmitJobResult> {
         // Validate program exists for kinds that reference a hash_id
         {
-            let s = self.state.lock().await;
+            let mut s = self.state.lock().await;
             if let Some(hash_id) = kind.hash_id() {
                 if !s.programs.contains(hash_id) {
                     return Err(ApiError::ProgramNotFound(hash_id.to_owned()));
                 }
             }
+            s.last_submit_metadata = metadata;
         }
 
         // Track setup jobs so list_active_setups can return them.

--- a/distributed/crates/coordinator-server/src/backend/mod.rs
+++ b/distributed/crates/coordinator-server/src/backend/mod.rs
@@ -47,7 +47,13 @@ pub trait BackendService: Send + Sync + 'static {
     ) -> ApiResult<String>;
 
     /// Submit a new job. Returns the job UUID.
-    async fn submit_job(&self, kind: DomainJobKind) -> ApiResult<SubmitJobResult>;
+    ///
+    /// `metadata` is the optional string supplied via the extended API.
+    async fn submit_job(
+        &self,
+        kind: DomainJobKind,
+        metadata: Option<String>,
+    ) -> ApiResult<SubmitJobResult>;
 
     /// Long-poll: block until the job reaches a terminal state or `timeout`
     /// elapses, then return the current state.

--- a/distributed/crates/coordinator-server/src/backend/mod.rs
+++ b/distributed/crates/coordinator-server/src/backend/mod.rs
@@ -50,12 +50,26 @@ pub trait BackendService: Send + Sync + 'static {
 
     /// Submit a new job. Returns the job UUID.
     ///
-    /// `metadata` carries the caller-defined key/value pairs supplied via the
-    /// extended API (empty map for the base API).
-    async fn submit_job(
+    /// Submit a base job. The base API carries no caller metadata.
+    async fn submit_job(&self, kind: DomainJobKind) -> ApiResult<SubmitJobResult> {
+        self.submit_job_with_metadata(kind, None).await
+    }
+
+    /// Submit a job with caller-defined key/value metadata (the extended API).
+    async fn submit_job_ext(
         &self,
         kind: DomainJobKind,
         metadata: std::collections::BTreeMap<String, String>,
+    ) -> ApiResult<SubmitJobResult> {
+        self.submit_job_with_metadata(kind, Some(metadata)).await
+    }
+
+    /// Implementation seam shared by [`submit_job`](Self::submit_job) and
+    /// [`submit_job_ext`](Self::submit_job_ext); backends implement this one.
+    async fn submit_job_with_metadata(
+        &self,
+        kind: DomainJobKind,
+        metadata: Option<std::collections::BTreeMap<String, String>>,
     ) -> ApiResult<SubmitJobResult>;
 
     /// Long-poll: block until the job reaches a terminal state or `timeout`

--- a/distributed/crates/coordinator-server/src/grpc.rs
+++ b/distributed/crates/coordinator-server/src/grpc.rs
@@ -319,16 +319,8 @@ impl<B: BackendService> ZiskCoordinatorApiExt for GrpcAdapter<B> {
     ) -> Result<Response<JobResponse>, Status> {
         let start = Instant::now();
         let msg = request.into_inner();
-        // Parse the opaque metadata bytes as a UTF-8 string (strict: reject
-        // non-UTF-8). Empty bytes mean "no metadata".
-        let metadata = if msg.metadata.is_empty() {
-            None
-        } else {
-            Some(
-                String::from_utf8(msg.metadata)
-                    .map_err(|_| Status::invalid_argument("metadata must be valid UTF-8"))?,
-            )
-        };
+        // Empty string means "no metadata".
+        let metadata = if msg.metadata.is_empty() { None } else { Some(msg.metadata) };
         let kind = msg
             .job_kind
             .ok_or_else(|| Status::invalid_argument("job_kind must be set"))?

--- a/distributed/crates/coordinator-server/src/grpc.rs
+++ b/distributed/crates/coordinator-server/src/grpc.rs
@@ -19,6 +19,7 @@ use crate::backend::BackendService;
 use crate::errors::ApiError;
 use crate::handler::CoordinatorHandler;
 use crate::proto::zisk_coordinator_api_server::ZiskCoordinatorApi;
+use crate::proto::zisk_coordinator_api_ext_server::ZiskCoordinatorApiExt;
 use crate::proto::*;
 use zisk_coordinator_api::dto::{
     RegisterAggregationProgramRequestDto, RegisterGuestProgramRequestDto,
@@ -305,6 +306,34 @@ impl<B: BackendService> ZiskCoordinatorApi for GrpcAdapter<B> {
             .map_err(Status::from);
 
         Self::log_call("CancelJob", start, result.as_ref().map(|_| ()));
+        result
+    }
+}
+
+#[tonic::async_trait]
+impl<B: BackendService> ZiskCoordinatorApiExt for GrpcAdapter<B> {
+    #[instrument(level = "debug", skip(self, request))]
+    async fn job_request_ext(
+        &self,
+        request: Request<JobRequestExtMessage>,
+    ) -> Result<Response<JobResponse>, Status> {
+        let start = Instant::now();
+        // `metadata` is opaque and currently ignored; behaviour matches `job_request`.
+        let kind = request
+            .into_inner()
+            .job_kind
+            .ok_or_else(|| Status::invalid_argument("job_kind must be set"))?
+            .try_into()
+            .map_err(|e: String| Status::invalid_argument(e))?;
+
+        let result = self
+            .handler
+            .submit_job(kind)
+            .await
+            .map(|r| Response::new(JobResponse { job_id: r.job_id.to_string() }))
+            .map_err(Status::from);
+
+        Self::log_call("JobRequestExt", start, result.as_ref().map(|_| ()));
         result
     }
 }

--- a/distributed/crates/coordinator-server/src/grpc.rs
+++ b/distributed/crates/coordinator-server/src/grpc.rs
@@ -180,7 +180,7 @@ impl<B: BackendService> ZiskCoordinatorApi for GrpcAdapter<B> {
 
         let result = self
             .handler
-            .submit_job(kind, std::collections::BTreeMap::new())
+            .submit_job(kind)
             .await
             .map(|r| Response::new(JobResponse { job_id: r.job_id.to_string() }))
             .map_err(Status::from);
@@ -358,7 +358,7 @@ impl<B: BackendService> ZiskCoordinatorApiExt for GrpcAdapter<B> {
         let start = Instant::now();
         let msg = request.into_inner();
         // Proto `map<string, string>` (a HashMap on the wire) into the domain's
-        // ordered map. Empty map means "no metadata".
+        // ordered map. An empty map means "no metadata" → route through the base path.
         validate_metadata(&msg.metadata)?;
         let metadata: std::collections::BTreeMap<String, String> =
             msg.metadata.into_iter().collect();
@@ -368,10 +368,12 @@ impl<B: BackendService> ZiskCoordinatorApiExt for GrpcAdapter<B> {
             .try_into()
             .map_err(|e: String| Status::invalid_argument(e))?;
 
-        let result = self
-            .handler
-            .submit_job(kind, metadata)
-            .await
+        let submitted = if metadata.is_empty() {
+            self.handler.submit_job(kind).await
+        } else {
+            self.handler.submit_job_ext(kind, metadata).await
+        };
+        let result = submitted
             .map(|r| Response::new(JobResponse { job_id: r.job_id.to_string() }))
             .map_err(Status::from);
 

--- a/distributed/crates/coordinator-server/src/grpc.rs
+++ b/distributed/crates/coordinator-server/src/grpc.rs
@@ -18,8 +18,8 @@ use uuid::Uuid;
 use crate::backend::BackendService;
 use crate::errors::ApiError;
 use crate::handler::CoordinatorHandler;
-use crate::proto::zisk_coordinator_api_server::ZiskCoordinatorApi;
 use crate::proto::zisk_coordinator_api_ext_server::ZiskCoordinatorApiExt;
+use crate::proto::zisk_coordinator_api_server::ZiskCoordinatorApi;
 use crate::proto::*;
 use zisk_coordinator_api::dto::{
     RegisterAggregationProgramRequestDto, RegisterGuestProgramRequestDto,
@@ -142,7 +142,7 @@ impl<B: BackendService> ZiskCoordinatorApi for GrpcAdapter<B> {
 
         let result = self
             .handler
-            .submit_job(kind)
+            .submit_job(kind, None)
             .await
             .map(|r| Response::new(JobResponse { job_id: r.job_id.to_string() }))
             .map_err(Status::from);
@@ -318,9 +318,18 @@ impl<B: BackendService> ZiskCoordinatorApiExt for GrpcAdapter<B> {
         request: Request<JobRequestExtMessage>,
     ) -> Result<Response<JobResponse>, Status> {
         let start = Instant::now();
-        // `metadata` is opaque and currently ignored; behaviour matches `job_request`.
-        let kind = request
-            .into_inner()
+        let msg = request.into_inner();
+        // Parse the opaque metadata bytes as a UTF-8 string (strict: reject
+        // non-UTF-8). Empty bytes mean "no metadata".
+        let metadata = if msg.metadata.is_empty() {
+            None
+        } else {
+            Some(
+                String::from_utf8(msg.metadata)
+                    .map_err(|_| Status::invalid_argument("metadata must be valid UTF-8"))?,
+            )
+        };
+        let kind = msg
             .job_kind
             .ok_or_else(|| Status::invalid_argument("job_kind must be set"))?
             .try_into()
@@ -328,7 +337,7 @@ impl<B: BackendService> ZiskCoordinatorApiExt for GrpcAdapter<B> {
 
         let result = self
             .handler
-            .submit_job(kind)
+            .submit_job(kind, metadata)
             .await
             .map(|r| Response::new(JobResponse { job_id: r.job_id.to_string() }))
             .map_err(Status::from);

--- a/distributed/crates/coordinator-server/src/grpc.rs
+++ b/distributed/crates/coordinator-server/src/grpc.rs
@@ -29,6 +29,40 @@ const WAIT_TIMEOUT_DEFAULT_SECS: u32 = 5;
 const WAIT_TIMEOUT_MIN_SECS: u32 = 1;
 const WAIT_TIMEOUT_MAX_SECS: u32 = 3600;
 
+// Bounds on caller-supplied job metadata. Messages may be up to
+// `MAX_MESSAGE_SIZE` (128 MB), so metadata is capped here to keep a client from
+// pushing large blobs into backend storage and per-worker clones. These are
+// generous for label-style metadata and can be raised if a use case needs it.
+const METADATA_MAX_ENTRIES: usize = 32;
+const METADATA_MAX_KEY_BYTES: usize = 128;
+const METADATA_MAX_VALUE_BYTES: usize = 1024;
+
+/// Reject oversized caller-supplied metadata early with `InvalidArgument`,
+/// before it reaches backend storage or worker dispatch.
+fn validate_metadata(metadata: &std::collections::HashMap<String, String>) -> Result<(), Status> {
+    if metadata.len() > METADATA_MAX_ENTRIES {
+        return Err(Status::invalid_argument(format!(
+            "metadata has too many entries ({} > {METADATA_MAX_ENTRIES})",
+            metadata.len()
+        )));
+    }
+    for (k, v) in metadata {
+        if k.len() > METADATA_MAX_KEY_BYTES {
+            return Err(Status::invalid_argument(format!(
+                "metadata key too long ({} > {METADATA_MAX_KEY_BYTES} bytes)",
+                k.len()
+            )));
+        }
+        if v.len() > METADATA_MAX_VALUE_BYTES {
+            return Err(Status::invalid_argument(format!(
+                "metadata value for key {k:?} too long ({} > {METADATA_MAX_VALUE_BYTES} bytes)",
+                v.len()
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Server-streaming type for the `WatchJob` RPC.
 pub type WatchJobStream = Pin<Box<dyn Stream<Item = Result<JobEvent, Status>> + Send + 'static>>;
 
@@ -325,6 +359,7 @@ impl<B: BackendService> ZiskCoordinatorApiExt for GrpcAdapter<B> {
         let msg = request.into_inner();
         // Proto `map<string, string>` (a HashMap on the wire) into the domain's
         // ordered map. Empty map means "no metadata".
+        validate_metadata(&msg.metadata)?;
         let metadata: std::collections::BTreeMap<String, String> =
             msg.metadata.into_iter().collect();
         let kind = msg

--- a/distributed/crates/coordinator-server/src/handler.rs
+++ b/distributed/crates/coordinator-server/src/handler.rs
@@ -49,12 +49,12 @@ impl<B: BackendService> CoordinatorHandler<B> {
         Ok(RegisterAggregationProgramResponseDto { recurser_id })
     }
 
-    /// Submit a base job (no caller metadata) and return its assigned id.
+    /// Submit a base job and return its assigned id.
     pub async fn submit_job(&self, job: DomainJobKind) -> ApiResult<SubmitJobResult> {
         self.backend.submit_job(job).await
     }
 
-    /// Submit a job with caller-defined key/value metadata (the extended API).
+    /// Submit a job with caller-defined key/value metadata.
     pub async fn submit_job_ext(
         &self,
         job: DomainJobKind,

--- a/distributed/crates/coordinator-server/src/handler.rs
+++ b/distributed/crates/coordinator-server/src/handler.rs
@@ -49,16 +49,18 @@ impl<B: BackendService> CoordinatorHandler<B> {
         Ok(RegisterAggregationProgramResponseDto { recurser_id })
     }
 
-    /// Submit a job and return its assigned id.
-    ///
-    /// `metadata` carries the caller-defined job-level key/value pairs supplied
-    /// via the extended API (empty map for the base API).
-    pub async fn submit_job(
+    /// Submit a base job (no caller metadata) and return its assigned id.
+    pub async fn submit_job(&self, job: DomainJobKind) -> ApiResult<SubmitJobResult> {
+        self.backend.submit_job(job).await
+    }
+
+    /// Submit a job with caller-defined key/value metadata (the extended API).
+    pub async fn submit_job_ext(
         &self,
         job: DomainJobKind,
         metadata: std::collections::BTreeMap<String, String>,
     ) -> ApiResult<SubmitJobResult> {
-        self.backend.submit_job(job, metadata).await
+        self.backend.submit_job_ext(job, metadata).await
     }
 
     /// Wait up to `timeout` for the job to reach a terminal state.

--- a/distributed/crates/coordinator-server/src/handler.rs
+++ b/distributed/crates/coordinator-server/src/handler.rs
@@ -45,8 +45,12 @@ impl<B: BackendService> CoordinatorHandler<B> {
         Ok(RegisterAggregationProgramResponseDto { recurser_id })
     }
 
-    pub async fn submit_job(&self, job: DomainJobKind) -> ApiResult<SubmitJobResult> {
-        self.backend.submit_job(job).await
+    pub async fn submit_job(
+        &self,
+        job: DomainJobKind,
+        metadata: Option<String>,
+    ) -> ApiResult<SubmitJobResult> {
+        self.backend.submit_job(job, metadata).await
     }
 
     pub async fn wait_job_result(&self, job_id: Uuid, timeout: Duration) -> ApiResult<WaitResult> {

--- a/distributed/crates/coordinator-server/src/server.rs
+++ b/distributed/crates/coordinator-server/src/server.rs
@@ -13,6 +13,7 @@ use crate::config::Config as CoordinatorServerConfig;
 use crate::grpc::GrpcAdapter;
 use crate::handler::CoordinatorHandler;
 use crate::metrics;
+use crate::proto::zisk_coordinator_api_ext_server::ZiskCoordinatorApiExtServer;
 use crate::proto::zisk_coordinator_api_server::ZiskCoordinatorApiServer;
 use crate::shutdown::shutdown_signal;
 
@@ -48,6 +49,12 @@ impl<B: BackendService> CoordinatorServer<B> {
             .max_decoding_message_size(MAX_MESSAGE_SIZE)
             .max_encoding_message_size(MAX_MESSAGE_SIZE);
 
+        // Extended API: same handler, carries opt-in job-level metadata.
+        let ext_service = GrpcAdapter::new(CoordinatorHandler::new(Arc::clone(&self.backend)));
+        let ext_svc = ZiskCoordinatorApiExtServer::new(ext_service)
+            .max_decoding_message_size(MAX_MESSAGE_SIZE)
+            .max_encoding_message_size(MAX_MESSAGE_SIZE);
+
         // Standard grpc.health.v1.Health service — used by grpc_health_probe / k8s.
         let (health_reporter, health_svc) = tonic_health::server::health_reporter();
         health_reporter.set_service_status("", tonic_health::ServingStatus::Serving).await;
@@ -66,6 +73,7 @@ impl<B: BackendService> CoordinatorServer<B> {
             .http2_keepalive_timeout(Some(Duration::from_secs(10)))
             .add_service(health_svc)
             .add_service(svc)
+            .add_service(ext_svc)
             .serve_with_shutdown(addr, async move {
                 shutdown_signal().await;
                 info!("shutdown signal received — draining in-flight requests");

--- a/distributed/crates/coordinator-server/tests/integration/api_test.rs
+++ b/distributed/crates/coordinator-server/tests/integration/api_test.rs
@@ -12,12 +12,14 @@ use tonic::transport::{Channel, Server};
 
 use zisk_coordinator_api::dto::RegisterGuestProgramRequestDto;
 use zisk_coordinator_api::grpc::proto::{
-    input_kind, job_event, job_kind, job_status,
+    input_kind, job_event, job_kind, job_kind_ext, job_status,
     zisk_coordinator_api_client::ZiskCoordinatorApiClient,
+    zisk_coordinator_api_ext_client::ZiskCoordinatorApiExtClient,
+    zisk_coordinator_api_ext_server::ZiskCoordinatorApiExtServer,
     zisk_coordinator_api_server::ZiskCoordinatorApiServer, CancelJobRequest, ExecuteRequest,
-    InputChunk, InputKind, JobKind, JobRequestMessage, ProofKind, ProveRequest,
-    PushJobHintsInputRequest, PushJobInputRequest, SetupRequest, WaitJobResultRequest,
-    WatchJobRequest, WrapRequest,
+    InputChunk, InputKind, JobKind, JobKindExt, JobRequestExtMessage, JobRequestMessage, ProofKind,
+    ProveRequest, PushJobHintsInputRequest, PushJobInputRequest, SetupRequest,
+    WaitJobResultRequest, WatchJobRequest, WrapRequest,
 };
 use zisk_coordinator_server::{backend::mock::MockBackend, CoordinatorHandler, GrpcAdapter};
 
@@ -57,6 +59,36 @@ async fn start_test_server_with_backend() -> (ZiskCoordinatorApiClient<Channel>,
     (client, backend_clone)
 }
 
+/// Start a coordinator server exposing BOTH the base and extended APIs over a
+/// single shared `MockBackend`. Returns a base client (for register/wait), an
+/// extended client (for `job_request_ext`), and the backend for assertions.
+async fn start_test_server_ext(
+) -> (ZiskCoordinatorApiClient<Channel>, ZiskCoordinatorApiExtClient<Channel>, Arc<MockBackend>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let backend = Arc::new(MockBackend::default());
+    // One adapter per registered service, both over the same backend state.
+    let base = GrpcAdapter::new(CoordinatorHandler::new(Arc::clone(&backend)));
+    let ext = GrpcAdapter::new(CoordinatorHandler::new(Arc::clone(&backend)));
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(ZiskCoordinatorApiServer::new(base))
+            .add_service(ZiskCoordinatorApiExtServer::new(ext))
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let endpoint = format!("http://{addr}");
+    let base_client = ZiskCoordinatorApiClient::connect(endpoint.clone()).await.unwrap();
+    let ext_client = ZiskCoordinatorApiExtClient::connect(endpoint).await.unwrap();
+    (base_client, ext_client, backend)
+}
+
 fn dummy_elf() -> Vec<u8> {
     vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03]
 }
@@ -71,6 +103,60 @@ async fn register_program(client: &mut ZiskCoordinatorApiClient<Channel>) -> Str
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn job_request_ext_round_trips_metadata() {
+    let (mut base_client, mut ext_client, backend) = start_test_server_ext().await;
+    let hash_id = register_program(&mut base_client).await;
+
+    let metadata = std::collections::HashMap::from([
+        ("team".to_string(), "zkvm".to_string()),
+        ("run".to_string(), "42".to_string()),
+    ]);
+
+    // Submit via the extended service, carrying job-level metadata.
+    let job_id = ext_client
+        .job_request_ext(JobRequestExtMessage {
+            job_kind: Some(JobKindExt {
+                kind: Some(job_kind_ext::Kind::Execute(ExecuteRequest {
+                    hash_id,
+                    input: inline_input(),
+                    hints: None,
+                    execute_timeout: None,
+                })),
+            }),
+            metadata: metadata.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .job_id;
+
+    assert!(!job_id.is_empty(), "extended submit must return a job id");
+
+    // Metadata must have propagated through grpc → handler → backend.
+    let seen = backend.last_submit_metadata().await;
+    let expected: std::collections::BTreeMap<String, String> = metadata.into_iter().collect();
+    assert_eq!(seen, expected, "submitted metadata must reach the backend");
+
+    // The job created via the extended API is visible on the base API and runs
+    // to completion.
+    loop {
+        let r = base_client
+            .wait_job_result(WaitJobResultRequest {
+                job_id: job_id.clone(),
+                timeout_seconds: Some(2),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if let Some(s) = &r.job_status {
+            if matches!(s.status, Some(job_status::Status::Completed(_))) {
+                return;
+            }
+        }
+    }
+}
 
 #[tokio::test]
 async fn register_idempotent() {

--- a/distributed/crates/coordinator-server/tests/integration/api_test.rs
+++ b/distributed/crates/coordinator-server/tests/integration/api_test.rs
@@ -27,6 +27,23 @@ use std::sync::Arc;
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
+/// Connect a generated client to `endpoint`, retrying under a bounded timeout so
+/// the test is deterministic on slow runners: it returns as soon as the server
+/// is accepting connections, and fails cleanly if it never comes up (instead of
+/// racing a fixed sleep against server startup).
+async fn connect_with_retry<C, Fut>(connect: impl Fn(String) -> Fut, endpoint: &str) -> C
+where
+    Fut: std::future::Future<Output = Result<C, tonic::transport::Error>>,
+{
+    for _ in 0..100 {
+        if let Ok(client) = connect(endpoint.to_string()).await {
+            return client;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    connect(endpoint.to_string()).await.expect("server did not become ready within timeout")
+}
+
 /// Start a coordinator server on a random local port and return a connected client.
 async fn start_test_server() -> ZiskCoordinatorApiClient<Channel> {
     let (client, _) = start_test_server_with_backend().await;
@@ -51,11 +68,9 @@ async fn start_test_server_with_backend() -> (ZiskCoordinatorApiClient<Channel>,
             .unwrap();
     });
 
-    // Brief pause to let the server start accepting connections
-    tokio::time::sleep(Duration::from_millis(10)).await;
-
     let endpoint = format!("http://{addr}");
-    let client = ZiskCoordinatorApiClient::connect(endpoint).await.unwrap();
+    let client =
+        connect_with_retry(|e: String| ZiskCoordinatorApiClient::connect(e), &endpoint).await;
     (client, backend_clone)
 }
 
@@ -81,11 +96,11 @@ async fn start_test_server_ext(
             .unwrap();
     });
 
-    tokio::time::sleep(Duration::from_millis(10)).await;
-
     let endpoint = format!("http://{addr}");
-    let base_client = ZiskCoordinatorApiClient::connect(endpoint.clone()).await.unwrap();
-    let ext_client = ZiskCoordinatorApiExtClient::connect(endpoint).await.unwrap();
+    let base_client =
+        connect_with_retry(|e: String| ZiskCoordinatorApiClient::connect(e), &endpoint).await;
+    let ext_client =
+        connect_with_retry(|e: String| ZiskCoordinatorApiExtClient::connect(e), &endpoint).await;
     (base_client, ext_client, backend)
 }
 

--- a/distributed/crates/coordinator-server/tests/integration/api_test.rs
+++ b/distributed/crates/coordinator-server/tests/integration/api_test.rs
@@ -135,7 +135,7 @@ async fn job_request_ext_round_trips_metadata() {
     assert!(!job_id.is_empty(), "extended submit must return a job id");
 
     // Metadata must have propagated through grpc → handler → backend.
-    let seen = backend.last_submit_metadata().await;
+    let seen = backend.submit_metadata(job_id.parse().unwrap()).await;
     let expected: std::collections::BTreeMap<String, String> = metadata.into_iter().collect();
     assert_eq!(seen, expected, "submitted metadata must reach the backend");
 

--- a/distributed/crates/coordinator-server/tests/integration/api_test.rs
+++ b/distributed/crates/coordinator-server/tests/integration/api_test.rs
@@ -140,22 +140,26 @@ async fn job_request_ext_round_trips_metadata() {
     assert_eq!(seen, expected, "submitted metadata must reach the backend");
 
     // The job created via the extended API is visible on the base API and runs
-    // to completion.
-    loop {
-        let r = base_client
-            .wait_job_result(WaitJobResultRequest {
-                job_id: job_id.clone(),
-                timeout_seconds: Some(2),
-            })
-            .await
-            .unwrap()
-            .into_inner();
-        if let Some(s) = &r.job_status {
-            if matches!(s.status, Some(job_status::Status::Completed(_))) {
-                return;
+    // to completion. Bound the poll so a regression can't hang CI.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let r = base_client
+                .wait_job_result(WaitJobResultRequest {
+                    job_id: job_id.clone(),
+                    timeout_seconds: Some(2),
+                })
+                .await
+                .unwrap()
+                .into_inner();
+            if let Some(s) = &r.job_status {
+                if matches!(s.status, Some(job_status::Status::Completed(_))) {
+                    break;
+                }
             }
         }
-    }
+    })
+    .await
+    .expect("job did not complete within timeout");
 }
 
 #[tokio::test]

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -1584,6 +1584,35 @@ impl Coordinator {
         result
     }
 
+    /// Render caller-supplied job metadata for a single log line as a leading
+    /// `" k: v, k: v"` string (empty when there is no metadata).
+    ///
+    /// Values come from clients, so control characters (newlines, tabs, …) are
+    /// replaced with spaces to prevent log injection and the result is bounded
+    /// in length to avoid unbounded log lines from large blobs.
+    fn format_job_metadata(metadata: &std::collections::BTreeMap<String, String>) -> String {
+        if metadata.is_empty() {
+            return String::new();
+        }
+
+        const MAX_LEN: usize = 512;
+        let sanitize = |s: &str| -> String {
+            s.chars().map(|c| if c.is_control() { ' ' } else { c }).collect()
+        };
+
+        let joined = metadata
+            .iter()
+            .map(|(k, v)| format!("{}: {}", sanitize(k), sanitize(v)))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let mut truncated: String = joined.chars().take(MAX_LEN).collect();
+        if truncated.len() < joined.len() {
+            truncated.push('…');
+        }
+        format!(" {}", truncated)
+    }
+
     // MONITOR METHODS
     // ---------------------------------------------------------------
 

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -717,7 +717,7 @@ impl Coordinator {
             vec![worker_id.clone()],
             Vec::<Vec<u32>>::new(),
             JobExecutionMode::Standard,
-            std::collections::BTreeMap::new(),
+            None,
             false,
             ProofKind::VadcopFinal,
         );
@@ -1284,7 +1284,7 @@ impl Coordinator {
         inputs_mode: InputsModeDto,
         hints_mode: HintsModeDto,
         simulated_node: Option<u32>,
-        metadata: std::collections::BTreeMap<String, String>,
+        metadata: Option<std::collections::BTreeMap<String, String>>,
         execution_only: bool,
         proof_type: ProofKind,
     ) -> CoordinatorResult<Job> {
@@ -1595,10 +1595,12 @@ impl Coordinator {
     /// Sanitized characters are streamed straight into the output under a byte
     /// budget and iteration stops the moment it is exhausted, so the work is
     /// bounded by `MAX_LEN` rather than by the (client-controlled) metadata size.
-    fn format_job_metadata(metadata: &std::collections::BTreeMap<String, String>) -> String {
-        if metadata.is_empty() {
+    fn format_job_metadata(
+        metadata: Option<&std::collections::BTreeMap<String, String>>,
+    ) -> String {
+        let Some(metadata) = metadata.filter(|m| !m.is_empty()) else {
             return String::new();
-        }
+        };
 
         const MAX_LEN: usize = 512;
         let ellipsis = '…';
@@ -1918,7 +1920,7 @@ mod tests {
             workers.to_vec(),
             partitions,
             JobExecutionMode::Standard,
-            std::collections::BTreeMap::new(),
+            None,
             false,
             ProofKind::VadcopFinal,
         )
@@ -2781,7 +2783,7 @@ mod tests {
             inputs_mode: zisk_cluster_common::InputsModeDto::InputsNone,
             hints_mode: zisk_cluster_common::HintsModeDto::HintsNone,
             simulated_node: None,
-            metadata: std::collections::BTreeMap::new(),
+            metadata: None,
             execution_only: false,
             proof_type: zisk_cluster_common::ProofKind::VadcopFinal,
         };
@@ -3185,7 +3187,7 @@ mod tests {
                 zisk_cluster_common::InputsModeDto::InputsNone,
                 zisk_cluster_common::HintsModeDto::HintsNone,
                 None,
-                std::collections::BTreeMap::new(),
+                None,
                 false,
                 zisk_cluster_common::ProofKind::VadcopFinal,
             )
@@ -3232,7 +3234,7 @@ mod tests {
                     zisk_cluster_common::InputsModeDto::InputsNone,
                     zisk_cluster_common::HintsModeDto::HintsNone,
                     None,
-                    std::collections::BTreeMap::new(),
+                    None,
                     false,
                     zisk_cluster_common::ProofKind::VadcopFinal,
                 )
@@ -3249,7 +3251,7 @@ mod tests {
                     zisk_cluster_common::InputsModeDto::InputsNone,
                     zisk_cluster_common::HintsModeDto::HintsNone,
                     None,
-                    std::collections::BTreeMap::new(),
+                    None,
                     false,
                     zisk_cluster_common::ProofKind::VadcopFinal,
                 )
@@ -4416,7 +4418,7 @@ mod tests {
             inputs_mode: InputsModeDto::InputsNone,
             hints_mode: HintsModeDto::HintsNone,
             simulated_node: None,
-            metadata: std::collections::BTreeMap::new(),
+            metadata: None,
             execution_only: false,
             proof_type: ProofKind::VadcopFinal,
         }

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -1591,35 +1591,46 @@ impl Coordinator {
     /// replaced with spaces to prevent log injection, and the returned string is
     /// capped at `MAX_LEN` bytes — including the leading space and any trailing
     /// `…` — so a large blob can't produce an unbounded log line.
+    ///
+    /// Sanitized characters are streamed straight into the output under a byte
+    /// budget and iteration stops the moment it is exhausted, so the work is
+    /// bounded by `MAX_LEN` rather than by the (client-controlled) metadata size.
     fn format_job_metadata(metadata: &std::collections::BTreeMap<String, String>) -> String {
         if metadata.is_empty() {
             return String::new();
         }
 
         const MAX_LEN: usize = 512;
-        let sanitize = |s: &str| -> String {
-            s.chars().map(|c| if c.is_control() { ' ' } else { c }).collect()
-        };
+        let ellipsis = '…';
+        // Always leave room for the trailing ellipsis within the total budget.
+        let budget = MAX_LEN - ellipsis.len_utf8();
+        let sanitize = |c: char| if c.is_control() { ' ' } else { c };
 
-        let joined = metadata
-            .iter()
-            .map(|(k, v)| format!("{}: {}", sanitize(k), sanitize(v)))
-            .collect::<Vec<_>>()
-            .join(", ");
+        let mut out = String::with_capacity(MAX_LEN);
+        out.push(' ');
+        let mut first = true;
+        let mut truncated = false;
 
-        // Cap the whole returned string at MAX_LEN bytes — the leading space
-        // and any trailing '…' both count against the budget — backing off to
-        // the nearest char boundary so a multi-byte character is never split.
-        if joined.len() < MAX_LEN {
-            format!(" {joined}")
-        } else {
-            let ellipsis = '…';
-            let mut end = MAX_LEN - 1 - ellipsis.len_utf8();
-            while end > 0 && !joined.is_char_boundary(end) {
-                end -= 1;
+        'entries: for (k, v) in metadata {
+            let sep = if first { "" } else { ", " };
+            first = false;
+            // Push "sep + k: v" char by char, stopping the moment we'd exceed
+            // the budget — so we never read or allocate more than ~MAX_LEN bytes
+            // of input, and never split a multi-byte character.
+            for part in [sep, k.as_str(), ": ", v.as_str()] {
+                for c in part.chars().map(sanitize) {
+                    if out.len() + c.len_utf8() > budget {
+                        truncated = true;
+                        break 'entries;
+                    }
+                    out.push(c);
+                }
             }
-            format!(" {}{}", &joined[..end], ellipsis)
         }
+        if truncated {
+            out.push(ellipsis);
+        }
+        out
     }
 
     // MONITOR METHODS

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -1588,9 +1588,9 @@ impl Coordinator {
     /// `" k: v, k: v"` string (empty when there is no metadata).
     ///
     /// Values come from clients, so control characters (newlines, tabs, …) are
-    /// replaced with spaces to prevent log injection, and the line is capped at
-    /// `MAX_LEN` bytes (including a trailing `…`) so a large blob can't produce
-    /// an unbounded log line.
+    /// replaced with spaces to prevent log injection, and the returned string is
+    /// capped at `MAX_LEN` bytes — including the leading space and any trailing
+    /// `…` — so a large blob can't produce an unbounded log line.
     fn format_job_metadata(metadata: &std::collections::BTreeMap<String, String>) -> String {
         if metadata.is_empty() {
             return String::new();
@@ -1607,13 +1607,14 @@ impl Coordinator {
             .collect::<Vec<_>>()
             .join(", ");
 
-        // Cap the line at MAX_LEN bytes, backing off to the nearest char
-        // boundary so a multi-byte character is never split.
-        if joined.len() <= MAX_LEN {
+        // Cap the whole returned string at MAX_LEN bytes — the leading space
+        // and any trailing '…' both count against the budget — backing off to
+        // the nearest char boundary so a multi-byte character is never split.
+        if joined.len() < MAX_LEN {
             format!(" {joined}")
         } else {
             let ellipsis = '…';
-            let mut end = MAX_LEN - ellipsis.len_utf8();
+            let mut end = MAX_LEN - 1 - ellipsis.len_utf8();
             while end > 0 && !joined.is_char_boundary(end) {
                 end -= 1;
             }

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -1588,8 +1588,9 @@ impl Coordinator {
     /// `" k: v, k: v"` string (empty when there is no metadata).
     ///
     /// Values come from clients, so control characters (newlines, tabs, …) are
-    /// replaced with spaces to prevent log injection and the result is bounded
-    /// in length to avoid unbounded log lines from large blobs.
+    /// replaced with spaces to prevent log injection, and the line is capped at
+    /// `MAX_LEN` bytes (including a trailing `…`) so a large blob can't produce
+    /// an unbounded log line.
     fn format_job_metadata(metadata: &std::collections::BTreeMap<String, String>) -> String {
         if metadata.is_empty() {
             return String::new();
@@ -1606,11 +1607,18 @@ impl Coordinator {
             .collect::<Vec<_>>()
             .join(", ");
 
-        let mut truncated: String = joined.chars().take(MAX_LEN).collect();
-        if truncated.len() < joined.len() {
-            truncated.push('…');
+        // Cap the line at MAX_LEN bytes, backing off to the nearest char
+        // boundary so a multi-byte character is never split.
+        if joined.len() <= MAX_LEN {
+            format!(" {joined}")
+        } else {
+            let ellipsis = '…';
+            let mut end = MAX_LEN - ellipsis.len_utf8();
+            while end > 0 && !joined.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!(" {}{}", &joined[..end], ellipsis)
         }
-        format!(" {}", truncated)
     }
 
     // MONITOR METHODS

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -47,7 +47,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     fs,
     sync::{atomic::AtomicU64, Arc},
     time::Duration,
@@ -717,7 +717,7 @@ impl Coordinator {
             vec![worker_id.clone()],
             Vec::<Vec<u32>>::new(),
             JobExecutionMode::Standard,
-            BTreeMap::new(),
+            None,
             false,
             ProofKind::VadcopFinal,
         );
@@ -1169,7 +1169,7 @@ impl Coordinator {
         inputs_mode: InputsModeDto,
         hints_mode: HintsModeDto,
         simulated_node: Option<u32>,
-        metadata: std::collections::BTreeMap<String, String>,
+        metadata: Option<String>,
         execution_only: bool,
         proof_type: ProofKind,
     ) -> CoordinatorResult<Job> {
@@ -1728,7 +1728,6 @@ impl Coordinator {
 mod tests {
     use super::*;
     use crate::test_utils::*;
-    use std::collections::BTreeMap;
     use zisk_cluster_common::{
         ComputeCapacity, HintsModeDto, InputsModeDto, Job, JobExecutionMode, JobPhase, JobState,
         PhaseTimings, WorkerState,
@@ -1755,7 +1754,7 @@ mod tests {
             workers.to_vec(),
             partitions,
             JobExecutionMode::Standard,
-            BTreeMap::new(),
+            None,
             false,
             ProofKind::VadcopFinal,
         )
@@ -2405,7 +2404,7 @@ mod tests {
             inputs_mode: zisk_cluster_common::InputsModeDto::InputsNone,
             hints_mode: zisk_cluster_common::HintsModeDto::HintsNone,
             simulated_node: None,
-            metadata: std::collections::BTreeMap::new(),
+            metadata: None,
             execution_only: false,
             proof_type: zisk_cluster_common::ProofKind::VadcopFinal,
         };
@@ -2809,7 +2808,7 @@ mod tests {
                 zisk_cluster_common::InputsModeDto::InputsNone,
                 zisk_cluster_common::HintsModeDto::HintsNone,
                 None,
-                std::collections::BTreeMap::new(),
+                None,
                 false,
                 zisk_cluster_common::ProofKind::VadcopFinal,
             )
@@ -2856,7 +2855,7 @@ mod tests {
                     zisk_cluster_common::InputsModeDto::InputsNone,
                     zisk_cluster_common::HintsModeDto::HintsNone,
                     None,
-                    std::collections::BTreeMap::new(),
+                    None,
                     false,
                     zisk_cluster_common::ProofKind::VadcopFinal,
                 )
@@ -2873,7 +2872,7 @@ mod tests {
                     zisk_cluster_common::InputsModeDto::InputsNone,
                     zisk_cluster_common::HintsModeDto::HintsNone,
                     None,
-                    std::collections::BTreeMap::new(),
+                    None,
                     false,
                     zisk_cluster_common::ProofKind::VadcopFinal,
                 )
@@ -4040,7 +4039,7 @@ mod tests {
             inputs_mode: InputsModeDto::InputsNone,
             hints_mode: HintsModeDto::HintsNone,
             simulated_node: None,
-            metadata: BTreeMap::new(),
+            metadata: None,
             execution_only: false,
             proof_type: ProofKind::VadcopFinal,
         }

--- a/distributed/crates/coordinator/src/coordinator/aggregate.rs
+++ b/distributed/crates/coordinator/src/coordinator/aggregate.rs
@@ -133,12 +133,9 @@ impl Coordinator {
             "Instances: N/A".to_string().red().bold()
         };
 
-        let metadata_str = if job.metadata.is_empty() {
-            String::new()
-        } else {
-            let pairs: Vec<String> =
-                job.metadata.iter().map(|(k, v)| format!("{}: {}", k, v)).collect();
-            format!(" {}", pairs.join(", "))
+        let metadata_str = match job.metadata.as_deref() {
+            Some(m) => format!(" {}", m),
+            None => String::new(),
         };
 
         info!(
@@ -498,6 +495,8 @@ impl Coordinator {
                 final_proof: all_done,
                 proof_type,
             }),
+            // Metadata is attached at job creation; later phases reuse the worker's job.
+            metadata: None,
         };
 
         let message = CoordinatorMessageDto::ExecuteTaskRequest(req);

--- a/distributed/crates/coordinator/src/coordinator/aggregate.rs
+++ b/distributed/crates/coordinator/src/coordinator/aggregate.rs
@@ -133,13 +133,7 @@ impl Coordinator {
             "Instances: N/A".to_string().red().bold()
         };
 
-        let metadata_str = if job.metadata.is_empty() {
-            String::new()
-        } else {
-            let pairs: Vec<String> =
-                job.metadata.iter().map(|(k, v)| format!("{}: {}", k, v)).collect();
-            format!(" {}", pairs.join(", "))
-        };
+        let metadata_str = Self::format_job_metadata(&job.metadata);
 
         info!(
             "{} {} ({:.3}s+{:.3}s+{:.3}s) {} {} Capacity: {}{}",

--- a/distributed/crates/coordinator/src/coordinator/aggregate.rs
+++ b/distributed/crates/coordinator/src/coordinator/aggregate.rs
@@ -492,7 +492,6 @@ impl Coordinator {
                 final_proof: all_done,
                 proof_type,
             }),
-            // Metadata is attached at job creation; later phases reuse the worker's job.
             metadata: None,
         };
 

--- a/distributed/crates/coordinator/src/coordinator/aggregate.rs
+++ b/distributed/crates/coordinator/src/coordinator/aggregate.rs
@@ -133,7 +133,7 @@ impl Coordinator {
             "Instances: N/A".to_string().red().bold()
         };
 
-        let metadata_str = Self::format_job_metadata(&job.metadata);
+        let metadata_str = Self::format_job_metadata(job.metadata.as_ref());
 
         info!(
             "{} {} ({:.3}s+{:.3}s+{:.3}s) {} {} Capacity: {}{}",
@@ -493,7 +493,7 @@ impl Coordinator {
                 proof_type,
             }),
             // Metadata is attached at job creation; later phases reuse the worker's job.
-            metadata: std::collections::BTreeMap::new(),
+            metadata: None,
         };
 
         let message = CoordinatorMessageDto::ExecuteTaskRequest(req);

--- a/distributed/crates/coordinator/src/coordinator/aggregate.rs
+++ b/distributed/crates/coordinator/src/coordinator/aggregate.rs
@@ -140,7 +140,7 @@ impl Coordinator {
                 job.metadata.iter().map(|(k, v)| format!("{}: {}", k, v)).collect();
             format!(" {}", pairs.join(", "))
         };
-        
+
         info!(
             "{} {} ({:.3}s+{:.3}s+{:.3}s) {} {} Capacity: {}{}",
             header,

--- a/distributed/crates/coordinator/src/coordinator/contributions.rs
+++ b/distributed/crates/coordinator/src/coordinator/contributions.rs
@@ -518,13 +518,7 @@ impl Coordinator {
             "Instances: N/A".to_string().red().bold()
         };
 
-        let metadata_str = if job.metadata.is_empty() {
-            String::new()
-        } else {
-            let pairs: Vec<String> =
-                job.metadata.iter().map(|(k, v)| format!("{}: {}", k, v)).collect();
-            format!(" {}", pairs.join(", "))
-        };
+        let metadata_str = Self::format_job_metadata(&job.metadata);
 
         info!(
             "{} {} {} {} Capacity: {}{}",

--- a/distributed/crates/coordinator/src/coordinator/contributions.rs
+++ b/distributed/crates/coordinator/src/coordinator/contributions.rs
@@ -518,7 +518,7 @@ impl Coordinator {
             "Instances: N/A".to_string().red().bold()
         };
 
-        let metadata_str = Self::format_job_metadata(&job.metadata);
+        let metadata_str = Self::format_job_metadata(job.metadata.as_ref());
 
         info!(
             "{} {} {} {} Capacity: {}{}",

--- a/distributed/crates/coordinator/src/coordinator/contributions.rs
+++ b/distributed/crates/coordinator/src/coordinator/contributions.rs
@@ -93,6 +93,7 @@ impl Coordinator {
             let hints_source = hints_source.clone();
             let worker_allocation = job.partitions[rank_id].clone();
             let job_compute_capacity = job.compute_capacity;
+            let job_metadata = job.metadata.clone();
             let workers_pool = &self.workers_pool;
 
             async move {
@@ -117,6 +118,7 @@ impl Coordinator {
                     worker_id: worker_id.clone(),
                     job_id: job_id.clone(),
                     params,
+                    metadata: job_metadata,
                 };
                 let req = CoordinatorMessageDto::ExecuteTaskRequest(req);
 
@@ -516,12 +518,9 @@ impl Coordinator {
             "Instances: N/A".to_string().red().bold()
         };
 
-        let metadata_str = if job.metadata.is_empty() {
-            String::new()
-        } else {
-            let pairs: Vec<String> =
-                job.metadata.iter().map(|(k, v)| format!("{}: {}", k, v)).collect();
-            format!(" {}", pairs.join(", "))
+        let metadata_str = match job.metadata.as_deref() {
+            Some(m) => format!(" {}", m),
+            None => String::new(),
         };
 
         info!(

--- a/distributed/crates/coordinator/src/coordinator/prove.rs
+++ b/distributed/crates/coordinator/src/coordinator/prove.rs
@@ -47,7 +47,7 @@ impl Coordinator {
                 params: ExecuteTaskRequestTypeDto::ProveParams(ProveParamsDto {
                     challenges: challenges.clone(),
                 }),
-                metadata: std::collections::BTreeMap::new(),
+                metadata: None,
             };
             let req = CoordinatorMessageDto::ExecuteTaskRequest(req);
 

--- a/distributed/crates/coordinator/src/coordinator/prove.rs
+++ b/distributed/crates/coordinator/src/coordinator/prove.rs
@@ -47,6 +47,7 @@ impl Coordinator {
                 params: ExecuteTaskRequestTypeDto::ProveParams(ProveParamsDto {
                     challenges: challenges.clone(),
                 }),
+                metadata: None,
             };
             let req = CoordinatorMessageDto::ExecuteTaskRequest(req);
 

--- a/distributed/crates/coordinator/src/coordinator/wrap.rs
+++ b/distributed/crates/coordinator/src/coordinator/wrap.rs
@@ -2,7 +2,6 @@ use crate::{
     job_events::{CoordinatorJobEvent, CoordinatorJobResult},
     Coordinator, CoordinatorError, CoordinatorResult,
 };
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use zisk_cluster_common::{
@@ -39,7 +38,7 @@ impl Coordinator {
             vec![worker_id.clone()],
             vec![],
             JobExecutionMode::Standard,
-            BTreeMap::new(),
+            None,
             false,
             ProofKind::VadcopFinal,
         );
@@ -60,6 +59,7 @@ impl Coordinator {
                 proof_data: request.proof_data,
                 proof_dest: request.proof_dest,
             }),
+            metadata: None,
         };
         let message = CoordinatorMessageDto::ExecuteTaskRequest(req);
         if let Err(e) = self.workers_pool.send_message(&worker_id, message).await {

--- a/distributed/crates/coordinator/src/coordinator/wrap.rs
+++ b/distributed/crates/coordinator/src/coordinator/wrap.rs
@@ -38,7 +38,7 @@ impl Coordinator {
             vec![worker_id.clone()],
             vec![],
             JobExecutionMode::Standard,
-            std::collections::BTreeMap::new(),
+            None,
             false,
             ProofKind::VadcopFinal,
         );
@@ -59,7 +59,7 @@ impl Coordinator {
                 proof_data: request.proof_data,
                 proof_dest: request.proof_dest,
             }),
-            metadata: std::collections::BTreeMap::new(),
+            metadata: None,
         };
         let message = CoordinatorMessageDto::ExecuteTaskRequest(req);
         if let Err(e) = self.workers_pool.send_message(&worker_id, message).await {

--- a/distributed/crates/coordinator/tests/common/mod.rs
+++ b/distributed/crates/coordinator/tests/common/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use zisk_cluster_common::{
     ComputeCapacity, CoordinatorMessageDto, HintsModeDto, InputsModeDto, Job, JobExecutionMode,
@@ -68,7 +67,7 @@ pub fn create_test_job(workers: &[WorkerId]) -> Job {
         workers.to_vec(),
         partitions,
         JobExecutionMode::Standard,
-        BTreeMap::new(),
+        None,
         false,
         zisk_common::ProofKind::VadcopFinal,
     )

--- a/distributed/crates/coordinator/tests/common/mod.rs
+++ b/distributed/crates/coordinator/tests/common/mod.rs
@@ -67,7 +67,7 @@ pub fn create_test_job(workers: &[WorkerId]) -> Job {
         workers.to_vec(),
         partitions,
         JobExecutionMode::Standard,
-        std::collections::BTreeMap::new(),
+        None,
         false,
         zisk_common::ProofKind::VadcopFinal,
     )

--- a/distributed/crates/worker/src/worker.rs
+++ b/distributed/crates/worker/src/worker.rs
@@ -326,8 +326,8 @@ pub struct JobContext {
     pub instances: u64,
     /// When the current task was received (for latency accounting).
     pub task_received_time: Option<chrono::DateTime<chrono::Utc>>,
-    /// Job-level metadata propagated from the coordinator (empty map means none).
-    pub metadata: BTreeMap<String, String>,
+    /// Job-level metadata propagated from the coordinator (`None` when there is none).
+    pub metadata: Option<BTreeMap<String, String>>,
 }
 
 /// A ZisK worker over backend `T`: holds the prover, the current job context
@@ -659,7 +659,7 @@ impl<T: ZiskBackend + 'static> Worker<T> {
         allocation: Vec<u32>,
         total_compute_units: u32,
         task_received_time: Option<chrono::DateTime<chrono::Utc>>,
-        metadata: BTreeMap<String, String>,
+        metadata: Option<BTreeMap<String, String>>,
     ) -> Arc<Mutex<JobContext>> {
         let current_job = Arc::new(Mutex::new(JobContext {
             job_id: job_id.clone(),

--- a/distributed/crates/worker/src/worker.rs
+++ b/distributed/crates/worker/src/worker.rs
@@ -326,7 +326,7 @@ pub struct JobContext {
     pub instances: u64,
     /// When the current task was received (for latency accounting).
     pub task_received_time: Option<chrono::DateTime<chrono::Utc>>,
-    /// Job-level metadata propagated from the coordinator (`None` when there is none).
+    /// Job-level metadata propagated from the coordinator.
     pub metadata: Option<BTreeMap<String, String>>,
 }
 

--- a/distributed/crates/worker/src/worker.rs
+++ b/distributed/crates/worker/src/worker.rs
@@ -282,6 +282,7 @@ pub struct JobContext {
     pub executed_steps: u64,
     pub instances: u64,
     pub task_received_time: Option<chrono::DateTime<chrono::Utc>>,
+    pub metadata: Option<String>,
 }
 
 pub struct Worker<T: ZiskBackend + 'static> {
@@ -588,6 +589,7 @@ impl<T: ZiskBackend + 'static> Worker<T> {
         allocation: Vec<u32>,
         total_compute_units: u32,
         task_received_time: Option<chrono::DateTime<chrono::Utc>>,
+        metadata: Option<String>,
     ) -> Arc<Mutex<JobContext>> {
         let current_job = Arc::new(Mutex::new(JobContext {
             job_id: job_id.clone(),
@@ -601,6 +603,7 @@ impl<T: ZiskBackend + 'static> Worker<T> {
             executed_steps: 0,
             task_received_time,
             instances: 0,
+            metadata,
         }));
         self.current_job = Some(current_job.clone());
 

--- a/distributed/crates/worker/src/worker_node.rs
+++ b/distributed/crates/worker/src/worker_node.rs
@@ -1658,9 +1658,9 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
         let cancelled = self.worker.cancel_current_computation();
         Self::drain_cancelled_computation(cancelled, "partial_contribution").await;
 
-        // Proto `map<string, string>` (a HashMap) into the domain's ordered map.
-        let metadata: std::collections::BTreeMap<String, String> =
-            request.metadata.into_iter().collect();
+        // Proto `map<string, string>` (a HashMap); an empty map means "no metadata".
+        let metadata = (!request.metadata.is_empty())
+            .then(|| request.metadata.into_iter().collect::<std::collections::BTreeMap<_, _>>());
 
         // Extract the PartialContribution params
         let Some(execute_task_request::Params::ContributionParams(params)) = request.params else {
@@ -1735,9 +1735,9 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
         let cancelled = self.worker.cancel_current_computation();
         Self::drain_cancelled_computation(cancelled, "execute_only").await;
 
-        // Proto `map<string, string>` (a HashMap) into the domain's ordered map.
-        let metadata: std::collections::BTreeMap<String, String> =
-            request.metadata.into_iter().collect();
+        // Proto `map<string, string>` (a HashMap); an empty map means "no metadata".
+        let metadata = (!request.metadata.is_empty())
+            .then(|| request.metadata.into_iter().collect::<std::collections::BTreeMap<_, _>>());
 
         // Extract the ExecutionParams (reuses ContributionParams structure)
         let Some(execute_task_request::Params::ExecutionParams(params)) = request.params else {

--- a/distributed/crates/worker/src/worker_node.rs
+++ b/distributed/crates/worker/src/worker_node.rs
@@ -1593,6 +1593,8 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
         // Cancel any existing computation
         self.worker.cancel_current_computation();
 
+        let metadata = request.metadata.clone();
+
         // Extract the PartialContribution params
         let Some(execute_task_request::Params::ContributionParams(params)) = request.params else {
             return Err(anyhow!("Expected ContributionParams for Partial Contribution task"));
@@ -1640,6 +1642,7 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
             params.worker_allocation,
             params.job_compute_units,
             Some(task_received_time),
+            metadata,
         );
 
         // Start computation in background task
@@ -1660,6 +1663,8 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
 
         // Cancel any existing computation
         self.worker.cancel_current_computation();
+
+        let metadata = request.metadata.clone();
 
         // Extract the ExecutionParams (reuses ContributionParams structure)
         let Some(execute_task_request::Params::ExecutionParams(params)) = request.params else {
@@ -1708,6 +1713,7 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
             params.worker_allocation,
             params.job_compute_units,
             Some(task_received_time),
+            metadata,
         );
 
         // Start execution-only computation in background task

--- a/distributed/crates/worker/src/worker_node.rs
+++ b/distributed/crates/worker/src/worker_node.rs
@@ -1660,7 +1660,7 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
 
         // Proto `map<string, string>` (a HashMap) into the domain's ordered map.
         let metadata: std::collections::BTreeMap<String, String> =
-            request.metadata.clone().into_iter().collect();
+            request.metadata.into_iter().collect();
 
         // Extract the PartialContribution params
         let Some(execute_task_request::Params::ContributionParams(params)) = request.params else {
@@ -1737,7 +1737,7 @@ impl<T: ZiskBackend + 'static> WorkerNodeGrpc<T> {
 
         // Proto `map<string, string>` (a HashMap) into the domain's ordered map.
         let metadata: std::collections::BTreeMap<String, String> =
-            request.metadata.clone().into_iter().collect();
+            request.metadata.into_iter().collect();
 
         // Extract the ExecutionParams (reuses ContributionParams structure)
         let Some(execute_task_request::Params::ExecutionParams(params)) = request.params else {

--- a/sdk/src/execute.rs
+++ b/sdk/src/execute.rs
@@ -7,7 +7,7 @@ use zisk_prover_backend::{ExecuteOutput, GuestProgram};
 use crate::hints::HintsSource;
 use crate::input_source::InputSource;
 use crate::job_handle::{new_subscriber_list, JobHandle, JobId};
-use crate::{Client, ClientSync, ExecutorKind};
+use crate::{Client, ClientSync, ExecutorKind, RemoteClient};
 
 /// Result of an execute operation.
 pub struct ExecuteResult {
@@ -118,5 +118,83 @@ impl<'a, C: ClientSync> ExecuteRequest<'a, C> {
     pub fn run_sync(self) -> Result<ExecuteResult> {
         let subs = new_subscriber_list();
         self.client.run_execute_sync(self.program, self.stdin, self.hints, self.executor, subs)
+    }
+}
+
+/// Extended execute request builder — identical to [`ExecuteRequest`] but adds
+/// opt-in, job-level [`metadata`](Self::metadata).
+///
+/// Remote backend only; obtain via
+/// [`RemoteClientExt::execute`](crate::RemoteClientExt::execute).
+pub struct ExecuteRequestExt<'a> {
+    client: &'a RemoteClient,
+    program: &'a GuestProgram,
+    stdin: InputSource,
+    hints: Option<HintsSource>,
+    executor: ExecutorKind,
+    timeout: Option<Duration>,
+    metadata: Vec<u8>,
+}
+
+impl<'a> ExecuteRequestExt<'a> {
+    pub(crate) fn new(
+        client: &'a RemoteClient,
+        program: &'a GuestProgram,
+        stdin: impl Into<InputSource>,
+    ) -> Self {
+        Self {
+            client,
+            program,
+            stdin: stdin.into(),
+            hints: None,
+            executor: ExecutorKind::default(),
+            timeout: None,
+            metadata: Vec::new(),
+        }
+    }
+
+    /// Attach opaque, job-level metadata forwarded to the coordinator.
+    ///
+    /// The bytes are caller-defined (e.g. serde-serialized) and currently ignored
+    /// by the coordinator.
+    #[must_use]
+    pub fn metadata(mut self, metadata: impl Into<Vec<u8>>) -> Self {
+        self.metadata = metadata.into();
+        self
+    }
+
+    /// Attach a hints stream to this execute request.
+    #[must_use]
+    pub fn hints(mut self, hints: impl Into<HintsSource>) -> Self {
+        self.hints = Some(hints.into());
+        self
+    }
+
+    /// Override the executor for this execute call.
+    #[must_use]
+    pub fn executor(mut self, executor: ExecutorKind) -> Self {
+        self.executor = executor;
+        self
+    }
+
+    /// Set a timeout for the execution.
+    #[must_use]
+    pub fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+
+    /// Submit the execution, returning a [`JobHandle<ExecuteResult>`].
+    pub fn run(self) -> Result<JobHandle<ExecuteResult>> {
+        let subs = new_subscriber_list();
+        self.client.do_execute_ext(
+            self.program,
+            self.stdin,
+            self.hints,
+            self.executor,
+            self.timeout,
+            subs,
+            self.metadata,
+        )
     }
 }

--- a/sdk/src/execute.rs
+++ b/sdk/src/execute.rs
@@ -133,7 +133,7 @@ pub struct ExecuteRequestExt<'a> {
     hints: Option<HintsSource>,
     executor: ExecutorKind,
     timeout: Option<Duration>,
-    metadata: Vec<u8>,
+    metadata: String,
 }
 
 impl<'a> ExecuteRequestExt<'a> {
@@ -149,16 +149,14 @@ impl<'a> ExecuteRequestExt<'a> {
             hints: None,
             executor: ExecutorKind::default(),
             timeout: None,
-            metadata: Vec::new(),
+            metadata: String::new(),
         }
     }
 
-    /// Attach opaque, job-level metadata forwarded to the coordinator.
-    ///
-    /// The bytes are caller-defined (e.g. serde-serialized) and currently ignored
-    /// by the coordinator.
+    /// Attach job-level metadata forwarded to the coordinator (e.g. a tag or a
+    /// JSON string). Empty means no metadata.
     #[must_use]
-    pub fn metadata(mut self, metadata: impl Into<Vec<u8>>) -> Self {
+    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
         self.metadata = metadata.into();
         self
     }

--- a/sdk/src/job_handle.rs
+++ b/sdk/src/job_handle.rs
@@ -103,6 +103,7 @@ pub(crate) trait FromWaitResult: Sized + Send + 'static {
     fn from_terminal(status: TerminalStatus, job_id: JobId) -> Result<Self>;
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum JobHandleInner<T> {
     Embedded(tokio::task::JoinHandle<Result<T>>),
     Remote { remote_job: Job, _watch_handle: WatchHandle },

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -39,16 +39,16 @@ pub use embedded::{
 pub use error::{Result, SdkError};
 pub use zisk_client::ZiskClient;
 
-pub use execute::{ExecuteRequest, ExecuteResult};
+pub use execute::{ExecuteRequest, ExecuteRequestExt, ExecuteResult};
 pub use hints::{HintsSource, ZiskHints};
 pub use input_source::InputSource;
 pub use input_stream::ZiskStream;
 pub use job_handle::JobHandle;
 pub use lifecycle::{SetupTarget, UploadTarget};
-pub use prove::{JobEvent, ProveRequest, ProveResult};
+pub use prove::{JobEvent, ProveRequest, ProveRequestExt, ProveResult};
 pub use recurser::{AggregationProgram, AggregationProgramBuilder, Recurser};
 pub use remote::setup::SetupByIdRequest;
-pub use remote::{RemoteClient, RemoteClientBuilder};
+pub use remote::{RemoteClient, RemoteClientBuilder, RemoteClientExt};
 pub use setup::SetupRequest;
 pub use stdin::ZiskStdin;
 pub use upload::UploadRequest;

--- a/sdk/src/prove.rs
+++ b/sdk/src/prove.rs
@@ -189,7 +189,7 @@ pub struct ProveRequestExt<'a> {
     timeout: Option<Duration>,
     proof_kind: ProofKind,
     subscribers: Vec<Subscriber>,
-    metadata: Vec<u8>,
+    metadata: String,
 }
 
 impl<'a> ProveRequestExt<'a> {
@@ -207,16 +207,14 @@ impl<'a> ProveRequestExt<'a> {
             timeout: None,
             proof_kind: ProofKind::default(),
             subscribers: Vec::new(),
-            metadata: Vec::new(),
+            metadata: String::new(),
         }
     }
 
-    /// Attach opaque, job-level metadata forwarded to the coordinator.
-    ///
-    /// The bytes are caller-defined (e.g. serde-serialized) and currently ignored
-    /// by the coordinator.
+    /// Attach job-level metadata forwarded to the coordinator (e.g. a tag or a
+    /// JSON string). Empty means no metadata.
     #[must_use]
-    pub fn metadata(mut self, metadata: impl Into<Vec<u8>>) -> Self {
+    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
         self.metadata = metadata.into();
         self
     }

--- a/sdk/src/prove.rs
+++ b/sdk/src/prove.rs
@@ -9,7 +9,7 @@ use zisk_prover_backend::{GuestProgram, ProveOutput};
 use crate::hints::HintsSource;
 use crate::input_source::InputSource;
 use crate::job_handle::{subscriber_list_from, JobHandle, JobId, Subscriber, SubscriberList};
-use crate::{Client, ClientSync, ExecutorKind};
+use crate::{Client, ClientSync, ExecutorKind, RemoteClient};
 
 /// Result of a prove operation.
 pub struct ProveResult {
@@ -171,6 +171,105 @@ impl<'a, C: ClientSync> ProveRequest<'a, C> {
             self.executor,
             self.proof_kind,
             subs,
+        )
+    }
+}
+
+/// Extended prove request builder — identical to [`ProveRequest`] but adds
+/// opt-in, job-level [`metadata`](Self::metadata).
+///
+/// Remote backend only; obtain via
+/// [`RemoteClientExt::prove`](crate::RemoteClientExt::prove).
+pub struct ProveRequestExt<'a> {
+    client: &'a RemoteClient,
+    program: &'a GuestProgram,
+    stdin: InputSource,
+    hints: Option<HintsSource>,
+    executor: ExecutorKind,
+    timeout: Option<Duration>,
+    proof_kind: ProofKind,
+    subscribers: Vec<Subscriber>,
+    metadata: Vec<u8>,
+}
+
+impl<'a> ProveRequestExt<'a> {
+    pub(crate) fn new(
+        client: &'a RemoteClient,
+        program: &'a GuestProgram,
+        stdin: impl Into<InputSource>,
+    ) -> Self {
+        Self {
+            client,
+            program,
+            stdin: stdin.into(),
+            hints: None,
+            executor: ExecutorKind::default(),
+            timeout: None,
+            proof_kind: ProofKind::default(),
+            subscribers: Vec::new(),
+            metadata: Vec::new(),
+        }
+    }
+
+    /// Attach opaque, job-level metadata forwarded to the coordinator.
+    ///
+    /// The bytes are caller-defined (e.g. serde-serialized) and currently ignored
+    /// by the coordinator.
+    #[must_use]
+    pub fn metadata(mut self, metadata: impl Into<Vec<u8>>) -> Self {
+        self.metadata = metadata.into();
+        self
+    }
+
+    /// Attach a hints stream to this prove request.
+    #[must_use]
+    pub fn hints(mut self, hints: impl Into<HintsSource>) -> Self {
+        self.hints = Some(hints.into());
+        self
+    }
+
+    /// Override the executor for this prove call.
+    #[must_use]
+    pub fn executor(mut self, executor: ExecutorKind) -> Self {
+        self.executor = executor;
+        self
+    }
+
+    /// Set a timeout for proof generation.
+    #[must_use]
+    pub fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+
+    /// Set the proof wrapping mode.
+    #[must_use]
+    pub fn wrap(mut self, kind: ProofKind) -> Self {
+        self.proof_kind = kind;
+        self
+    }
+
+    /// Register a pre-submit event callback.
+    ///
+    /// Use [`JobEvent::All`] to subscribe to all events.
+    #[must_use]
+    pub fn on(mut self, event: JobEvent, cb: impl Fn(JobEvent) + Send + Sync + 'static) -> Self {
+        self.subscribers.push((event, Arc::new(cb)));
+        self
+    }
+
+    /// Submit proof generation, returning a [`JobHandle<ProveResult>`] immediately.
+    pub fn run(self) -> Result<JobHandle<ProveResult>> {
+        let subs: SubscriberList = subscriber_list_from(self.subscribers);
+        self.client.do_prove_ext(
+            self.program,
+            self.stdin,
+            self.hints,
+            self.executor,
+            self.proof_kind,
+            self.timeout,
+            subs,
+            self.metadata,
         )
     }
 }

--- a/sdk/src/remote.rs
+++ b/sdk/src/remote.rs
@@ -92,7 +92,7 @@ impl<Out: From<RemoteClient>> RemoteClientBuilder<Out> {
     /// Build an **extended** remote client.
     ///
     /// # Returns
-    /// 
+    ///
     /// [`RemoteClientExt`] — a wrapper around [`RemoteClient`] that overrides
     /// [`execute`](RemoteClient::execute) and [`prove`](RemoteClient::prove)
     /// to return builders that can carry extended features.

--- a/sdk/src/remote.rs
+++ b/sdk/src/remote.rs
@@ -77,16 +77,23 @@ impl<Out> RemoteClientBuilder<Out> {
 }
 
 impl<Out: From<RemoteClient>> RemoteClientBuilder<Out> {
+    /// Connect the gateway and construct the base client. Shared by
+    /// [`build`](Self::build) and [`build_ext`](Self::build_ext) so the
+    /// connection path stays in one place.
+    fn connect(self) -> Result<RemoteClient> {
+        crate::client::ensure_single_instance();
+        let gw = CoordinatorClient::connect(self.url, self.connect_timeout, self.request_timeout)
+            .map_err(SdkError::backend)?;
+        Ok(RemoteClient { gw })
+    }
+
     /// Build the client.
     ///
     /// Returns the type fixed by the constructor: a [`RemoteClient`] via
     /// [`ProverClient::remote`](crate::ProverClient::remote), or an
     /// [`ZiskClient`](crate::ZiskClient) via [`ZiskClient::remote`](crate::ZiskClient::remote).
     pub fn build(self) -> Result<Out> {
-        crate::client::ensure_single_instance();
-        let gw = CoordinatorClient::connect(self.url, self.connect_timeout, self.request_timeout)
-            .map_err(SdkError::backend)?;
-        Ok(RemoteClient { gw }.into())
+        Ok(self.connect()?.into())
     }
 
     /// Build an **extended** remote client.
@@ -97,10 +104,7 @@ impl<Out: From<RemoteClient>> RemoteClientBuilder<Out> {
     /// [`execute`](RemoteClient::execute) and [`prove`](RemoteClient::prove)
     /// to return builders that can carry extended features.
     pub fn build_ext(self) -> Result<RemoteClientExt> {
-        crate::client::ensure_single_instance();
-        let gw = CoordinatorClient::connect(self.url, self.connect_timeout, self.request_timeout)
-            .map_err(SdkError::backend)?;
-        Ok(RemoteClientExt { inner: RemoteClient { gw } })
+        Ok(RemoteClientExt { inner: self.connect()? })
     }
 }
 

--- a/sdk/src/remote.rs
+++ b/sdk/src/remote.rs
@@ -88,6 +88,20 @@ impl<Out: From<RemoteClient>> RemoteClientBuilder<Out> {
             .map_err(SdkError::backend)?;
         Ok(RemoteClient { gw }.into())
     }
+
+    /// Build an **extended** remote client.
+    ///
+    /// # Returns
+    /// 
+    /// [`RemoteClientExt`] — a wrapper around [`RemoteClient`] that overrides
+    /// [`execute`](RemoteClient::execute) and [`prove`](RemoteClient::prove)
+    /// to return builders that can carry extended features.
+    pub fn build_ext(self) -> Result<RemoteClientExt> {
+        crate::client::ensure_single_instance();
+        let gw = CoordinatorClient::connect(self.url, self.connect_timeout, self.request_timeout)
+            .map_err(SdkError::backend)?;
+        Ok(RemoteClientExt { inner: RemoteClient { gw } })
+    }
 }
 
 /// Remote client implementation.
@@ -257,6 +271,49 @@ impl RemoteClient {
         input_b: impl Into<AggregationInput<'a>>,
     ) -> AggregateProofsRequest<'a, Self> {
         AggregateProofsRequest::new(self, agg, input_a.into(), input_b.into())
+    }
+}
+
+/// Extended remote client with opt-in, job-level metadata on `execute`/`prove`.
+///
+/// Built via [`RemoteClientBuilder::build_ext`]. Dereferences to [`RemoteClient`],
+/// so every other operation (`setup`, `upload`, `wrap_proof`, `aggregate_proofs`,
+/// …) is available unchanged; only [`execute`](Self::execute) and
+/// [`prove`](Self::prove) are overridden to return metadata-capable builders.
+#[derive(Clone)]
+pub struct RemoteClientExt {
+    inner: RemoteClient,
+}
+
+impl std::ops::Deref for RemoteClientExt {
+    type Target = RemoteClient;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl RemoteClientExt {
+    /// Submit a prove request that can carry opaque job-level metadata via
+    /// [`ProveRequestExt::metadata`](crate::ProveRequestExt::metadata).
+    #[must_use]
+    pub fn prove<'a>(
+        &'a self,
+        program: &'a GuestProgram,
+        stdin: impl Into<InputSource>,
+    ) -> crate::prove::ProveRequestExt<'a> {
+        crate::prove::ProveRequestExt::new(&self.inner, program, stdin)
+    }
+
+    /// Submit an execute request (dry-run, no proof) that can carry opaque
+    /// job-level metadata via
+    /// [`ExecuteRequestExt::metadata`](crate::ExecuteRequestExt::metadata).
+    #[must_use]
+    pub fn execute<'a>(
+        &'a self,
+        program: &'a GuestProgram,
+        stdin: impl Into<InputSource>,
+    ) -> crate::execute::ExecuteRequestExt<'a> {
+        crate::execute::ExecuteRequestExt::new(&self.inner, program, stdin)
     }
 }
 

--- a/sdk/src/remote/execute.rs
+++ b/sdk/src/remote/execute.rs
@@ -38,7 +38,7 @@ impl RemoteClient {
         executor: ExecutorKind,
         timeout: Option<Duration>,
         subs: SubscriberList,
-        metadata: Vec<u8>,
+        metadata: String,
     ) -> Result<JobHandle<ExecuteResult>> {
         self.submit_execute(program, stdin, hints, executor, timeout, subs, Some(metadata))
     }
@@ -54,7 +54,7 @@ impl RemoteClient {
         _executor: ExecutorKind, // remote: coordinator uses its configured executor; hint ignored
         timeout: Option<Duration>,
         subs: SubscriberList,
-        metadata: Option<Vec<u8>>,
+        metadata: Option<String>,
     ) -> Result<JobHandle<ExecuteResult>> {
         let (hints, maybe_hints_stream) = hints_to_input_kind(hints)?;
 

--- a/sdk/src/remote/execute.rs
+++ b/sdk/src/remote/execute.rs
@@ -41,7 +41,10 @@ impl RemoteClient {
         subs: SubscriberList,
         metadata: BTreeMap<String, String>,
     ) -> Result<JobHandle<ExecuteResult>> {
-        self.submit_execute(program, stdin, hints, executor, timeout, subs, Some(metadata))
+        // Empty metadata routes through the standard API so callers that set no
+        // metadata don't hard-require the extended service to be deployed.
+        let metadata = if metadata.is_empty() { None } else { Some(metadata) };
+        self.submit_execute(program, stdin, hints, executor, timeout, subs, metadata)
     }
 
     /// Shared execute submission. `metadata` selects the transport: `Some` routes

--- a/sdk/src/remote/execute.rs
+++ b/sdk/src/remote/execute.rs
@@ -41,10 +41,7 @@ impl RemoteClient {
         subs: SubscriberList,
         metadata: BTreeMap<String, String>,
     ) -> Result<JobHandle<ExecuteResult>> {
-        // Empty metadata routes through the standard API so callers that set no
-        // metadata don't hard-require the extended service to be deployed.
-        let metadata = if metadata.is_empty() { None } else { Some(metadata) };
-        self.submit_execute(program, stdin, hints, executor, timeout, subs, metadata)
+        self.submit_execute(program, stdin, hints, executor, timeout, subs, Some(metadata))
     }
 
     /// Shared execute submission. `metadata` selects the transport: `Some` routes
@@ -60,6 +57,7 @@ impl RemoteClient {
         subs: SubscriberList,
         metadata: Option<BTreeMap<String, String>>,
     ) -> Result<JobHandle<ExecuteResult>> {
+        let metadata = metadata.filter(|m| !m.is_empty());
         let (hints, maybe_hints_stream) = hints_to_input_kind(hints)?;
 
         let hash_id = program.program_id.hash_id.to_string();

--- a/sdk/src/remote/execute.rs
+++ b/sdk/src/remote/execute.rs
@@ -14,7 +14,39 @@ use zisk_prover_backend::GuestProgram;
 use crate::Result;
 
 impl RemoteClient {
+    /// Submit an execute job over the standard coordinator API.
     pub(crate) fn do_execute(
+        &self,
+        program: &GuestProgram,
+        stdin: InputSource,
+        hints: Option<HintsSource>,
+        executor: ExecutorKind,
+        timeout: Option<Duration>,
+        subs: SubscriberList,
+    ) -> Result<JobHandle<ExecuteResult>> {
+        self.submit_execute(program, stdin, hints, executor, timeout, subs, None)
+    }
+
+    /// Submit an execute job over the extended coordinator API, attaching opaque
+    /// job-level `metadata` (currently ignored by the coordinator).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn do_execute_ext(
+        &self,
+        program: &GuestProgram,
+        stdin: InputSource,
+        hints: Option<HintsSource>,
+        executor: ExecutorKind,
+        timeout: Option<Duration>,
+        subs: SubscriberList,
+        metadata: Vec<u8>,
+    ) -> Result<JobHandle<ExecuteResult>> {
+        self.submit_execute(program, stdin, hints, executor, timeout, subs, Some(metadata))
+    }
+
+    /// Shared execute submission. `metadata` selects the transport: `Some` routes
+    /// through the extended API (`submit_job_ext`), `None` through the standard one.
+    #[allow(clippy::too_many_arguments)]
+    fn submit_execute(
         &self,
         program: &GuestProgram,
         stdin: InputSource,
@@ -22,6 +54,7 @@ impl RemoteClient {
         _executor: ExecutorKind, // remote: coordinator uses its configured executor; hint ignored
         timeout: Option<Duration>,
         subs: SubscriberList,
+        metadata: Option<Vec<u8>>,
     ) -> Result<JobHandle<ExecuteResult>> {
         let (hints, maybe_hints_stream) = hints_to_input_kind(hints)?;
 
@@ -40,7 +73,11 @@ impl RemoteClient {
         let job_kind =
             DomainJobKind::Execute(DomainExecuteRequest { hash_id, input, hints, execute_timeout });
 
-        let remote_job = self.gw.submit_job(job_kind).map_err(SdkError::backend)?;
+        let remote_job = match metadata {
+            Some(metadata) => self.gw.submit_job_ext(job_kind, metadata),
+            None => self.gw.submit_job(job_kind),
+        }
+        .map_err(SdkError::backend)?;
 
         // gRPC streams need an InputSender injected after job submission.
         if let Some(ref stream) = maybe_stream {

--- a/sdk/src/remote/prove.rs
+++ b/sdk/src/remote/prove.rs
@@ -41,7 +41,7 @@ impl RemoteClient {
         proof_kind: ProofKind,
         timeout: Option<Duration>,
         subs: SubscriberList,
-        metadata: Vec<u8>,
+        metadata: String,
     ) -> Result<JobHandle<ProveResult>> {
         self.submit_prove(
             program,
@@ -67,7 +67,7 @@ impl RemoteClient {
         proof_kind: ProofKind,
         timeout: Option<Duration>,
         subs: SubscriberList,
-        metadata: Option<Vec<u8>>,
+        metadata: Option<String>,
     ) -> Result<JobHandle<ProveResult>> {
         let (hints, maybe_hints_stream) = hints_to_input_kind(hints)?;
 

--- a/sdk/src/remote/prove.rs
+++ b/sdk/src/remote/prove.rs
@@ -43,7 +43,16 @@ impl RemoteClient {
         subs: SubscriberList,
         metadata: Vec<u8>,
     ) -> Result<JobHandle<ProveResult>> {
-        self.submit_prove(program, stdin, hints, executor, proof_kind, timeout, subs, Some(metadata))
+        self.submit_prove(
+            program,
+            stdin,
+            hints,
+            executor,
+            proof_kind,
+            timeout,
+            subs,
+            Some(metadata),
+        )
     }
 
     /// Shared prove submission. `metadata` selects the transport: `Some` routes

--- a/sdk/src/remote/prove.rs
+++ b/sdk/src/remote/prove.rs
@@ -14,8 +14,42 @@ use zisk_prover_backend::GuestProgram;
 use crate::{Result, SdkError};
 
 impl RemoteClient {
+    /// Submit a prove job over the standard coordinator API.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn do_prove(
+        &self,
+        program: &GuestProgram,
+        stdin: InputSource,
+        hints: Option<HintsSource>,
+        executor: ExecutorKind,
+        proof_kind: ProofKind,
+        timeout: Option<Duration>,
+        subs: SubscriberList,
+    ) -> Result<JobHandle<ProveResult>> {
+        self.submit_prove(program, stdin, hints, executor, proof_kind, timeout, subs, None)
+    }
+
+    /// Submit a prove job over the extended coordinator API, attaching opaque
+    /// job-level `metadata` (currently ignored by the coordinator).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn do_prove_ext(
+        &self,
+        program: &GuestProgram,
+        stdin: InputSource,
+        hints: Option<HintsSource>,
+        executor: ExecutorKind,
+        proof_kind: ProofKind,
+        timeout: Option<Duration>,
+        subs: SubscriberList,
+        metadata: Vec<u8>,
+    ) -> Result<JobHandle<ProveResult>> {
+        self.submit_prove(program, stdin, hints, executor, proof_kind, timeout, subs, Some(metadata))
+    }
+
+    /// Shared prove submission. `metadata` selects the transport: `Some` routes
+    /// through the extended API (`submit_job_ext`), `None` through the standard one.
+    #[allow(clippy::too_many_arguments)]
+    fn submit_prove(
         &self,
         program: &GuestProgram,
         stdin: InputSource,
@@ -24,6 +58,7 @@ impl RemoteClient {
         proof_kind: ProofKind,
         timeout: Option<Duration>,
         subs: SubscriberList,
+        metadata: Option<Vec<u8>>,
     ) -> Result<JobHandle<ProveResult>> {
         let (hints, maybe_hints_stream) = hints_to_input_kind(hints)?;
 
@@ -48,7 +83,11 @@ impl RemoteClient {
             proof_dest,
         });
 
-        let remote_job = self.gw.submit_job(job_kind).map_err(SdkError::backend)?;
+        let remote_job = match metadata {
+            Some(metadata) => self.gw.submit_job_ext(job_kind, metadata),
+            None => self.gw.submit_job(job_kind),
+        }
+        .map_err(SdkError::backend)?;
 
         // gRPC streams need an InputSender injected after job submission.
         if let Some(ref stream) = maybe_stream {

--- a/sdk/src/remote/prove.rs
+++ b/sdk/src/remote/prove.rs
@@ -44,16 +44,10 @@ impl RemoteClient {
         subs: SubscriberList,
         metadata: BTreeMap<String, String>,
     ) -> Result<JobHandle<ProveResult>> {
-        self.submit_prove(
-            program,
-            stdin,
-            hints,
-            executor,
-            proof_kind,
-            timeout,
-            subs,
-            Some(metadata),
-        )
+        // Empty metadata routes through the standard API so callers that set no
+        // metadata don't hard-require the extended service to be deployed.
+        let metadata = if metadata.is_empty() { None } else { Some(metadata) };
+        self.submit_prove(program, stdin, hints, executor, proof_kind, timeout, subs, metadata)
     }
 
     /// Shared prove submission. `metadata` selects the transport: `Some` routes

--- a/sdk/src/remote/prove.rs
+++ b/sdk/src/remote/prove.rs
@@ -44,10 +44,16 @@ impl RemoteClient {
         subs: SubscriberList,
         metadata: BTreeMap<String, String>,
     ) -> Result<JobHandle<ProveResult>> {
-        // Empty metadata routes through the standard API so callers that set no
-        // metadata don't hard-require the extended service to be deployed.
-        let metadata = if metadata.is_empty() { None } else { Some(metadata) };
-        self.submit_prove(program, stdin, hints, executor, proof_kind, timeout, subs, metadata)
+        self.submit_prove(
+            program,
+            stdin,
+            hints,
+            executor,
+            proof_kind,
+            timeout,
+            subs,
+            Some(metadata),
+        )
     }
 
     /// Shared prove submission. `metadata` selects the transport: `Some` routes
@@ -64,6 +70,7 @@ impl RemoteClient {
         subs: SubscriberList,
         metadata: Option<BTreeMap<String, String>>,
     ) -> Result<JobHandle<ProveResult>> {
+        let metadata = metadata.filter(|m| !m.is_empty());
         let (hints, maybe_hints_stream) = hints_to_input_kind(hints)?;
 
         let hash_id = program.program_id.hash_id.to_string();

--- a/sdk/src/zisk_client.rs
+++ b/sdk/src/zisk_client.rs
@@ -67,6 +67,7 @@ use crate::{
 };
 
 #[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
 enum Inner {
     Embedded(EmbeddedClient),
     Remote(RemoteClient),


### PR DESCRIPTION
Adds an opt-in extended remote path (`RemoteClientExt`, built via `build_ext) that lets callers attach arbitrary key/value job metadata to prove/execute jobs, carried over a new extended coordinator gRPC API (`job_request_ext` / `JobKindExt). Metadata is modeled as a `String→String` map end-to-end, propagated from the coordinator through to workers, and surfaced in job log lines.

Includes hardening: metadata is bounded at ingress (max entries, key and value size → `InvalidArgument`) so a client can't push large blobs behind the 128 MB message limit into storage and per-worker clones, and the metadata log formatter caps its own work by output size. Adds integration coverage for the extended round-trip and makes test-server startup deterministic.
