### PR TITLE
Improve ZisK examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -7710,18 +7710,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -14,7 +14,6 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "test-artifacts",
- "tokio",
  "zisk-sdk",
 ]
 
@@ -76,7 +75,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -106,7 +105,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -123,7 +122,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.118",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
@@ -139,7 +138,7 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
@@ -150,7 +149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -385,7 +384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -395,7 +394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -433,7 +432,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -446,7 +445,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -541,7 +540,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -552,7 +551,7 @@ checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -562,7 +561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -572,7 +571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -582,7 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -592,7 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -648,7 +647,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -660,7 +659,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -671,7 +670,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -698,7 +697,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -802,7 +801,6 @@ name = "big-program-host"
 version = "0.1.0"
 dependencies = [
  "test-artifacts",
- "tokio",
  "zisk-sdk",
 ]
 
@@ -833,7 +831,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -862,21 +860,20 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
 dependencies = [
  "bitcoin-internals",
+ "hex-conservative 1.2.0",
+ "serde",
 ]
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
-dependencies = [
- "hex-conservative 0.3.2",
-]
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
@@ -980,7 +977,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -994,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "serde_core",
@@ -1043,7 +1040,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1078,7 +1075,7 @@ checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
 dependencies = [
  "serde",
  "serde_derive",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
 ]
 
 [[package]]
@@ -1107,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1231,7 +1228,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1542,13 +1539,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "fields",
  "num-bigint",
@@ -1582,7 +1579,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1593,7 +1590,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1681,7 +1678,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1691,7 +1688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1713,7 +1710,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1784,7 +1781,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1822,7 +1819,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1873,7 +1870,7 @@ checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1950,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "exps-codegen"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "anyhow",
  "rayon",
@@ -2037,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2058,7 +2055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2174,7 +2171,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2442,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
@@ -2454,7 +2451,6 @@ name = "hints-host"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "tokio",
  "zisk-sdk",
 ]
 
@@ -2488,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2498,9 +2494,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2760,7 +2756,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2852,7 +2848,7 @@ dependencies = [
  "quote",
  "rustc_version 0.4.1",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2871,7 +2867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3074,7 +3070,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3164,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3218,7 +3214,6 @@ name = "multiple-programs-host"
 version = "0.1.0"
 dependencies = [
  "test-artifacts",
- "tokio",
  "zisk-sdk",
 ]
 
@@ -3239,7 +3234,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3477,7 +3472,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3570,7 +3565,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3629,7 +3624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3644,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "colored",
  "fields",
@@ -3664,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "pil2-stark-setup"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "anyhow",
  "clap",
@@ -3691,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "pilout"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "bytes",
  "prost 0.13.5",
@@ -3716,7 +3711,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3977,7 +3972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4023,7 +4018,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4045,7 +4040,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4060,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "bincode",
  "blake3",
@@ -4094,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "bincode",
  "borsh",
@@ -4125,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "fields",
  "itoa",
@@ -4138,17 +4133,17 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -4157,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "bincode",
  "colored",
@@ -4168,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "bincode",
  "fields",
@@ -4188,7 +4183,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4233,7 +4228,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -4254,7 +4249,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -4268,7 +4263,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4281,7 +4276,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4319,7 +4314,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4444,9 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4455,9 +4450,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4675,7 +4670,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4793,7 +4788,7 @@ checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4854,8 +4849,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.6",
- "rand 0.9.4",
+ "rand 0.8.7",
+ "rand 0.9.5",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -4955,9 +4950,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5132,7 +5127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.4",
+ "rand 0.9.5",
  "secp256k1-sys",
 ]
 
@@ -5232,7 +5227,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5400,15 +5395,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version 0.4.1",
  "simdutf8",
@@ -5544,9 +5539,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5571,7 +5566,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stark-recurser"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "anyhow",
  "fields",
@@ -5647,9 +5642,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5665,7 +5660,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5682,7 +5677,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5746,7 +5741,7 @@ dependencies = [
  "percent-encoding",
  "pest",
  "pest_derive",
- "rand 0.8.6",
+ "rand 0.8.7",
  "regex",
  "serde",
  "serde_json",
@@ -5787,7 +5782,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5798,14 +5793,14 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -5873,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5911,7 +5906,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5967,15 +5962,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6021,14 +6016,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6037,7 +6032,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6048,9 +6043,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -6090,7 +6085,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6115,7 +6110,7 @@ dependencies = [
  "prost-build 0.14.4",
  "prost-types 0.14.4",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -6197,7 +6192,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6366,9 +6361,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6509,7 +6504,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -6683,7 +6678,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6694,7 +6689,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6885,9 +6880,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -6907,7 +6902,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#2f34298194253fee6dd2645c37b9658563e925a6"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "colored",
  "fields",
@@ -6986,7 +6981,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7007,7 +7002,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7027,7 +7022,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7048,7 +7043,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7081,7 +7076,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7211,7 +7206,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7345,7 +7340,7 @@ dependencies = [
  "once_cell",
  "paste",
  "precompiles-helpers",
- "rand 0.8.6",
+ "rand 0.8.7",
  "ripemd",
  "secp256k1",
  "serde",
@@ -7374,7 +7369,7 @@ dependencies = [
  "num-traits",
  "paste",
  "precompiles-helpers",
- "rand 0.8.6",
+ "rand 0.8.7",
  "ripemd",
  "serde",
  "sha2 0.10.9",
@@ -7392,6 +7387,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,5 +29,5 @@ opt-level = 3
 [workspace.dependencies]
 ziskos = { path = "../ziskos/entrypoint" }
 zisk-sdk = { path = "../sdk" }
-test-artifacts = { path = "../test-artifacts" }
+test-artifacts = { path = "../test-artifacts", default-features = false }
 examples-utils = { path = "utils"}

--- a/examples/aggregation/host/Cargo.toml
+++ b/examples/aggregation/host/Cargo.toml
@@ -5,9 +5,8 @@ edition = "2021"
 
 [dependencies]
 zisk-sdk = { workspace = true }
-test-artifacts = { workspace = true }
+test-artifacts = { workspace = true, features = ["fib_mod", "agg_verify"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []

--- a/examples/aggregation/host/src/main.rs
+++ b/examples/aggregation/host/src/main.rs
@@ -10,8 +10,7 @@ struct GuestPublics {
     b: u32,
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting ZisK Prover Client...\n");
 
     let n: u32 = 2000;
@@ -27,13 +26,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = builder.build()?;
 
     println!("Setting up first program (fib_mod)...");
-    client.setup(&ELF_FIB_MOD).run()?.await?;
+    client.setup(&ELF_FIB_MOD).run_sync()?;
 
     println!("Setting up second program (agg_verify)...");
-    client.setup(&ELF_AGG_VERIFY).run()?.await?;
+    client.setup(&ELF_AGG_VERIFY).run_sync()?;
 
     println!("Executing first program...");
-    let result = client.execute(&ELF_FIB_MOD, &stdin).run()?.await?;
+    let result = client.execute(&ELF_FIB_MOD, &stdin).run_sync()?;
 
     println!(
         "Program executed successfully: {} cycles in {} ms",
@@ -60,14 +59,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Publics OK: n={}, module={}, b={}", publics.n, publics.module, publics.b);
 
     println!("Generating first proof for fib_mod...");
-    let vadcop_result1 = client.prove(&ELF_FIB_MOD, stdin).run()?.await?;
+    let vadcop_result1 = client.prove(&ELF_FIB_MOD, stdin).run_sync()?;
 
     let stdin2 = ZiskStdin::new();
     stdin2.write(&n);
     stdin2.write(&module);
 
     println!("Generating second proof for fib_mod...");
-    let vadcop_result2 = client.prove(&ELF_FIB_MOD, stdin2).run()?.await?;
+    let vadcop_result2 = client.prove(&ELF_FIB_MOD, stdin2).run_sync()?;
 
     let stdin_aggregation = ZiskStdin::new();
     stdin_aggregation.write_slice(&vadcop_result1.get_proof_bytes()?);
@@ -76,7 +75,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Running ZisK Emulator on aggregation program for profiling...");
     zisk_sdk::run(&ELF_AGG_VERIFY, stdin_aggregation.clone(), Some(ProfilingMode::Complete))?;
 
-    let result_aggregation = client.prove(&ELF_AGG_VERIFY, stdin_aggregation).run()?.await?;
+    let result_aggregation = client.prove(&ELF_AGG_VERIFY, stdin_aggregation).run_sync()?;
 
     result_aggregation.verify()?;
 

--- a/examples/big-program/host/Cargo.toml
+++ b/examples/big-program/host/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 
 [dependencies]
 zisk-sdk = { workspace = true }
-test-artifacts = { workspace = true }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+test-artifacts = { workspace = true, features = ["big_input"] }
 
 [build-dependencies]
 zisk-sdk = { workspace = true }

--- a/examples/big-program/host/src/main.rs
+++ b/examples/big-program/host/src/main.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 use test_artifacts::ELF_BIG_INPUT;
 use zisk_sdk::{ProverClient, ZiskStdin};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting ZisK Prover Client...");
 
     // Read the input size that was configured during build
@@ -24,9 +23,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let builder = builder.gpu();
     let client = builder.build()?;
 
-    client.setup(&ELF_BIG_INPUT).run()?.await?;
+    client.setup(&ELF_BIG_INPUT).run_sync()?;
 
-    let result = client.execute(&ELF_BIG_INPUT, &stdin).run()?.await?;
+    let result = client.execute(&ELF_BIG_INPUT, &stdin).run_sync()?;
 
     println!(
         "ZisK has executed program with {} cycles in {} ms",
@@ -35,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     println!("Generating proof...");
-    client.prove(&ELF_BIG_INPUT, &stdin).run()?.await?;
+    client.prove(&ELF_BIG_INPUT, &stdin).run_sync()?;
 
     println!("\u{2713} Prove completed successfully!");
 

--- a/examples/hints/host/Cargo.toml
+++ b/examples/hints/host/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 zisk-sdk = { workspace = true }
 anyhow = "1.0"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 zisk-sdk = { workspace = true }

--- a/examples/hints/host/src/main.rs
+++ b/examples/hints/host/src/main.rs
@@ -1,8 +1,7 @@
 use std::error::Error;
 use zisk_sdk::{ExecutorKind, GuestProgram, ProverClient, ZiskHints, ZiskStdin};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting ZisK Prover Client...\n");
 
     let elf_path = "hints/example/zec-reth.elf";
@@ -18,15 +17,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     println!("Setting up program...");
     client.upload(&program).run()?;
-    client.setup(&program).with_hints().run()?.await?;
+    client.setup(&program).with_hints().run_sync()?;
 
     println!("Executing program...");
     let result = client
         .execute(&program, ZiskStdin::new())
         .hints(hints)
         .executor(ExecutorKind::Assembly)
-        .run()?
-        .await?;
+        .run_sync()?;
 
     println!(
         "Program executed successfully: {} cycles in {} ms",

--- a/examples/merkle-tree/guest/Cargo.lock
+++ b/examples/merkle-tree/guest/Cargo.lock
@@ -321,7 +321,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "circuit"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "clang-sys"
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -536,7 +536,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib-c"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "libc"
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "precompiles-helpers"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.0.0-beta#2967211d0a015a49dd7887517e4f1201a89e09db"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "fields",
  "num-traits",
@@ -1247,11 +1247,11 @@ dependencies = [
 
 [[package]]
 name = "zisk-definitions"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "zisk-stream"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "libc",
  "thiserror",
@@ -1260,14 +1260,14 @@ dependencies = [
 
 [[package]]
 name = "zisk-verifier"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "proofman-verifier",
 ]
 
 [[package]]
 name = "ziskos"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "bindgen",
 ]

--- a/examples/multiple-programs/host/Cargo.toml
+++ b/examples/multiple-programs/host/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 
 [dependencies]
 zisk-sdk = { workspace = true }
-test-artifacts = { workspace = true }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+test-artifacts = { workspace = true, features = ["fib_mod"] }
 
 [features]
 default = []

--- a/examples/multiple-programs/host/src/main.rs
+++ b/examples/multiple-programs/host/src/main.rs
@@ -2,8 +2,7 @@ use std::error::Error;
 use test_artifacts::ELF_FIB_MOD;
 use zisk_sdk::{EmbeddedOpts, ProverClient, ZiskStdin};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting ZisK Prover Client...\n");
 
     // Prove the same parameterized fib_mod ELF twice, with different (n, module) inputs.
@@ -20,10 +19,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     println!("Setting up program (single ELF, two invocations)...");
     client.upload(&ELF_FIB_MOD).run()?;
-    client.setup(&ELF_FIB_MOD).run()?.await?;
+    client.setup(&ELF_FIB_MOD).run_sync()?;
 
     println!("Executing first invocation (n=1000, module=233)...");
-    let result = client.execute(&ELF_FIB_MOD, &stdin).run()?.await?;
+    let result = client.execute(&ELF_FIB_MOD, &stdin).run_sync()?;
     println!(
         "Program executed successfully: {} cycles in {} ms",
         result.get_execution_steps(),
@@ -31,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     println!("Generating proof for first invocation...");
-    let vadcop_result = client.prove(&ELF_FIB_MOD, &stdin).run()?.await?;
+    let vadcop_result = client.prove(&ELF_FIB_MOD, &stdin).run_sync()?;
 
     println!("Verifying proof...");
     let vkey = ELF_FIB_MOD.vk()?;
@@ -43,7 +42,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     stdin2.write(&253u32);
 
     println!("Executing second invocation (n=2000, module=253)...");
-    let result2 = client.execute(&ELF_FIB_MOD, &stdin2).run()?.await?;
+    let result2 = client.execute(&ELF_FIB_MOD, &stdin2).run_sync()?;
     println!(
         "Program executed successfully: {} cycles in {} ms",
         result2.get_execution_steps(),
@@ -51,7 +50,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     println!("Generating proof for second invocation...");
-    let vadcop_result2 = client.prove(&ELF_FIB_MOD, &stdin2).run()?.await?;
+    let vadcop_result2 = client.prove(&ELF_FIB_MOD, &stdin2).run_sync()?;
 
     println!("Verifying proof...");
     vadcop_result2.with_program_vk(&vkey).verify()?;

--- a/examples/recurser/hash/guest/Cargo.lock
+++ b/examples/recurser/hash/guest/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "circuit"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "clang-sys"
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Frecurser-1.0.0-beta#1d568538d3087f5c560fd86aadb13d814cd22a9f"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -566,7 +566,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib-c"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "libc"
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "precompiles-helpers"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Frecurser-1.0.0-beta#1d568538d3087f5c560fd86aadb13d814cd22a9f"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "fields",
  "num-traits",
@@ -1275,11 +1275,11 @@ dependencies = [
 
 [[package]]
 name = "zisk-definitions"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "zisk-stream"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "libc",
  "thiserror",
@@ -1288,14 +1288,14 @@ dependencies = [
 
 [[package]]
 name = "zisk-verifier"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "proofman-verifier",
 ]
 
 [[package]]
 name = "ziskos"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "bindgen",
 ]

--- a/examples/recurser/l2/foreign/Cargo.lock
+++ b/examples/recurser/l2/foreign/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "circuit"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "clang-sys"
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Frecurser-1.0.0-beta#1d568538d3087f5c560fd86aadb13d814cd22a9f"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -566,7 +566,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib-c"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "libc"
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "precompiles-helpers"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Frecurser-1.0.0-beta#1d568538d3087f5c560fd86aadb13d814cd22a9f"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "fields",
  "num-traits",
@@ -1267,11 +1267,11 @@ dependencies = [
 
 [[package]]
 name = "zisk-definitions"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "zisk-stream"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "libc",
  "thiserror",
@@ -1280,14 +1280,14 @@ dependencies = [
 
 [[package]]
 name = "zisk-verifier"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "proofman-verifier",
 ]
 
 [[package]]
 name = "ziskos"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "bindgen",
 ]

--- a/examples/recurser/l2/guest/Cargo.lock
+++ b/examples/recurser/l2/guest/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "circuit"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "clang-sys"
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Frecurser-1.0.0-beta#1d568538d3087f5c560fd86aadb13d814cd22a9f"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -566,7 +566,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib-c"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "libc"
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "precompiles-helpers"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Frecurser-1.0.0-beta#1d568538d3087f5c560fd86aadb13d814cd22a9f"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "fields",
  "num-traits",
@@ -1267,11 +1267,11 @@ dependencies = [
 
 [[package]]
 name = "zisk-definitions"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "zisk-stream"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "libc",
  "thiserror",
@@ -1280,14 +1280,14 @@ dependencies = [
 
 [[package]]
 name = "zisk-verifier"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "proofman-verifier",
 ]
 
 [[package]]
 name = "ziskos"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "bindgen",
 ]

--- a/examples/sha-hasher/guest/Cargo.lock
+++ b/examples/sha-hasher/guest/Cargo.lock
@@ -639,7 +639,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "circuit"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "clang-sys"
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Frecurser-1.0.0-beta#72b498f21dfb6a80a2547a83367509d5e8d766dc"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -1257,7 +1257,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib-c"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "libc"
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "precompiles-helpers"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=feature%2Frecurser-1.0.0-beta#72b498f21dfb6a80a2547a83367509d5e8d766dc"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#6e4f39fcba8455ff8256aeade3fcad81460811ef"
 dependencies = [
  "fields",
  "num-traits",
@@ -2485,11 +2485,11 @@ dependencies = [
 
 [[package]]
 name = "zisk-definitions"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 
 [[package]]
 name = "zisk-stream"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "libc",
  "thiserror",
@@ -2498,14 +2498,14 @@ dependencies = [
 
 [[package]]
 name = "zisk-verifier"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "proofman-verifier",
 ]
 
 [[package]]
 name = "ziskos"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "1.0.0-beta"
+version = "1.1.0-alpha"
 dependencies = [
  "bindgen",
 ]

--- a/examples/sha-hasher/host/bin/embedded/execute.rs
+++ b/examples/sha-hasher/host/bin/embedded/execute.rs
@@ -3,8 +3,7 @@ use sha_hasher_host::ELF_SHA_HASHER;
 use std::error::Error;
 use zisk_sdk::{ExecutorKind, ProverClient, ZiskStdin};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting ZisK Prover Client...");
 
     // Create an input stream and write '1000' to it.
@@ -21,19 +20,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = builder.build()?;
 
     println!("Setting up program...");
-    client.setup(&ELF_SHA_HASHER).run()?.await?;
+    client.setup(&ELF_SHA_HASHER).run_sync()?;
     println!("Setup completed successfully");
 
     // Execute the program using the `ProverClient.execute` method, without generating a proof.
     println!("Executing program (no proof generation)...");
     let result =
-        client.execute(&ELF_SHA_HASHER, &stdin).executor(ExecutorKind::Emulator).run()?.await?;
+        client.execute(&ELF_SHA_HASHER, &stdin).executor(ExecutorKind::Emulator).run_sync()?;
     println!("\u{2713} Execution completed successfully!");
     println!("Cycles: {}", result.get_execution_steps());
     println!("Duration: {} ms", result.get_execution_time());
 
     let result =
-        client.execute(&ELF_SHA_HASHER, &stdin).executor(ExecutorKind::Assembly).run()?.await?;
+        client.execute(&ELF_SHA_HASHER, &stdin).executor(ExecutorKind::Assembly).run_sync()?;
 
     println!("\u{2713} Execution completed successfully!");
     println!("Cycles: {}", result.get_execution_steps());

--- a/examples/sha-hasher/host/bin/embedded/minimal.rs
+++ b/examples/sha-hasher/host/bin/embedded/minimal.rs
@@ -2,8 +2,7 @@ use sha_hasher_host::ELF_SHA_HASHER;
 use std::error::Error;
 use zisk_sdk::{ExecutorKind, ProofKind, ProverClient, ZiskStdin};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting ZisK Prover Client (Minimal proof mode)...");
 
     // Create an input stream and write '1000' to it.
@@ -20,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = builder.build()?;
 
     println!("Setting up program...");
-    client.setup(&ELF_SHA_HASHER).run()?.await?;
+    client.setup(&ELF_SHA_HASHER).run_sync()?;
     println!("Setup completed successfully");
 
     println!("Generating minimal proof (this may take a while)...");
@@ -28,8 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .prove(&ELF_SHA_HASHER, stdin)
         .executor(ExecutorKind::Assembly)
         .wrap(ProofKind::VadcopFinalMinimal)
-        .run()?
-        .await?;
+        .run_sync()?;
     println!("Minimal proof generated in {} ms", result.get_proving_time());
 
     println!("Verifying minimal proof...");

--- a/examples/sha-hasher/host/bin/embedded/plonk.rs
+++ b/examples/sha-hasher/host/bin/embedded/plonk.rs
@@ -2,8 +2,7 @@ use sha_hasher_host::ELF_SHA_HASHER;
 use std::error::Error;
 use zisk_sdk::{Proof, ProofKind, ProverClient, ZiskStdin};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting ZisK Prover Client (SNARK mode)...");
 
     // Create an input stream and write '1000' to it.
@@ -20,11 +19,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = builder.build()?;
 
     println!("Setting up program and generating verification key...");
-    client.setup(&ELF_SHA_HASHER).run()?.await?;
+    client.setup(&ELF_SHA_HASHER).run_sync()?;
     println!("Setup completed successfully");
 
     println!("Generating PLONK proof (this may take a while)...");
-    let snark_proof = client.prove(&ELF_SHA_HASHER, stdin).wrap(ProofKind::Plonk).run()?.await?;
+    let snark_proof = client.prove(&ELF_SHA_HASHER, stdin).wrap(ProofKind::Plonk).run_sync()?;
     println!("PLONK proof generated successfully in {} ms", snark_proof.get_proving_time());
     println!("Execution steps: {}", snark_proof.get_execution_steps());
 

--- a/examples/sha-hasher/host/bin/embedded/prove.rs
+++ b/examples/sha-hasher/host/bin/embedded/prove.rs
@@ -4,8 +4,7 @@ use sha_hasher_host::ELF_SHA_HASHER;
 use std::error::Error;
 use zisk_sdk::{ExecutorKind, Proof, ProverClient, PublicValues, ZiskStdin};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting ZisK Prover Client...");
 
     // Create an input stream and write '1000' to it.
@@ -22,11 +21,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = builder.build()?;
 
     println!("Setting up program...");
-    client.setup(&ELF_SHA_HASHER).run()?.await?;
+    client.setup(&ELF_SHA_HASHER).run_sync()?;
     println!("Setup completed successfully");
 
     println!("Generating proof (this may take a while)...");
-    let result = client.prove(&ELF_SHA_HASHER, stdin).run()?.await?;
+    let result = client.prove(&ELF_SHA_HASHER, stdin).run_sync()?;
     println!("Proof generated successfully in {} ms", result.get_proving_time());
     println!("Execution steps: {}", result.get_execution_steps());
 

--- a/test-artifacts/Cargo.toml
+++ b/test-artifacts/Cargo.toml
@@ -21,7 +21,7 @@ default = ["all"]
 
 # Build every guest program (the historical default). Consumers that only need a
 # subset should set `default-features = false` and enable just the programs they
-# use, e.g. `test-artifacts = { workspace = true, features = ["fib_mod"] }`.
+# use, e.g. `test-artifacts = { workspace = true, default-features = false, features = ["fib_mod"] }`.
 all = [
   "add256", "agg_verify", "arith256", "arith256_mod", "arith384_mod",
   "big_input", "bigint", "blake2", "bls12_381", "bls12_381_add",
@@ -76,6 +76,6 @@ secp256r1_dbl = []
 sha256 = []
 uint256 = []
 
-# Guest-compilation flag, orthogonal to program selection: builds guests with the
-# RISC-V bit-manipulation extensions enabled.
+# Guest-compilation flag: enables the RISC-V bit-manipulation extension code paths
+# in the `diagnostic` guest — the only program that defines this feature.
 bit_manipulation_extensions = []

--- a/test-artifacts/Cargo.toml
+++ b/test-artifacts/Cargo.toml
@@ -17,5 +17,65 @@ zisk-sdk = { path = "../sdk" }
 zisk-sdk = { path = "../sdk" }
 
 [features]
-default = []
+default = ["all"]
+
+# Build every guest program (the historical default). Consumers that only need a
+# subset should set `default-features = false` and enable just the programs they
+# use, e.g. `test-artifacts = { workspace = true, features = ["fib_mod"] }`.
+all = [
+  "add256", "agg_verify", "arith256", "arith256_mod", "arith384_mod",
+  "big_input", "bigint", "blake2", "bls12_381", "bls12_381_add",
+  "bls12_381_complex_add", "bls12_381_complex_mul", "bls12_381_complex_sub",
+  "bls12_381_dbl", "bn254", "bn254_add", "bn254_complex_add",
+  "bn254_complex_mul", "bn254_complex_sub", "bn254_dbl", "diagnostic",
+  "diagnostic-hints", "fib_mod", "hashes", "keccak", "liveness",
+  "missing_entrypoint", "panic_modes", "poseidon1", "poseidon2", "secp256k1",
+  "secp256k1_add", "secp256k1_dbl", "secp256r1", "secp256r1_add",
+  "secp256r1_dbl", "sha256", "uint256",
+]
+
+# One feature per guest program. Enabling a feature makes `build.rs` compile that
+# program and exposes its `ELF_*` constant in `lib.rs`; the feature name matches
+# the program's package name under `programs/`.
+add256 = []
+agg_verify = []
+arith256 = []
+arith256_mod = []
+arith384_mod = []
+big_input = []
+bigint = []
+blake2 = []
+bls12_381 = []
+bls12_381_add = []
+bls12_381_complex_add = []
+bls12_381_complex_mul = []
+bls12_381_complex_sub = []
+bls12_381_dbl = []
+bn254 = []
+bn254_add = []
+bn254_complex_add = []
+bn254_complex_mul = []
+bn254_complex_sub = []
+bn254_dbl = []
+diagnostic = []
+diagnostic-hints = []
+fib_mod = []
+hashes = []
+keccak = []
+liveness = []
+missing_entrypoint = []
+panic_modes = []
+poseidon1 = []
+poseidon2 = []
+secp256k1 = []
+secp256k1_add = []
+secp256k1_dbl = []
+secp256r1 = []
+secp256r1_add = []
+secp256r1_dbl = []
+sha256 = []
+uint256 = []
+
+# Guest-compilation flag, orthogonal to program selection: builds guests with the
+# RISC-V bit-manipulation extensions enabled.
 bit_manipulation_extensions = []

--- a/test-artifacts/build.rs
+++ b/test-artifacts/build.rs
@@ -74,20 +74,20 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Restrict the build to specific packages only for a strict subset; with every
-    // program enabled we build the whole workspace with no `--package`. That also
-    // avoids cargo's "package spec is ambiguous" error: some guest names collide
-    // with crates.io deps in `programs/` (e.g. `keccak`, `secp256k1`), so a bare
-    // `--package <name>` would be ambiguous — which also means a colliding-named
-    // guest cannot currently be selected as a strict subset.
+    // Restrict a subset build to the requested guests by binary name (`--bin`),
+    // not by package (`--package`). Some guest names collide with crates.io
+    // dependency package names in `programs/` (e.g. `keccak`, `secp256k1`), which
+    // makes `--package <name>` ambiguous; `--bin <name>` is unambiguous because
+    // only the guest defines a binary of that name. With the default `all` feature
+    // every program is enabled and we build the whole workspace with no target
+    // selection (the historical behavior).
     let subset = enabled.len() < PROGRAMS.len();
 
     // `bit_manipulation_extensions` exists only on the `diagnostic` guest, so
-    // forward it scoped to that package — and only in a subset build that includes
-    // `diagnostic`, so `--package diagnostic` is present and `--features` applies to
-    // a package that defines it. Forwarding it for the full build (no `--package`)
-    // or a subset without `diagnostic` would make Cargo error, so in those cases it
-    // has no effect — enable it via a subset build that includes `diagnostic`.
+    // forward it scoped to that package (`diagnostic/...`) and only in a subset
+    // build that includes `diagnostic` (so `--bin diagnostic` is in the build).
+    // Forwarding it otherwise — the full build, or a subset without `diagnostic` —
+    // would make Cargo error, so it has no effect in those cases.
     let mut features = Vec::new();
     if env::var("CARGO_FEATURE_BIT_MANIPULATION_EXTENSIONS").is_ok()
         && subset
@@ -104,7 +104,7 @@ fn main() -> Result<()> {
     let mut build_args = BuildArgs::default().release(release);
     build_args.features = if features.is_empty() { None } else { Some(features.join(",")) };
     if subset {
-        build_args.packages = enabled;
+        build_args.binaries = enabled;
     }
 
     build_program_with_args(

--- a/test-artifacts/build.rs
+++ b/test-artifacts/build.rs
@@ -87,7 +87,10 @@ fn main() -> Result<()> {
     let release = env::var("PROFILE").map(|p| p == "release").unwrap_or(false);
     let mut build_args = BuildArgs::default().release(release);
     build_args.features = if features.is_empty() { None } else { Some(features.join(",")) };
-    build_args.packages = enabled;
+    // Only restrict the build to specific packages for a strict subset.
+    if enabled.len() < PROGRAMS.len() {
+        build_args.packages = enabled;
+    }
 
     build_program_with_args(
         programs_path

--- a/test-artifacts/build.rs
+++ b/test-artifacts/build.rs
@@ -74,9 +74,20 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Guest-compilation flags, orthogonal to program selection.
+    // Restrict the build to specific packages only for a strict subset; with every
+    // program enabled we build the whole workspace with no `--package`.
+    let subset = enabled.len() < PROGRAMS.len();
+
+    // `bit_manipulation_extensions` exists only on the `diagnostic` guest, so
+    // forward it scoped to that package — and only in a subset build that includes
+    // `diagnostic`, so `--package diagnostic` is present and `--features` applies to
+    // a package that defines it. Forwarding it for the full build (no `--package`)
+    // or a subset without `diagnostic` makes Cargo error.
     let mut features = Vec::new();
-    if env::var("CARGO_FEATURE_BIT_MANIPULATION_EXTENSIONS").is_ok() {
+    if env::var("CARGO_FEATURE_BIT_MANIPULATION_EXTENSIONS").is_ok()
+        && subset
+        && enabled.iter().any(|p| p == "diagnostic")
+    {
         features.push("diagnostic/bit_manipulation_extensions");
     }
 
@@ -87,8 +98,7 @@ fn main() -> Result<()> {
     let release = env::var("PROFILE").map(|p| p == "release").unwrap_or(false);
     let mut build_args = BuildArgs::default().release(release);
     build_args.features = if features.is_empty() { None } else { Some(features.join(",")) };
-    // Only restrict the build to specific packages for a strict subset.
-    if enabled.len() < PROGRAMS.len() {
+    if subset {
         build_args.packages = enabled;
     }
 

--- a/test-artifacts/build.rs
+++ b/test-artifacts/build.rs
@@ -77,7 +77,7 @@ fn main() -> Result<()> {
     // Guest-compilation flags, orthogonal to program selection.
     let mut features = Vec::new();
     if env::var("CARGO_FEATURE_BIT_MANIPULATION_EXTENSIONS").is_ok() {
-        features.push("bit_manipulation_extensions");
+        features.push("diagnostic/bit_manipulation_extensions");
     }
 
     // Build guests with the same profile as the host so profiling/benchmarks

--- a/test-artifacts/build.rs
+++ b/test-artifacts/build.rs
@@ -75,14 +75,19 @@ fn main() -> Result<()> {
     }
 
     // Restrict the build to specific packages only for a strict subset; with every
-    // program enabled we build the whole workspace with no `--package`.
+    // program enabled we build the whole workspace with no `--package`. That also
+    // avoids cargo's "package spec is ambiguous" error: some guest names collide
+    // with crates.io deps in `programs/` (e.g. `keccak`, `secp256k1`), so a bare
+    // `--package <name>` would be ambiguous — which also means a colliding-named
+    // guest cannot currently be selected as a strict subset.
     let subset = enabled.len() < PROGRAMS.len();
 
     // `bit_manipulation_extensions` exists only on the `diagnostic` guest, so
     // forward it scoped to that package — and only in a subset build that includes
     // `diagnostic`, so `--package diagnostic` is present and `--features` applies to
     // a package that defines it. Forwarding it for the full build (no `--package`)
-    // or a subset without `diagnostic` makes Cargo error.
+    // or a subset without `diagnostic` would make Cargo error, so in those cases it
+    // has no effect — enable it via a subset build that includes `diagnostic`.
     let mut features = Vec::new();
     if env::var("CARGO_FEATURE_BIT_MANIPULATION_EXTENSIONS").is_ok()
         && subset

--- a/test-artifacts/build.rs
+++ b/test-artifacts/build.rs
@@ -6,14 +6,76 @@ use std::{
 use std::env;
 use zisk_sdk::{build_program_with_args, BuildArgs};
 
+/// Every guest program under `programs/`, by package name. Each has a matching
+/// Cargo feature (see `Cargo.toml`); enabling the feature builds that program and
+/// exposes its `ELF_*` constant in `lib.rs`. Keep this list in sync with the
+/// `[features]` table and the constants in `src/lib.rs`.
+const PROGRAMS: &[&str] = &[
+    "add256",
+    "agg_verify",
+    "arith256",
+    "arith256_mod",
+    "arith384_mod",
+    "big_input",
+    "bigint",
+    "blake2",
+    "bls12_381",
+    "bls12_381_add",
+    "bls12_381_complex_add",
+    "bls12_381_complex_mul",
+    "bls12_381_complex_sub",
+    "bls12_381_dbl",
+    "bn254",
+    "bn254_add",
+    "bn254_complex_add",
+    "bn254_complex_mul",
+    "bn254_complex_sub",
+    "bn254_dbl",
+    "diagnostic",
+    "diagnostic-hints",
+    "fib_mod",
+    "hashes",
+    "keccak",
+    "liveness",
+    "missing_entrypoint",
+    "panic_modes",
+    "poseidon1",
+    "poseidon2",
+    "secp256k1",
+    "secp256k1_add",
+    "secp256k1_dbl",
+    "secp256r1",
+    "secp256r1_add",
+    "secp256r1_dbl",
+    "sha256",
+    "uint256",
+];
+
+/// Whether the Cargo feature matching `program` (its package name) is enabled.
+/// Cargo exposes `features."foo-bar"` as the env var `CARGO_FEATURE_FOO_BAR`.
+fn feature_enabled(program: &str) -> bool {
+    let var = format!("CARGO_FEATURE_{}", program.to_uppercase().replace('-', "_"));
+    env::var(var).is_ok()
+}
+
 fn main() -> Result<()> {
     let programs_path =
         [env!("CARGO_MANIFEST_DIR"), "programs"].iter().collect::<PathBuf>().canonicalize()?;
 
-    // Collect enabled features from the environment
-    let mut features = Vec::new();
+    // Build only the programs whose feature is enabled. With the default `all`
+    // feature this is every program (the historical behavior); a consumer that
+    // opts into a subset builds only those, skipping the cost of the rest.
+    let enabled: Vec<String> =
+        PROGRAMS.iter().filter(|p| feature_enabled(p)).map(|p| p.to_string()).collect();
 
-    // Check for bit_manipulation_extensions feature
+    // No program selected (e.g. `default-features = false` with no program
+    // feature): nothing to build, and `lib.rs` exposes no constants.
+    if enabled.is_empty() {
+        return Ok(());
+    }
+
+    // Guest-compilation flags, orthogonal to program selection.
+    let mut features = Vec::new();
     if env::var("CARGO_FEATURE_BIT_MANIPULATION_EXTENSIONS").is_ok() {
         features.push("bit_manipulation_extensions");
     }
@@ -25,6 +87,7 @@ fn main() -> Result<()> {
     let release = env::var("PROFILE").map(|p| p == "release").unwrap_or(false);
     let mut build_args = BuildArgs::default().release(release);
     build_args.features = if features.is_empty() { None } else { Some(features.join(",")) };
+    build_args.packages = enabled;
 
     build_program_with_args(
         programs_path

--- a/test-artifacts/src/lib.rs
+++ b/test-artifacts/src/lib.rs
@@ -16,6 +16,7 @@
 //! and to `PROGRAMS` in `build.rs`) and expose its ELF via a feature-gated
 //! `load_program!` constant below.
 
+#[allow(unused_imports)]
 use zisk_sdk::{load_program, GuestProgram};
 
 #[cfg(feature = "add256")]

--- a/test-artifacts/src/lib.rs
+++ b/test-artifacts/src/lib.rs
@@ -1,46 +1,96 @@
-//! Compiles every program under `programs/` into an ELF and re-exports each one
+//! Compiles the guest programs under `programs/` into ELFs and re-exports each one
 //! as a constant for use by other crates in the workspace.
 //!
-//! **Adding a new program:** register it as a member of the `programs/` workspace
-//! so it gets built, then expose its ELF via a `load_program!` constant below.
+//! **Feature-gated:** each program has a Cargo feature named after its package
+//! (all enabled by default via the `all` feature). A consumer that only needs a
+//! subset can set `default-features = false` and enable just the programs it uses
+//! — `build.rs` then compiles only those guests and only their constants below
+//! are defined:
+//!
+//! ```toml
+//! test-artifacts = { workspace = true, default-features = false, features = ["fib_mod"] }
+//! ```
+//!
+//! **Adding a new program:** register it as a member of the `programs/` workspace,
+//! then add a matching feature (to `[features]` and the `all` list in `Cargo.toml`
+//! and to `PROGRAMS` in `build.rs`) and expose its ELF via a feature-gated
+//! `load_program!` constant below.
 
 use zisk_sdk::{load_program, GuestProgram};
 
+#[cfg(feature = "add256")]
 pub const ELF_ADD256: GuestProgram = load_program!("add256");
+#[cfg(feature = "agg_verify")]
 pub const ELF_AGG_VERIFY: GuestProgram = load_program!("agg_verify");
+#[cfg(feature = "arith256")]
 pub const ELF_ARITH256: GuestProgram = load_program!("arith256");
+#[cfg(feature = "arith256_mod")]
 pub const ELF_ARITH256_MOD: GuestProgram = load_program!("arith256_mod");
+#[cfg(feature = "arith384_mod")]
 pub const ELF_ARITH384_MOD: GuestProgram = load_program!("arith384_mod");
+#[cfg(feature = "big_input")]
 pub const ELF_BIG_INPUT: GuestProgram = load_program!("big_input");
+#[cfg(feature = "blake2")]
 pub const ELF_BLAKE2: GuestProgram = load_program!("blake2");
+#[cfg(feature = "bls12_381")]
 pub const ELF_BLS12_381: GuestProgram = load_program!("bls12_381");
+#[cfg(feature = "bls12_381_add")]
 pub const ELF_BLS12_381_ADD: GuestProgram = load_program!("bls12_381_add");
+#[cfg(feature = "bls12_381_complex_add")]
 pub const ELF_BLS12_381_COMPLEX_ADD: GuestProgram = load_program!("bls12_381_complex_add");
+#[cfg(feature = "bls12_381_complex_mul")]
 pub const ELF_BLS12_381_COMPLEX_MUL: GuestProgram = load_program!("bls12_381_complex_mul");
+#[cfg(feature = "bls12_381_complex_sub")]
 pub const ELF_BLS12_381_COMPLEX_SUB: GuestProgram = load_program!("bls12_381_complex_sub");
+#[cfg(feature = "bls12_381_dbl")]
 pub const ELF_BLS12_381_DBL: GuestProgram = load_program!("bls12_381_dbl");
+#[cfg(feature = "bn254")]
 pub const ELF_BN254: GuestProgram = load_program!("bn254");
+#[cfg(feature = "bn254_add")]
 pub const ELF_BN254_ADD: GuestProgram = load_program!("bn254_add");
+#[cfg(feature = "bn254_complex_add")]
 pub const ELF_BN254_COMPLEX_ADD: GuestProgram = load_program!("bn254_complex_add");
+#[cfg(feature = "bn254_complex_mul")]
 pub const ELF_BN254_COMPLEX_MUL: GuestProgram = load_program!("bn254_complex_mul");
+#[cfg(feature = "bn254_complex_sub")]
 pub const ELF_BN254_COMPLEX_SUB: GuestProgram = load_program!("bn254_complex_sub");
+#[cfg(feature = "bn254_dbl")]
 pub const ELF_BN254_DBL: GuestProgram = load_program!("bn254_dbl");
+#[cfg(feature = "diagnostic")]
 pub const ELF_DIAGNOSTIC: GuestProgram = load_program!("diagnostic");
+#[cfg(feature = "diagnostic-hints")]
 pub const ELF_DIAGNOSTIC_HINTS: GuestProgram = load_program!("diagnostic-hints");
+#[cfg(feature = "fib_mod")]
 pub const ELF_FIB_MOD: GuestProgram = load_program!("fib_mod");
+#[cfg(feature = "hashes")]
 pub const ELF_HASHES: GuestProgram = load_program!("hashes");
+#[cfg(feature = "keccak")]
 pub const ELF_KECCAK: GuestProgram = load_program!("keccak");
+#[cfg(feature = "liveness")]
 pub const ELF_LIVENESS: GuestProgram = load_program!("liveness");
+#[cfg(feature = "missing_entrypoint")]
 pub const ELF_MISSING_ENTRYPOINT: GuestProgram = load_program!("missing_entrypoint");
+#[cfg(feature = "bigint")]
 pub const ELF_BIGINT: GuestProgram = load_program!("bigint");
+#[cfg(feature = "panic_modes")]
 pub const ELF_PANIC_MODES: GuestProgram = load_program!("panic_modes");
+#[cfg(feature = "poseidon1")]
 pub const ELF_POSEIDON1: GuestProgram = load_program!("poseidon1");
+#[cfg(feature = "poseidon2")]
 pub const ELF_POSEIDON2: GuestProgram = load_program!("poseidon2");
+#[cfg(feature = "secp256k1")]
 pub const ELF_SECP256K1: GuestProgram = load_program!("secp256k1");
+#[cfg(feature = "secp256k1_add")]
 pub const ELF_SECP256K1_ADD: GuestProgram = load_program!("secp256k1_add");
+#[cfg(feature = "secp256k1_dbl")]
 pub const ELF_SECP256K1_DBL: GuestProgram = load_program!("secp256k1_dbl");
+#[cfg(feature = "secp256r1")]
 pub const ELF_SECP256R1: GuestProgram = load_program!("secp256r1");
+#[cfg(feature = "secp256r1_add")]
 pub const ELF_SECP256R1_ADD: GuestProgram = load_program!("secp256r1_add");
+#[cfg(feature = "secp256r1_dbl")]
 pub const ELF_SECP256R1_DBL: GuestProgram = load_program!("secp256r1_dbl");
+#[cfg(feature = "sha256")]
 pub const ELF_SHA256: GuestProgram = load_program!("sha256");
+#[cfg(feature = "uint256")]
 pub const ELF_UINT256: GuestProgram = load_program!("uint256");


### PR DESCRIPTION
## Improve ZisK examples

Makes the example programs cheaper to build.

### 1. Feature-gate `test-artifacts` guest ELFs
Each guest program now has its own Cargo feature, all enabled by default via a new `all` feature — so existing test/bench consumers are unaffected. Consumers that only need a subset can opt in explicitly:

```toml
test-artifacts = { workspace = true, default-features = false, features = ["fib_mod"] }
```

`build.rs` then compiles only the enabled guest packages instead of always building the full (crypto-heavy) guest set, and `lib.rs` exposes only the matching `ELF_*` constants. Building an example that uses one or two guests no longer compiles all of them.

### 2. Examples request only the guests they use
* `aggregation` → `fib_mod, agg_verify`
* `big-program` → `big_input`
* `multiple-programs` → `fib_mod`
The examples-workspace dependency sets `default-features = false` so the selection takes effect.

### 3. Embedded-only hosts drop the async runtime
Examples that only use the embedded prover no longer depend on `tokio: #[tokio::main]` + `.run()?.await?` become a plain `fn main()` + `.run_sync()?`.
Applies to `hints`, `big-program`, `multiple-programs`, and the `sha-hasher` embedded bins. Examples that genuinely need async are left unchanged — `recurser` (uses `aggregate_proofs`), `primes` streaming, and all remote-prover paths (`sha-hasher` remote bins, `gcd`).

### Compatibility
`default = ["all"]` preserves the historical "build everything" behavior, so the main workspace's tests and benchmarks are unaffected. Guest programs whose names collide with a crates.io crate (e.g. `keccak`) are handled by building the whole workspace when every program is enabled, rather than selecting by name.