### PR TITLE
add cargo on toolchain

### DIFF
--- a/cli/src/commands/user/toolchain/build.rs
+++ b/cli/src/commands/user/toolchain/build.rs
@@ -172,6 +172,27 @@ impl ZiskBuildToolchain {
             .with_context(|| "while linking the toolchain to rustup")?;
         println!("Successfully linked the toolchain to rustup.");
 
+        // ZISK: `stage2/bin` has `rustc` but not `cargo` (cargo is built into the
+        // sibling `stage2-tools-bin/`). Copy it into the toolchain's `bin/` so the
+        // packaged tarball is self-contained: `cargo +<toolchain>` then uses this
+        // (version-matched) cargo directly instead of falling back to rustup's
+        // `nightly` toolchain.
+        if let Some(build_root) = toolchain_dir.parent() {
+            let cargo_src = build_root.join("stage2-tools-bin").join("cargo");
+            let cargo_dst = toolchain_dir.join("bin").join("cargo");
+            if cargo_src.is_file() && !cargo_dst.exists() {
+                std::fs::copy(&cargo_src, &cargo_dst).with_context(|| {
+                    format!("while copying cargo from {} into the toolchain", cargo_src.display())
+                })?;
+                println!("Copied cargo into the toolchain bin: {}", cargo_dst.display());
+            } else if !cargo_src.is_file() {
+                eprintln!(
+                    "Warning: {} not found; the packaged toolchain will lack cargo.",
+                    cargo_src.display()
+                );
+            }
+        }
+
         // Compressing toolchain directory to tar.gz.
         let target = get_target();
         let tar_gz_path = format!("rust-toolchain-{target}.tar.gz");


### PR DESCRIPTION
# fix(toolchain): ship `cargo` inside the built toolchain (self-contained)

## Summary
`cargo-zisk toolchain build` packages the compiled Rust toolchain (`stage2`) into `rust-toolchain-<target>.tar.gz`, but `stage2/bin` contains only `rustc`. `cargo` is built into the sibling `stage2-tools-bin/` and was never copied in, so the
resulting toolchain — and every `ziskup` / `cargo-zisk toolchain install` of the published tarball — is **rustc-only**.

## Problem
`cargo-zisk build` runs `cargo +<toolchain> build`. When the ZisK toolchain has no `cargo`, rustup falls back to the **`nightly`** toolchain's cargo (rustup's default behaviour for a linked/custom toolchain that is missing a component). Builds then silently depend on a working `nightly` install; if `nightly` is absent orincomplete the build fails with:

```
info: `cargo` is unavailable for the active toolchain
info: falling back to ".../nightly-x86_64-unknown-linux-gnu/bin/cargo"
error: command failed: 'cargo': No such file or directory (os error 2)
```

## Fix
In `cli/src/commands/user/toolchain/build.rs`, just before compressing the toolchain to the tarball, copy the freshly built `cargo` from `stage2-tools-bin/` into the toolchain's `bin/`:

```rust
// stage2/bin has rustc but not cargo (cargo is built into the sibling
// stage2-tools-bin/). Copy it in so the packaged toolchain is self-contained:
// `cargo +<toolchain>` then uses this (version-matched) cargo directly instead
// of falling back to rustup's `nightly` toolchain.
if let Some(build_root) = toolchain_dir.parent() {
    let cargo_src = build_root.join("stage2-tools-bin").join("cargo");
    let cargo_dst = toolchain_dir.join("bin").join("cargo");
    if cargo_src.is_file() && !cargo_dst.exists() {
        std::fs::copy(&cargo_src, &cargo_dst)?;
    }
}
```

The copied `cargo` is **version-matched** (built from the same Rust source as `rustc`). The step is a no-op if `cargo` is already present, and warns if the source `cargo` cannot be found.

## Effect
- New tarballs produced by `toolchain build` — including the release CI, which  runs `cargo-zisk toolchain build` — now include `cargo`.
- `cargo-zisk build` works out of the box, with **no dependency on a `nightly`  toolchain**.

## Notes
- Only affects newly built toolchains; tarballs published before this change stay  rustc-only until re-released.
- Adds the `cargo` binary (~tens of MB) to the tarball — expected for a complete,  self-contained toolchain.

## Testing
- `cargo build --release --bin cargo-zisk` compiles cleanly.
- After `cargo-zisk toolchain build`, `<toolchain>/bin/cargo` exists and  `cargo +<toolchain> build` no longer falls back to `nightly`.