### PR TITLE
common: improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1305,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1742,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "curves"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "fields",
  "num-bigint",
@@ -2214,7 +2214,7 @@ dependencies = [
 [[package]]
 name = "exps-codegen"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "anyhow",
  "rayon",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "fields"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2819,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3027,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "pil-std-lib"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "colored",
  "fields",
@@ -4105,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "pil2-stark-setup"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "anyhow",
  "clap",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "pilout"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "bytes",
  "prost 0.13.5",
@@ -4543,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "proofman"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "bincode",
  "blake3",
@@ -4577,7 +4577,7 @@ dependencies = [
 [[package]]
 name = "proofman-common"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "bincode",
  "borsh",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "proofman-hints"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "fields",
  "itoa",
@@ -4621,7 +4621,7 @@ dependencies = [
 [[package]]
 name = "proofman-macros"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "proofman-starks-lib-c"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -4640,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "proofman-util"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "bincode",
  "colored",
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "proofman-verifier"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "bincode",
  "fields",
@@ -6117,7 +6117,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stark-recurser"
 version = "0.1.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "anyhow",
  "fields",
@@ -6492,9 +6492,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -7614,7 +7614,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "witness"
 version = "1.0.0-beta"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#8ae501a8c17c5e3e9d41c33560fc2fa5b3fd2f30"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-1.1.0-alpha#d8aa197214ccdb4e7b7cd1e35605733bdabce2ad"
 dependencies = [
  "colored",
  "fields",
@@ -7710,18 +7710,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/common/src/bus/data_bus_operation.rs
+++ b/common/src/bus/data_bus_operation.rs
@@ -2,7 +2,7 @@
 //! data for communication over the operation bus. This includes data extraction from instructions
 //! and managing the format of operation data.
 
-use crate::{uninit_array, BusId, PayloadType};
+use crate::{BusId, PayloadType};
 use std::collections::VecDeque;
 use zisk_core::zisk_ops::ZiskOp;
 use zisk_core::{InstContext, ZiskInst, ZiskOperationType};
@@ -467,8 +467,7 @@ impl OperationBusData<u64> {
 
         match inst.op_type {
             ZiskOperationType::Keccak => {
-                let mut data =
-                    unsafe { uninit_array::<OPERATION_BUS_KECCAKF_DATA_SIZE>().assume_init() };
+                let mut data = [0u64; OPERATION_BUS_KECCAKF_DATA_SIZE];
                 data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                     .copy_from_slice(&[op, op_type, a, b, step]);
                 data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -477,8 +476,7 @@ impl OperationBusData<u64> {
             }
 
             ZiskOperationType::Sha256 => {
-                let mut data =
-                    unsafe { uninit_array::<OPERATION_BUS_SHA256F_DATA_SIZE>().assume_init() };
+                let mut data = [0u64; OPERATION_BUS_SHA256F_DATA_SIZE];
                 data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                     .copy_from_slice(&[op, op_type, a, b, step]);
                 data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -487,8 +485,7 @@ impl OperationBusData<u64> {
             }
 
             ZiskOperationType::Poseidon => {
-                let mut data =
-                    unsafe { uninit_array::<OPERATION_BUS_POSEIDON_DATA_SIZE>().assume_init() };
+                let mut data = [0u64; OPERATION_BUS_POSEIDON_DATA_SIZE];
                 data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                     .copy_from_slice(&[op, op_type, a, b, step]);
                 data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -497,8 +494,7 @@ impl OperationBusData<u64> {
             }
 
             ZiskOperationType::Blake2 => {
-                let mut data =
-                    unsafe { uninit_array::<OPERATION_BUS_BLAKE2_DATA_SIZE>().assume_init() };
+                let mut data = [0u64; OPERATION_BUS_BLAKE2_DATA_SIZE];
                 data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                     .copy_from_slice(&[op, op_type, a, b, step]);
                 data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -508,9 +504,7 @@ impl OperationBusData<u64> {
 
             ZiskOperationType::ArithEq => match inst.op {
                 ZiskOp::ARITH256 => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_ARITH_256_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_ARITH_256_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -518,9 +512,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationArith256Data(data)
                 }
                 ZiskOp::ARITH256_MOD => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_ARITH_256_MOD_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_ARITH_256_MOD_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -528,9 +520,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationArith256ModData(data)
                 }
                 ZiskOp::SECP256K1_ADD => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_SECP256K1_ADD_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_SECP256K1_ADD_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -538,9 +528,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationSecp256k1AddData(data)
                 }
                 ZiskOp::SECP256K1_DBL => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_SECP256K1_DBL_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_SECP256K1_DBL_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -548,9 +536,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationSecp256k1DblData(data)
                 }
                 ZiskOp::BN254_CURVE_ADD => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BN254_CURVE_ADD_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BN254_CURVE_ADD_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -558,9 +544,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationBn254CurveAddData(data)
                 }
                 ZiskOp::BN254_CURVE_DBL => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BN254_CURVE_DBL_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BN254_CURVE_DBL_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -568,9 +552,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationBn254CurveDblData(data)
                 }
                 ZiskOp::BN254_COMPLEX_ADD => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BN254_COMPLEX_ADD_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BN254_COMPLEX_ADD_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -578,9 +560,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationBn254ComplexAddData(data)
                 }
                 ZiskOp::BN254_COMPLEX_SUB => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BN254_COMPLEX_SUB_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BN254_COMPLEX_SUB_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -588,9 +568,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationBn254ComplexSubData(data)
                 }
                 ZiskOp::BN254_COMPLEX_MUL => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BN254_COMPLEX_MUL_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BN254_COMPLEX_MUL_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -598,9 +576,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationBn254ComplexMulData(data)
                 }
                 ZiskOp::SECP256R1_ADD => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_SECP256R1_ADD_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_SECP256R1_ADD_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -608,9 +584,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationSecp256r1AddData(data)
                 }
                 ZiskOp::SECP256R1_DBL => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_SECP256R1_DBL_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_SECP256R1_DBL_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -622,9 +596,7 @@ impl OperationBusData<u64> {
 
             ZiskOperationType::ArithEq384 => match inst.op {
                 ZiskOp::ARITH384_MOD => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_ARITH_384_MOD_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_ARITH_384_MOD_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -632,9 +604,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationArith384ModData(data)
                 }
                 ZiskOp::BLS12_381_CURVE_ADD => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BLS12_381_CURVE_ADD_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BLS12_381_CURVE_ADD_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -642,9 +612,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationBls12_381CurveAddData(data)
                 }
                 ZiskOp::BLS12_381_CURVE_DBL => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BLS12_381_CURVE_DBL_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BLS12_381_CURVE_DBL_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -652,10 +620,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationBls12_381CurveDblData(data)
                 }
                 ZiskOp::BLS12_381_COMPLEX_ADD => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BLS12_381_COMPLEX_ADD_DATA_SIZE>()
-                            .assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BLS12_381_COMPLEX_ADD_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -663,10 +628,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationBls12_381ComplexAddData(data)
                 }
                 ZiskOp::BLS12_381_COMPLEX_SUB => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BLS12_381_COMPLEX_SUB_DATA_SIZE>()
-                            .assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BLS12_381_COMPLEX_SUB_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -674,10 +636,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationBls12_381ComplexSubData(data)
                 }
                 ZiskOp::BLS12_381_COMPLEX_MUL => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_BLS12_381_COMPLEX_MUL_DATA_SIZE>()
-                            .assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_BLS12_381_COMPLEX_MUL_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -689,8 +648,7 @@ impl OperationBusData<u64> {
 
             ZiskOperationType::BigInt => match inst.op {
                 ZiskOp::ADD256 => {
-                    let mut data =
-                        unsafe { uninit_array::<OPERATION_BUS_ADD_256_DATA_SIZE>().assume_init() };
+                    let mut data = [0u64; OPERATION_BUS_ADD_256_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -702,9 +660,7 @@ impl OperationBusData<u64> {
 
             ZiskOperationType::Dma => match inst.op {
                 ZiskOp::DMA_MEMCPY => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_DMA_MEMCPY_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_DMA_MEMCPY_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -712,9 +668,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationDmaMemCpyData(data)
                 }
                 ZiskOp::DMA_MEMCMP => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_DMA_MEMCMP_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_DMA_MEMCMP_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -722,9 +676,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationDmaMemCmpData(data)
                 }
                 ZiskOp::DMA_INPUTCPY => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_DMA_INPUTCPY_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_DMA_INPUTCPY_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -732,9 +684,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationDmaInputCpyData(data)
                 }
                 ZiskOp::DMA_XMEMSET => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_DMA_XMEMSET_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_DMA_XMEMSET_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -742,9 +692,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationDmaXMemSetData(data)
                 }
                 ZiskOp::DMA_XMEMCPY => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_DMA_XMEMCPY_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_DMA_XMEMCPY_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]
@@ -752,9 +700,7 @@ impl OperationBusData<u64> {
                     ExtOperationData::OperationDmaXMemCpyData(data)
                 }
                 ZiskOp::DMA_XMEMCMP => {
-                    let mut data = unsafe {
-                        uninit_array::<OPERATION_BUS_DMA_XMEMCMP_DATA_SIZE>().assume_init()
-                    };
+                    let mut data = [0u64; OPERATION_BUS_DMA_XMEMCMP_DATA_SIZE];
                     data[0..OPERATION_PRECOMPILED_BUS_DATA_SIZE]
                         .copy_from_slice(&[op, op_type, a, b, step]);
                     data[OPERATION_PRECOMPILED_BUS_DATA_SIZE..]

--- a/common/src/component/component_instance.rs
+++ b/common/src/component/component_instance.rs
@@ -31,6 +31,11 @@ pub trait Instance<F: PrimeField64>: Any + Send + Sync {
     ///
     /// # Returns
     /// An optional `AirInstance` object representing the computed witness.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the witness computation fails. Implementations that do
+    /// no fallible work return `Ok`.
     fn compute_witness(
         &self,
         _pctx: &ProofCtx<F>,

--- a/common/src/component/component_planner.rs
+++ b/common/src/component/component_planner.rs
@@ -351,7 +351,14 @@ impl Plan {
     }
 }
 
+// SAFETY: The only field that prevents auto-derivation of `Send`/`Sync` is
+// `meta: Option<Box<dyn Any>>`, whose type erasure drops the auto-trait bounds.
+// In practice `meta` only ever holds `Send + Sync` payloads (plain collections of
+// plain data, e.g. `HashMap<ChunkId, (u64, CollectSkipper)>`), and a `Plan` is
+// owned by a single thread at a time rather than mutated through shared aliases.
 unsafe impl Send for Plan {}
+// SAFETY: See the `Send` impl above — `meta` only holds `Send + Sync` payloads and
+// `Plan` is never mutated through shared cross-thread aliases.
 unsafe impl Sync for Plan {}
 
 /// The `Planner` trait defines the interface for creating execution plans.

--- a/common/src/component/component_planner.rs
+++ b/common/src/component/component_planner.rs
@@ -311,7 +311,12 @@ pub struct Plan {
     pub check_point: CheckPoint,
 
     /// Additional metadata associated with the plan.
-    pub meta: Option<Box<dyn Any>>,
+    ///
+    /// Bounded to `Send + Sync` so that `Plan` (and everything that embeds it, e.g.
+    /// [`InstanceCtx`](crate::InstanceCtx)) auto-derives `Send`/`Sync` instead of
+    /// relying on a hand-written `unsafe impl` whose invariant the type system could
+    /// not enforce.
+    pub meta: Option<Box<dyn Any + Send + Sync>>,
 
     /// The global instance ID associated with this plan.
     pub global_id: Option<usize>,
@@ -337,7 +342,7 @@ impl Plan {
         segment_id: Option<SegmentId>,
         instance_type: InstanceType,
         check_point: CheckPoint,
-        meta: Option<Box<dyn Any>>,
+        meta: Option<Box<dyn Any + Send + Sync>>,
     ) -> Self {
         Plan { airgroup_id, air_id, segment_id, instance_type, check_point, meta, global_id: None }
     }
@@ -350,16 +355,6 @@ impl Plan {
         self.global_id = Some(global_id);
     }
 }
-
-// SAFETY: The only field that prevents auto-derivation of `Send`/`Sync` is
-// `meta: Option<Box<dyn Any>>`, whose type erasure drops the auto-trait bounds.
-// In practice `meta` only ever holds `Send + Sync` payloads (plain collections of
-// plain data, e.g. `HashMap<ChunkId, (u64, CollectSkipper)>`), and a `Plan` is
-// owned by a single thread at a time rather than mutated through shared aliases.
-unsafe impl Send for Plan {}
-// SAFETY: See the `Send` impl above — `meta` only holds `Send + Sync` payloads and
-// `Plan` is never mutated through shared cross-thread aliases.
-unsafe impl Sync for Plan {}
 
 /// The `Planner` trait defines the interface for creating execution plans.
 ///

--- a/common/src/component/component_planner.rs
+++ b/common/src/component/component_planner.rs
@@ -331,7 +331,6 @@ impl Plan {
     /// * `segment_id` - The segment ID (if any).
     /// * `instance_type` - The type of instance.
     /// * `check_point` - The checkpoint type.
-    /// * `collect_info` - Optional input collection information.
     /// * `meta` - Optional additional metadata.
     ///
     /// # Returns

--- a/common/src/hints.rs
+++ b/common/src/hints.rs
@@ -444,6 +444,11 @@ impl PrecompileHint {
     /// * `PrecompileHintParseResult::Complete` - Successfully parsed a complete hint
     /// * `PrecompileHintParseResult::Partial` - Parsed header but slice doesn't contain all data
     /// * `Err` - If the slice is empty, index is out of bounds or hint code is invalid
+    ///
+    /// # Errors
+    ///
+    /// - [`CommonError::OutOfBounds`] if the slice is empty or the index is out of bounds.
+    /// - [`CommonError::InvalidHint`] if the hint code is unrecognized and `allow_custom` is `false`.
     #[inline(always)]
     pub fn from_u64_slice(
         slice: &[u64],

--- a/common/src/hints.rs
+++ b/common/src/hints.rs
@@ -458,7 +458,7 @@ impl PrecompileHint {
     ) -> Result<(PrecompileHintParseResult, usize)> {
         // If we have a partial hint, continue accumulating from it
         if let Some(partial_hint) = partial {
-            let available = slice.len() - idx;
+            let available = slice.len().checked_sub(idx).ok_or(CommonError::OutOfBounds)?;
 
             if available >= partial_hint.remaining_u64s {
                 // We have enough data to complete the hint

--- a/common/src/instance_context.rs
+++ b/common/src/instance_context.rs
@@ -31,8 +31,3 @@ impl InstanceCtx {
         Self { plan, global_id }
     }
 }
-
-// SAFETY: Both fields are safe to transfer across threads: `global_id: usize` is
-// `Send`, and `plan: Plan` carries its own documented `Send` impl. No interior
-// state is shared through aliases, so moving an `InstanceCtx` between threads is sound.
-unsafe impl Send for InstanceCtx {}

--- a/common/src/instance_context.rs
+++ b/common/src/instance_context.rs
@@ -32,7 +32,7 @@ impl InstanceCtx {
     }
 }
 
-/// # Safety
-/// This struct is marked as `Send` because its fields are safe to transfer across threads,
-/// assuming that the `Plan` type and its associated data are also thread-safe.
+// SAFETY: Both fields are safe to transfer across threads: `global_id: usize` is
+// `Send`, and `plan: Plan` carries its own documented `Send` impl. No interior
+// state is shared through aliases, so moving an `InstanceCtx` between threads is sound.
 unsafe impl Send for InstanceCtx {}

--- a/common/src/io/stdin/zisk_stdin.rs
+++ b/common/src/io/stdin/zisk_stdin.rs
@@ -39,6 +39,10 @@ impl ZiskStdin {
     }
 
     /// Creates a `ZiskStdin` instance by reading data from a file at the specified path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::Io`] if the file cannot be read.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let data = std::fs::read(path.as_ref()).map_err(|e| {
             CommonError::Io(format!("Failed to read input file {:?}: {}", path.as_ref(), e))
@@ -51,6 +55,12 @@ impl ZiskStdin {
     /// - `"file://path"` → read from file
     /// - `"inline://[[1,2],[3]]"` → inline input, a JSON array of u64 arrays
     /// - No scheme → treated as a file path
+    ///
+    /// # Errors
+    ///
+    /// - [`CommonError::UnknownScheme`] if the URI carries an unrecognized scheme.
+    /// - Any error from [`from_file`](Self::from_file) or [`from_inline`](Self::from_inline)
+    ///   when reading the referenced input.
     pub fn from_uri<S: Into<String>>(stdin_uri: Option<S>) -> Result<ZiskStdin> {
         let Some(uri) = stdin_uri else { return Ok(ZiskStdin::new()) };
         let uri = uri.into();
@@ -74,6 +84,10 @@ impl ZiskStdin {
     /// 8-byte little-endian length prefix and is padded to an 8-byte boundary.
     ///
     /// Example: `"[[1,2],[3],[4,5,6]]"` produces three frames.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::Invalid`] if the input is not a valid JSON array of u64 arrays.
     pub fn from_inline(json: &str) -> Result<ZiskStdin> {
         let frames: Vec<Vec<u64>> = serde_json::from_str(json).map_err(|e| {
             CommonError::Invalid(format!(
@@ -92,16 +106,30 @@ impl ZiskStdin {
     }
 
     /// Read the raw byte data from the `ZiskStdin` buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
     pub fn read_data(&self) -> Vec<u8> {
         self.inner.data.lock().unwrap().clone()
     }
 
     /// Read the next frame of data from the `ZiskStdin` buffer as a vector of bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned or if reading the next frame fails.
     pub fn read_bytes(&self) -> Vec<u8> {
         self.read_raw().expect("Failed to read from stdin buffer")
     }
 
-    /// Read the next frame of data from the `ZiskStdin` buffer and deserialize it into a value of type `T`.
+    /// Reads the next frame of data from the [`ZiskStdin`] buffer and deserializes
+    /// it into a value of type `T`.
+    ///
+    /// # Errors
+    ///
+    /// - [`CommonError::Io`] if reading from the buffer fails.
+    /// - [`CommonError::Deserialization`] if deserialization fails.
     pub fn read<T: DeserializeOwned>(&self) -> Result<T> {
         let data = self
             .read_raw()
@@ -112,6 +140,10 @@ impl ZiskStdin {
     }
 
     /// Write a serializable value of type `T` to the `ZiskStdin` buffer as a new frame.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data` cannot be serialized, or if the internal mutex is poisoned.
     pub fn write<T: Serialize>(&self, data: &T) {
         let bytes = bincode::serde::encode_to_vec(data, bincode::config::standard())
             .expect("Failed to serialize");
@@ -119,6 +151,10 @@ impl ZiskStdin {
     }
 
     /// Write a raw slice of bytes to the `ZiskStdin` buffer as a new frame, prefixed with its length and padded to an 8-byte boundary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
     pub fn write_slice(&self, data: &[u8]) {
         let data_len = data.len();
         let total_len = 8 + data_len;
@@ -141,6 +177,14 @@ impl ZiskStdin {
     }
 
     /// Save the `ZiskStdin` buffer to a file at the specified path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::Io`] if the parent directory cannot be created or the file cannot be written.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
     pub fn save(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
@@ -157,6 +201,10 @@ impl ZiskStdin {
     }
 
     /// Reset the read cursor to the beginning.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
     pub fn rewind(&self) {
         self.inner.cursor.lock().unwrap().set_position(0);
     }
@@ -167,6 +215,10 @@ impl ZiskStdin {
     }
 
     /// Clear the `ZiskStdin` buffer and reset the cursor.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
     pub fn clear(&self) {
         self.inner.data.lock().unwrap().clear();
         let mut cursor = self.inner.cursor.lock().unwrap();

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -3,6 +3,8 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::all)]
 #![deny(rustdoc::missing_crate_level_docs)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+#![warn(clippy::unnecessary_safety_comment)]
 
 mod bus;
 mod component;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -3,8 +3,6 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::all)]
 #![deny(rustdoc::missing_crate_level_docs)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::unnecessary_safety_comment)]
 
 mod bus;
 mod component;

--- a/common/src/proof.rs
+++ b/common/src/proof.rs
@@ -50,6 +50,10 @@ pub struct ProgramVK {
 impl ProgramVK {
     /// Build from the first `PROGRAM_VK_LEN` u64 elements of a publics blob,
     /// recording the [`HashMode`] the verkey was produced under.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `publics` has fewer than `PROGRAM_VK_LEN` elements.
     pub fn new_from_publics_with_mode(publics: &[u64], hash_mode: HashMode) -> Self {
         // Strip the recursion-layer `is_vadcop_final_proof` flag (present on a
         // full 69-wide vadcop_final publics vector) so the VK is read from the
@@ -240,6 +244,11 @@ pub struct PlonkVkey {
 
 impl PlonkVkey {
     /// Load PlonkVkey from a JSON file
+    ///
+    /// # Errors
+    ///
+    /// - [`CommonError::Io`] if the file cannot be opened or read.
+    /// - [`CommonError::Deserialization`] if the JSON cannot be parsed into a [`PlonkVkey`].
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let file = File::open(path.as_ref()).map_err(|e| {
             CommonError::Io(format!(
@@ -257,6 +266,11 @@ impl PlonkVkey {
     }
 
     /// Save PlonkVkey to a JSON file
+    ///
+    /// # Errors
+    ///
+    /// - [`CommonError::Io`] if the parent directory or the file cannot be created.
+    /// - [`CommonError::Serialization`] if the vkey cannot be serialized to JSON.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();
 
@@ -309,6 +323,10 @@ impl Clone for PublicValues {
 
 impl PublicValues {
     /// Build from the full proof publics byte blob.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `publics_bytes` is not exactly `ZISK_PUBLICS * 8 + 32` bytes long.
     pub fn new(publics_bytes: &[u8]) -> Self {
         assert!(
             publics_bytes.len() == ZISK_PUBLICS * 8 + 32,
@@ -326,6 +344,10 @@ impl PublicValues {
 
     /// Build from the full proof publics u64 blob: `[program_vk(4)][publics(ZISK_PUBLICS)]`.
     /// Each public u64 is truncated to its low 32 bits (matching `public_u64()`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `publics` does not contain exactly `ZISK_PUBLICS + PROGRAM_VK_LEN` elements.
     pub fn new_from_u64(publics: &[u64]) -> Self {
         // Accept either the flag-free app view (`[vk | inputs]`, 68) or a full
         // vadcop_final vector (`[flag | vk | inputs]`, 69); strip the flag first.
@@ -352,6 +374,11 @@ impl PublicValues {
 
     /// Create PublicValues from a serializable value.
     /// The value is serialized with bincode and stored in the public outputs as 64-bit chunks.
+    ///
+    /// # Errors
+    ///
+    /// - [`CommonError::Serialization`] if the value cannot be serialized with bincode.
+    /// - [`CommonError::Invalid`] if the serialized data exceeds `ZISK_PUBLICS * 4` bytes.
     pub fn write<T: serde::Serialize>(value: &T) -> Result<Self> {
         let serialized = bincode::serde::encode_to_vec(value, bincode::config::standard())
             .map_err(|e| CommonError::Serialization(e.to_string()))?;
@@ -378,6 +405,10 @@ impl PublicValues {
 
     /// Create PublicValues from an ABI-encodable value.
     /// The value is ABI-encoded and stored in the public outputs as 32-bit chunks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::Invalid`] if the ABI-encoded data exceeds `ZISK_PUBLICS * 4` bytes.
     pub fn write_abi<T: alloy_sol_types::SolValue>(value: &T) -> Result<Self> {
         let encoded = value.abi_encode();
 
@@ -414,6 +445,10 @@ impl PublicValues {
 
     /// Deserialize a value from public outputs.
     /// The value must have been previously written with bincode serialization using `commit()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::Deserialization`] if the stored bytes cannot be decoded into `T`.
     pub fn read<T: serde::Serialize + serde::de::DeserializeOwned>(&self) -> Result<T> {
         let ptr = self.ptr.load(Ordering::Relaxed);
         let (result, nb_bytes): (T, usize) =
@@ -425,6 +460,10 @@ impl PublicValues {
 
     /// Decode an ABI-encoded value from public outputs.
     /// The value must have been previously written with ABI encoding using `write_abi()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::AbiDecoding`] if the stored bytes cannot be ABI-decoded into `T`.
     pub fn read_abi<T>(&self) -> Result<T>
     where
         T: alloy_sol_types::SolValue + From<<T::SolType as alloy_sol_types::SolType>::RustType>,
@@ -658,6 +697,15 @@ impl<'a> ZiskVerifyBuilder<'a> {
     ///
     /// This method uses the overridden values if provided, otherwise falls back
     /// to the values stored in the proof.
+    ///
+    /// # Errors
+    ///
+    /// - [`CommonError::NotVerified`] if the proof is well-formed but does not verify.
+    /// - [`CommonError::InvalidProof`] if the proof is malformed or its hash family
+    ///   does not match the verification key.
+    /// - [`CommonError::Invalid`] if SNARK proof verification fails (Plonk).
+    /// - [`CommonError::Serialization`] / [`CommonError::Io`] if writing the temporary
+    ///   PlonkVkey file fails (Plonk).
     pub fn verify(self) -> Result<()> {
         let derived_publics = self.proof_with_values.publics();
         let has_override = self.override_publics.is_some() || self.override_program_vk.is_some();
@@ -829,6 +877,11 @@ impl Proof {
     }
 
     /// Save the proof to a file using bincode serialization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::Io`] if the parent directory or file cannot be created,
+    /// or if serializing the proof to the file fails.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();
 
@@ -853,6 +906,11 @@ impl Proof {
     }
 
     /// Load a proof from a file using bincode deserialization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::Io`] if the file cannot be opened or its contents
+    /// cannot be deserialized into a [`Proof`].
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let mut file = File::open(path.as_ref()).map_err(|e| {
             CommonError::Io(format!(
@@ -867,6 +925,10 @@ impl Proof {
     }
 
     /// Extract a `VadcopFinalProof` from the proof body.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::InvalidProof`] if the proof is not a Vadcop final proof.
     pub fn get_vadcop_final_proof(&self) -> Result<VadcopFinalProof> {
         match &self.body {
             ProofBody::Vadcop { proof, kind, hash, publics_full, .. } => {
@@ -888,6 +950,11 @@ impl Proof {
     }
 
     /// Get the proof data as a vector of u64 values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::InvalidProof`] if the program or Zisk verification key
+    /// has an unexpected length, or if the proof is not a Vadcop proof.
     pub fn get_proof_u64(&self) -> Result<Vec<u64>> {
         match &self.body {
             ProofBody::Vadcop { proof, zisk_vk, kind, publics_full, .. } => {
@@ -931,6 +998,11 @@ impl Proof {
     }
 
     /// Get the proof data as a vector of bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommonError::InvalidProof`] under the same conditions as
+    /// [`get_proof_u64`](Self::get_proof_u64), which this method builds upon.
     pub fn get_proof_bytes(&self) -> Result<Vec<u8>> {
         let words = self.get_proof_u64()?;
         let mut bytes = Vec::with_capacity(words.len() * 8);
@@ -965,6 +1037,12 @@ impl Proof {
     /// # Returns
     ///
     /// A Proof containing the parsed proof, publics, and program VK
+    ///
+    /// # Errors
+    ///
+    /// - [`CommonError::InvalidProof`] if `zisk_vk` has an unexpected length or the
+    ///   proof bytes cannot be parsed.
+    /// - [`CommonError::Invalid`] if `hash` is not a recognized proof hash family.
     pub fn new_from_vadcop_proof(
         proof: &[u64],
         minimal: bool,
@@ -1035,6 +1113,10 @@ impl Proof {
     /// // Custom verification with multiple overrides
     /// proof.publics(&custom_publics).program_vk(&custom_program_vk).verify()?;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`ZiskVerifyBuilder::verify`], which this method delegates to.
     pub fn verify(&self) -> Result<()> {
         ZiskVerifyBuilder::new(self).verify()
     }

--- a/common/src/proof_log.rs
+++ b/common/src/proof_log.rs
@@ -19,6 +19,11 @@ impl ProofLog {
     }
 
     /// Writes the proof log entries to a JSON file at the specified path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `entries` cannot be serialized to JSON, or if the file
+    /// cannot be created or written.
     pub fn write_json_log(file_path: &PathBuf, entries: &ProofLog) -> Result<(), Box<dyn Error>> {
         let json = serde_json::to_string_pretty(entries)?;
         let mut file = File::create(file_path)?;

--- a/common/src/regular_planner.rs
+++ b/common/src/regular_planner.rs
@@ -2,8 +2,6 @@
 //! for regular instances and table instances. It leverages operation counts and metadata
 //! to construct detailed plans for execution.
 
-use std::any::Any;
-
 use crate::{
     BusDeviceMetrics, CheckPoint, ChunkId, InstCount, InstanceType, Metrics, Plan, Planner,
     RegularCounters,
@@ -162,7 +160,7 @@ impl Planner for RegularPlanner {
             let plan: Vec<_> = plan(&count[idx], instance.num_ops as u64)
                 .into_iter()
                 .map(|(check_point, collect_info)| {
-                    let converted: Box<dyn Any> = Box::new(collect_info);
+                    let converted = Box::new(collect_info);
                     Plan::new(
                         instance.airgroup_id,
                         instance.air_id,

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -1,19 +1,7 @@
 use std::mem::MaybeUninit;
+use std::sync::atomic::AtomicU64;
 
 use crate::error::{CommonError, Result};
-
-/// Marker for types whose all-zero bit pattern is a valid, fully-initialized value and
-/// that carry no `Drop` glue — so a bulk-zeroed allocation is a valid `Vec<Self>`.
-///
-/// # Safety
-///
-/// Implementors must be valid when zero-initialized: no niche, no reference, no field
-/// that forbids the all-zero pattern, and no `Drop` implementation.
-pub(crate) unsafe trait Zeroable {}
-
-// SAFETY: `AtomicU64` wraps a `u64` whose all-zero pattern is the valid value `0`, and it
-// has no `Drop` glue.
-unsafe impl Zeroable for std::sync::atomic::AtomicU64 {}
 
 /// Marker for types that are sound to reinterpret raw bytes as, in either direction:
 /// an arbitrary byte buffer can be read as them, and their own bytes can be read raw.
@@ -31,34 +19,30 @@ unsafe impl Zeroable for std::sync::atomic::AtomicU64 {}
 ///
 /// Integer types qualify; `bool`, `char`, `NonZero*`, niche enums, references, and structs
 /// with padding do not.
-pub(crate) unsafe trait AnyBitPattern {}
+pub unsafe trait AnyBitPattern {}
 
 // SAFETY: `u8` has no invalid bit patterns.
 unsafe impl AnyBitPattern for u8 {}
 // SAFETY: `u64` has no invalid bit patterns.
 unsafe impl AnyBitPattern for u64 {}
 
-/// Creates a `Vec<DT>` of `size` elements by zeroing the backing allocation in bulk
-/// instead of constructing each element — a fast path for atomic integer element types.
-///
-/// The `DT: Zeroable` bound guarantees the zeroed bytes form valid `DT` values, so this
-/// function is safe.
-// `Zeroable` is a crate-internal soundness marker, deliberately not part of the public API.
-#[allow(private_bounds)]
-pub fn create_atomic_vec<DT: Zeroable>(size: usize) -> Vec<DT> {
-    let mut vec: Vec<MaybeUninit<DT>> = Vec::with_capacity(size);
+/// Creates a `Vec<AtomicU64>` of `size` elements by zeroing the backing allocation in
+/// bulk instead of constructing each element — a fast path for atomic counters.
+pub fn create_atomic_vec(size: usize) -> Vec<AtomicU64> {
+    let mut vec: Vec<MaybeUninit<AtomicU64>> = Vec::with_capacity(size);
 
-    // SAFETY: `vec` has capacity for `size` elements, so the `size * size_of::<DT>()`
-    // bytes zeroed by `write_bytes` lie within the allocation. `DT: Zeroable` makes the
-    // all-zero pattern a valid `DT`, so afterwards those `size` elements are initialized
-    // and `set_len(size)` is sound. `MaybeUninit<DT>` shares `DT`'s layout, so
-    // transmuting `Vec<MaybeUninit<DT>>` to `Vec<DT>` preserves the allocation.
+    // SAFETY: `vec` has capacity for `size` elements, so the `size * size_of::<AtomicU64>()`
+    // bytes zeroed by `write_bytes` lie within the allocation. `AtomicU64`'s all-zero
+    // pattern is the valid value `0` and it has no `Drop` glue, so afterwards those `size`
+    // elements are initialized and `set_len(size)` is sound. `MaybeUninit<AtomicU64>` shares
+    // `AtomicU64`'s layout, so transmuting `Vec<MaybeUninit<AtomicU64>>` to `Vec<AtomicU64>`
+    // preserves the allocation.
     unsafe {
         let ptr = vec.as_mut_ptr() as *mut u8;
-        std::ptr::write_bytes(ptr, 0, size * std::mem::size_of::<DT>()); // Fast zeroing
+        std::ptr::write_bytes(ptr, 0, size * std::mem::size_of::<AtomicU64>()); // Fast zeroing
 
         vec.set_len(size);
-        std::mem::transmute(vec) // Convert Vec<MaybeUninit<DT>> -> Vec<DT>
+        std::mem::transmute(vec) // Convert Vec<MaybeUninit<AtomicU64>> -> Vec<AtomicU64>
     }
 }
 
@@ -94,8 +78,7 @@ pub fn create_atomic_vec<DT: Zeroable>(size: usize) -> Vec<DT> {
 /// # Errors
 ///
 /// - [`CommonError::Invalid`] if `U` is a zero-sized type.
-// `AnyBitPattern` is a crate-internal soundness marker, deliberately not part of the public API.
-#[allow(private_bounds)]
+// `AnyBitPattern` is sealed, so the set of valid `T`/`U` is fixed by this crate.
 pub fn reinterpret_vec<T: Copy + AnyBitPattern, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -38,6 +38,11 @@ pub fn uninit_array<const N: usize>() -> MaybeUninit<[u64; N]> {
 /// # Type Parameters
 /// * `T` - Source element type
 /// * `U` - Destination element type
+///
+/// # Errors
+///
+/// Returns [`CommonError::Invalid`] if the resulting pointer is not properly aligned
+/// for `U`.
 pub fn reinterpret_vec<T: Default + Clone, U>(mut v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -79,7 +79,8 @@ pub fn create_atomic_vec<DT: Zeroable>(size: usize) -> Vec<DT> {
 /// * `v` - The source vector to reinterpret.
 ///
 /// # Type Parameters
-/// * `T` - Source element type
+/// * `T` - Source element type; must be `Copy` (destructor-free and bitwise-copyable),
+///   so drop behavior is identical on the zero-copy and copy paths.
 /// * `U` - Destination element type
 ///
 /// # Errors
@@ -87,7 +88,7 @@ pub fn create_atomic_vec<DT: Zeroable>(size: usize) -> Vec<DT> {
 /// - [`CommonError::Invalid`] if `U` is a zero-sized type.
 // `AnyBitPattern` is a crate-internal soundness marker, deliberately not part of the public API.
 #[allow(private_bounds)]
-pub fn reinterpret_vec<T, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
+pub fn reinterpret_vec<T: Copy, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();
 

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -2,84 +2,97 @@ use std::mem::MaybeUninit;
 
 use crate::error::{CommonError, Result};
 
-/// Creates a vector of `size` elements, zero-initialized and reinterpreted as `Vec<DT>`.
+/// Marker for types whose all-zero bit pattern is a valid, fully-initialized value and
+/// that carry no `Drop` glue — so a bulk-zeroed allocation is a valid `Vec<Self>`.
 ///
-/// This is a fast path that zeroes the backing allocation in bulk instead of
-/// constructing each element, intended for atomic integer element types.
+/// # Safety
 ///
-/// # Safety / caller obligation
+/// Implementors must be valid when zero-initialized: no niche, no reference, no field
+/// that forbids the all-zero pattern, and no `Drop` implementation.
+pub(crate) unsafe trait Zeroable {}
+
+// SAFETY: `AtomicU64` wraps a `u64` whose all-zero pattern is the valid value `0`, and it
+// has no `Drop` glue.
+unsafe impl Zeroable for std::sync::atomic::AtomicU64 {}
+
+/// Marker for types with no invalid bit patterns, so an arbitrary byte buffer can be
+/// reinterpreted into them without validation.
 ///
-/// Although this function is not marked `unsafe`, it is only sound for a `DT` whose
-/// all-zero bit pattern is a valid value — e.g. atomic integer types such as
-/// [`AtomicU64`](std::sync::atomic::AtomicU64). Calling it with a `DT` that has no
-/// valid all-zero representation (e.g. a type with a niche, or a non-trivial `Drop`)
-/// is undefined behaviour.
-pub fn create_atomic_vec<DT>(size: usize) -> Vec<DT> {
+/// A private mirror of this trait lives in `zisk-stream` (`zisk_stream.rs`), which cannot
+/// depend on `zisk-common`; keep the two in sync.
+///
+/// # Safety
+///
+/// Implementors must accept *every* bit pattern as a valid value. Integer types qualify;
+/// `bool`, `char`, `NonZero*`, niche enums, and references do not.
+pub(crate) unsafe trait AnyBitPattern {}
+
+// SAFETY: `u8` has no invalid bit patterns.
+unsafe impl AnyBitPattern for u8 {}
+// SAFETY: `u64` has no invalid bit patterns.
+unsafe impl AnyBitPattern for u64 {}
+
+/// Creates a `Vec<DT>` of `size` elements by zeroing the backing allocation in bulk
+/// instead of constructing each element — a fast path for atomic integer element types.
+///
+/// The `DT: Zeroable` bound guarantees the zeroed bytes form valid `DT` values, so this
+/// function is safe.
+// `Zeroable` is a crate-internal soundness marker, deliberately not part of the public API.
+#[allow(private_bounds)]
+pub fn create_atomic_vec<DT: Zeroable>(size: usize) -> Vec<DT> {
     let mut vec: Vec<MaybeUninit<DT>> = Vec::with_capacity(size);
 
     // SAFETY: `vec` has capacity for `size` elements, so the `size * size_of::<DT>()`
-    // bytes written by `write_bytes` lie within the allocation. After zeroing, those
-    // `size` elements are initialized, making `set_len(size)` sound. `MaybeUninit<DT>`
-    // shares `DT`'s layout, so transmuting `Vec<MaybeUninit<DT>>` to `Vec<DT>` preserves
-    // the allocation. The caller upholds that all-zero is a valid `DT` (see the
-    // function's "caller obligation" docs).
+    // bytes zeroed by `write_bytes` lie within the allocation. `DT: Zeroable` makes the
+    // all-zero pattern a valid `DT`, so afterwards those `size` elements are initialized
+    // and `set_len(size)` is sound. `MaybeUninit<DT>` shares `DT`'s layout, so
+    // transmuting `Vec<MaybeUninit<DT>>` to `Vec<DT>` preserves the allocation.
     unsafe {
         let ptr = vec.as_mut_ptr() as *mut u8;
         std::ptr::write_bytes(ptr, 0, size * std::mem::size_of::<DT>()); // Fast zeroing
 
         vec.set_len(size);
-        std::mem::transmute(vec) // Convert MaybeUninit<Vec> -> Vec<AtomicU64>
+        std::mem::transmute(vec) // Convert Vec<MaybeUninit<DT>> -> Vec<DT>
     }
 }
 
-/// Reinterprets a `Vec<T>` as a `Vec<U>` by reusing the source allocation in place
-/// (zero-copy): the returned vector owns the same buffer, viewed as `U`.
+/// Reinterprets a `Vec<T>` as a `Vec<U>` over the same bytes.
 ///
-/// The byte length is zero-padded up to a multiple of `size_of::<U>()` (with
-/// `T::default()` elements) so the buffer divides evenly into `U` values.
+/// A private mirror of this function lives in `zisk-stream` (`zisk_stream.rs`), which
+/// cannot depend on `zisk-common`; keep the two in sync.
+///
+/// When the source allocation can legally be handed to `Vec<U>`'s deallocator —
+/// identical element alignment and a byte length/capacity that are whole numbers of `U`
+/// — the buffer is reused in place (zero-copy). Otherwise (e.g. `u8` → `u64`, where the
+/// alignment differs) the bytes are copied into a fresh `Vec<U>` allocated — and
+/// therefore freed — under `U`'s own layout, so the result is sound to drop on any
+/// global allocator.
+///
+/// If the byte length is not a whole number of `U`, the trailing partial `U` is
+/// zero-padded. Callers streaming data in chunks must therefore cut on `size_of::<U>()`
+/// boundaries, or the padding will shift every subsequent value.
+///
+/// The `U: AnyBitPattern` bound guarantees the reinterpreted bytes form valid `U`
+/// values, so this function is safe.
 ///
 /// # Arguments
 /// * `v` - The source vector to reinterpret.
-///
-/// # Returns
-/// * `Ok(Vec<U>)` - A vector that owns `v`'s buffer (zero-padded), viewed as `U`.
 ///
 /// # Type Parameters
 /// * `T` - Source element type
 /// * `U` - Destination element type
 ///
-/// # Preconditions (caller must uphold — this is zero-copy, nothing is validated)
-///
-/// 1. **Byte length should already be a multiple of `size_of::<U>()`.** When it is
-///    not, the trailing partial `U` is silently zero-padded; for a chunked stream
-///    (e.g. `u8` → `u64` processed chunk-by-chunk) that shifts every subsequent
-///    value and corrupts the logical sequence. All current callers feed data whose
-///    byte length is a multiple of 8 — `u64` payloads cut on 8-byte boundaries by
-///    `ZiskStreamWriter` — so no padding ever occurs.
-/// 2. **Every bit pattern of `U` must be valid.** Integer types such as `u64`
-///    qualify; `bool`, niche enums, `NonZero*`, or `Drop` types do not — the bytes
-///    are reinterpreted without validation.
-/// 3. **Deallocation caveat.** The returned `Vec<U>` is freed under `U`'s layout
-///    although the buffer was allocated under `T`'s. When
-///    `align_of::<U>() != align_of::<T>()` (e.g. `u8` → `u64`) this violates the
-///    global allocator's layout contract and is *technically* undefined behaviour;
-///    it is sound in practice only because the system allocator (glibc `malloc`)
-///    ignores the layout alignment on free. Do not rely on this under a strict
-///    allocator (jemalloc/mimalloc/Miri) — reintroduce a copy for the
-///    align-increasing case if that ever becomes the runtime.
-///
 /// # Errors
 ///
 /// - [`CommonError::Invalid`] if `U` is a zero-sized type.
-/// - [`CommonError::Invalid`] if the source pointer is not aligned for `U` (reads
-///   would be unsound). The system allocator over-aligns, so this does not trigger
-///   for the current callers.
-pub fn reinterpret_vec<T: Default + Clone, U>(mut v: Vec<T>) -> Result<Vec<U>> {
+// `AnyBitPattern` is a crate-internal soundness marker, deliberately not part of the public API.
+#[allow(private_bounds)]
+pub fn reinterpret_vec<T, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();
 
-    // A zero-sized `U` would make the `% size_u` / `/ size_u` arithmetic below divide
-    // by zero; reject it explicitly rather than panic.
+    // A zero-sized `U` would make the `% size_u` / `/ size_u` arithmetic below divide by
+    // zero; reject it explicitly rather than panic.
     if size_u == 0 {
         return Err(CommonError::Invalid(format!(
             "cannot reinterpret Vec<{}> as Vec<{}>: destination type is zero-sized",
@@ -88,35 +101,48 @@ pub fn reinterpret_vec<T: Default + Clone, U>(mut v: Vec<T>) -> Result<Vec<U>> {
         )));
     }
 
-    // Zero-pad so the byte length is an exact multiple of `size_u` (see precondition 1).
-    let rem = (v.len() * size_t) % size_u;
-    if rem != 0 {
-        let pad_bytes = size_u - rem;
-        let pad_t = pad_bytes.div_ceil(size_t);
-        v.extend(std::iter::repeat(T::default()).take(pad_t));
+    let byte_len = v.len() * size_t;
+    let byte_cap = v.capacity() * size_t;
+    let len = byte_len.div_ceil(size_u); // whole `U` count, rounding a partial tail up
+
+    // Zero-copy is sound only when the source allocation matches `Vec<U>`'s layout
+    // exactly: identical alignment (so `ptr` is aligned for `U` and the free-time
+    // `Layout` matches the allocation), a byte capacity that is a whole number of `U` (so
+    // `cap` is not truncated), and a byte length already a whole number of `U` (a reused
+    // buffer cannot grow to pad a partial tail).
+    if std::mem::align_of::<T>() == std::mem::align_of::<U>()
+        && byte_cap % size_u == 0
+        && byte_len % size_u == 0
+    {
+        let cap = byte_cap / size_u;
+        let ptr = v.as_ptr() as *mut U;
+        std::mem::forget(v);
+        // SAFETY: `ptr` comes from `v`'s allocation, forgotten just above so it is freed
+        // exactly once — by the returned `Vec`. Equal alignment makes `ptr` aligned for
+        // `U` and the layout identical under either type; `byte_cap % size_u == 0` makes
+        // `cap * size_u == byte_cap`, so the returned `Vec` frees precisely the original
+        // allocation, and `byte_len % size_u == 0` makes `len` cover it with no partial
+        // element. `U: AnyBitPattern` makes every byte a valid `U`.
+        return Ok(unsafe { Vec::from_raw_parts(ptr, len, cap) });
     }
 
-    // Reject a misaligned source rather than produce unaligned `U` reads.
-    if v.as_ptr() as usize % std::mem::align_of::<U>() != 0 {
-        return Err(CommonError::Invalid(format!(
-            "Vec<{}> is not properly aligned for Vec<{}> (requires {}-byte alignment)",
-            std::any::type_name::<T>(),
-            std::any::type_name::<U>(),
-            std::mem::align_of::<U>()
-        )));
+    // Layouts differ (e.g. `u8` → `u64`): reusing the buffer would free it under a
+    // different `Layout` than it was allocated with — undefined behaviour, and not merely
+    // theoretical under jemalloc/mimalloc/Miri or a non-glibc libc. Copy into a fresh
+    // `Vec<U>` owned end-to-end under `U`'s own layout, zero-filling any partial trailing
+    // `U`. The source `v` is left untouched and dropped normally at end of scope.
+    let mut out: Vec<U> = Vec::with_capacity(len);
+    let out_bytes = len * size_u;
+    // SAFETY: `out` reserves `out_bytes >= byte_len` bytes in a distinct allocation, so
+    // copying the `byte_len` source bytes is in-bounds and non-overlapping; the remaining
+    // `[byte_len, out_bytes)` tail is then zeroed, so all `out_bytes` bytes are
+    // initialized and `set_len(len)` is sound. `U: AnyBitPattern` makes every byte
+    // pattern (source data and zero padding alike) a valid `U`.
+    unsafe {
+        let dst = out.as_mut_ptr() as *mut u8;
+        std::ptr::copy_nonoverlapping(v.as_ptr() as *const u8, dst, byte_len);
+        std::ptr::write_bytes(dst.add(byte_len), 0, out_bytes - byte_len);
+        out.set_len(len);
     }
-
-    let len = (v.len() * size_t) / size_u;
-    let cap = (v.capacity() * size_t) / size_u;
-    let ptr = v.as_ptr() as *mut U;
-
-    std::mem::forget(v);
-    // SAFETY: `ptr` comes from `v`'s allocation, which is forgotten just above so the
-    // buffer is freed exactly once (by the returned `Vec`). `len`/`cap` are the same
-    // byte span recomputed in units of `U`, and the padding above makes the byte
-    // length an exact multiple of `size_of::<U>()`, so no partial element is exposed.
-    // The alignment check guarantees `ptr` is aligned for reads of `U`. The one
-    // remaining obligation — that freeing under `U`'s layout matches the original
-    // allocation — is the caller's (precondition 3 above).
-    Ok(unsafe { Vec::from_raw_parts(ptr, len, cap) })
+    Ok(out)
 }

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -78,7 +78,6 @@ pub fn create_atomic_vec(size: usize) -> Vec<AtomicU64> {
 /// # Errors
 ///
 /// - [`CommonError::Invalid`] if `U` is a zero-sized type.
-// `AnyBitPattern` is sealed, so the set of valid `T`/`U` is fixed by this crate.
 pub fn reinterpret_vec<T: Copy + AnyBitPattern, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -15,16 +15,22 @@ pub(crate) unsafe trait Zeroable {}
 // has no `Drop` glue.
 unsafe impl Zeroable for std::sync::atomic::AtomicU64 {}
 
-/// Marker for types with no invalid bit patterns, so an arbitrary byte buffer can be
-/// reinterpreted into them without validation.
+/// Marker for types that are sound to reinterpret raw bytes as, in either direction:
+/// an arbitrary byte buffer can be read as them, and their own bytes can be read raw.
 ///
 /// A private mirror of this trait lives in `zisk-stream` (`zisk_stream.rs`), which cannot
 /// depend on `zisk-common`; keep the two in sync.
 ///
 /// # Safety
 ///
-/// Implementors must accept *every* bit pattern as a valid value. Integer types qualify;
-/// `bool`, `char`, `NonZero*`, niche enums, and references do not.
+/// Implementors must both:
+/// - accept *every* bit pattern as a valid value (so an arbitrary byte buffer can be
+///   reinterpreted into them — the destination requirement), and
+/// - contain no padding or otherwise uninitialized bytes (so reading their own bytes is
+///   never a read of uninitialized memory — the source requirement).
+///
+/// Integer types qualify; `bool`, `char`, `NonZero*`, niche enums, references, and structs
+/// with padding do not.
 pub(crate) unsafe trait AnyBitPattern {}
 
 // SAFETY: `u8` has no invalid bit patterns.
@@ -72,23 +78,25 @@ pub fn create_atomic_vec<DT: Zeroable>(size: usize) -> Vec<DT> {
 /// zero-padded. Callers streaming data in chunks must therefore cut on `size_of::<U>()`
 /// boundaries, or the padding will shift every subsequent value.
 ///
-/// The `U: AnyBitPattern` bound guarantees the reinterpreted bytes form valid `U`
-/// values, so this function is safe.
+/// The `T: AnyBitPattern` bound guarantees the source bytes are fully initialized (no
+/// padding to read as uninitialized memory) and the `U: AnyBitPattern` bound guarantees
+/// the reinterpreted bytes form valid `U` values, so this function is safe.
 ///
 /// # Arguments
 /// * `v` - The source vector to reinterpret.
 ///
 /// # Type Parameters
-/// * `T` - Source element type; must be `Copy` (destructor-free and bitwise-copyable),
-///   so drop behavior is identical on the zero-copy and copy paths.
-/// * `U` - Destination element type
+/// * `T` - Source element type; must be `Copy` (destructor-free and bitwise-copyable, so
+///   drop behavior is identical on the zero-copy and copy paths) and `AnyBitPattern` (no
+///   padding/uninitialized bytes, so reading its raw bytes is sound).
+/// * `U` - Destination element type; must be `AnyBitPattern`.
 ///
 /// # Errors
 ///
 /// - [`CommonError::Invalid`] if `U` is a zero-sized type.
 // `AnyBitPattern` is a crate-internal soundness marker, deliberately not part of the public API.
 #[allow(private_bounds)]
-pub fn reinterpret_vec<T: Copy, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
+pub fn reinterpret_vec<T: Copy + AnyBitPattern, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();
 

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -32,39 +32,48 @@ pub fn create_atomic_vec<DT>(size: usize) -> Vec<DT> {
     }
 }
 
-/// Reinterprets a `Vec<T>` as a `Vec<U>` by transmuting the underlying memory.
+/// Reinterprets a `Vec<T>` as a `Vec<U>` by reusing the source allocation in place
+/// (zero-copy): the returned vector owns the same buffer, viewed as `U`.
 ///
-/// This function converts between vector types by reinterpreting the raw memory,
-/// adjusting length and capacity based on the size ratio between types.
-/// It performs internal unsafe operations but validates all safety requirements
-/// before the conversion.
+/// The byte length is zero-padded up to a multiple of `size_of::<U>()` (with
+/// `T::default()` elements) so the buffer divides evenly into `U` values.
 ///
 /// # Arguments
 /// * `v` - The source vector to reinterpret.
 ///
 /// # Returns
-/// * `Ok(Vec<U>)` - A new vector that owns the same memory as the input vector
-/// * `Err` - If validation fails (size incompatibility or alignment issues)
+/// * `Ok(Vec<U>)` - A vector that owns `v`'s buffer (zero-padded), viewed as `U`.
 ///
 /// # Type Parameters
 /// * `T` - Source element type
 /// * `U` - Destination element type
 ///
-/// # Safety / caller obligation
+/// # Preconditions (caller must uphold — this is zero-copy, nothing is validated)
 ///
-/// Although this function is not marked `unsafe`, the returned `Vec<U>` will be
-/// deallocated using `U`'s layout. For that to match the layout the buffer was
-/// allocated with, the caller must only use type pairs where
-/// `align_of::<U>() == align_of::<T>()` and the byte capacity divides evenly by
-/// `size_of::<U>()`. The runtime alignment check below only validates the pointer
-/// value, **not** the allocation layout, so a mismatched alignment (e.g. `u8` → `u64`)
-/// is undefined behaviour even when the `Ok` branch is taken.
+/// 1. **Byte length should already be a multiple of `size_of::<U>()`.** When it is
+///    not, the trailing partial `U` is silently zero-padded; for a chunked stream
+///    (e.g. `u8` → `u64` processed chunk-by-chunk) that shifts every subsequent
+///    value and corrupts the logical sequence. All current callers feed data whose
+///    byte length is a multiple of 8 — `u64` payloads cut on 8-byte boundaries by
+///    `ZiskStreamWriter` — so no padding ever occurs.
+/// 2. **Every bit pattern of `U` must be valid.** Integer types such as `u64`
+///    qualify; `bool`, niche enums, `NonZero*`, or `Drop` types do not — the bytes
+///    are reinterpreted without validation.
+/// 3. **Deallocation caveat.** The returned `Vec<U>` is freed under `U`'s layout
+///    although the buffer was allocated under `T`'s. When
+///    `align_of::<U>() != align_of::<T>()` (e.g. `u8` → `u64`) this violates the
+///    global allocator's layout contract and is *technically* undefined behaviour;
+///    it is sound in practice only because the system allocator (glibc `malloc`)
+///    ignores the layout alignment on free. Do not rely on this under a strict
+///    allocator (jemalloc/mimalloc/Miri) — reintroduce a copy for the
+///    align-increasing case if that ever becomes the runtime.
 ///
 /// # Errors
 ///
-/// - [`CommonError::Invalid`] if `U` is a zero-sized type (the reinterpretation is
-///   undefined for a ZST destination).
-/// - [`CommonError::Invalid`] if the resulting pointer is not properly aligned for `U`.
+/// - [`CommonError::Invalid`] if `U` is a zero-sized type.
+/// - [`CommonError::Invalid`] if the source pointer is not aligned for `U` (reads
+///   would be unsound). The system allocator over-aligns, so this does not trigger
+///   for the current callers.
 pub fn reinterpret_vec<T: Default + Clone, U>(mut v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();
@@ -79,24 +88,15 @@ pub fn reinterpret_vec<T: Default + Clone, U>(mut v: Vec<T>) -> Result<Vec<U>> {
         )));
     }
 
-    // Total bytes in Vec<T>
-    let total_bytes = v.len() * size_t;
-
-    // Compute remainder to see if we need padding
-    let rem = total_bytes % size_u;
-
-    // If remainder exists, pad with zeroed T elements
+    // Zero-pad so the byte length is an exact multiple of `size_u` (see precondition 1).
+    let rem = (v.len() * size_t) % size_u;
     if rem != 0 {
-        // Number of extra bytes needed
         let pad_bytes = size_u - rem;
-
-        // Number of T elements to pad (round up)
         let pad_t = pad_bytes.div_ceil(size_t);
-
         v.extend(std::iter::repeat(T::default()).take(pad_t));
     }
 
-    // Check that the pointer is properly aligned for U
+    // Reject a misaligned source rather than produce unaligned `U` reads.
     if v.as_ptr() as usize % std::mem::align_of::<U>() != 0 {
         return Err(CommonError::Invalid(format!(
             "Vec<{}> is not properly aligned for Vec<{}> (requires {}-byte alignment)",
@@ -111,12 +111,12 @@ pub fn reinterpret_vec<T: Default + Clone, U>(mut v: Vec<T>) -> Result<Vec<U>> {
     let ptr = v.as_ptr() as *mut U;
 
     std::mem::forget(v);
-    // SAFETY: `ptr` comes from `v`, which was allocated by the global allocator and is
-    // forgotten just above so its buffer is not freed twice. `len`/`cap` are recomputed
-    // for `U` from the byte size of the original allocation, and the padding loop ensures
-    // the byte length is an exact multiple of `size_of::<U>()`, so no partial element is
-    // exposed. The alignment check above guarantees `ptr` is suitably aligned for `U`.
-    // The remaining layout precondition (equal alignment of `T`/`U` for the eventual
-    // deallocation) is the caller's obligation — see this function's "caller obligation" docs.
+    // SAFETY: `ptr` comes from `v`'s allocation, which is forgotten just above so the
+    // buffer is freed exactly once (by the returned `Vec`). `len`/`cap` are the same
+    // byte span recomputed in units of `U`, and the padding above makes the byte
+    // length an exact multiple of `size_of::<U>()`, so no partial element is exposed.
+    // The alignment check guarantees `ptr` is aligned for reads of `U`. The one
+    // remaining obligation — that freeing under `U`'s layout matches the original
+    // allocation — is the caller's (precondition 3 above).
     Ok(unsafe { Vec::from_raw_parts(ptr, len, cap) })
 }

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -2,10 +2,27 @@ use std::mem::MaybeUninit;
 
 use crate::error::{CommonError, Result};
 
-/// Creates a vector of the specified size, initialized to zero, and reinterpreted as `Vec<DT>`.
+/// Creates a vector of `size` elements, zero-initialized and reinterpreted as `Vec<DT>`.
+///
+/// This is a fast path that zeroes the backing allocation in bulk instead of
+/// constructing each element, intended for atomic integer element types.
+///
+/// # Safety / caller obligation
+///
+/// Although this function is not marked `unsafe`, it is only sound for a `DT` whose
+/// all-zero bit pattern is a valid value — e.g. atomic integer types such as
+/// [`AtomicU64`](std::sync::atomic::AtomicU64). Calling it with a `DT` that has no
+/// valid all-zero representation (e.g. a type with a niche, or a non-trivial `Drop`)
+/// is undefined behaviour.
 pub fn create_atomic_vec<DT>(size: usize) -> Vec<DT> {
     let mut vec: Vec<MaybeUninit<DT>> = Vec::with_capacity(size);
 
+    // SAFETY: `vec` has capacity for `size` elements, so the `size * size_of::<DT>()`
+    // bytes written by `write_bytes` lie within the allocation. After zeroing, those
+    // `size` elements are initialized, making `set_len(size)` sound. `MaybeUninit<DT>`
+    // shares `DT`'s layout, so transmuting `Vec<MaybeUninit<DT>>` to `Vec<DT>` preserves
+    // the allocation. The caller upholds that all-zero is a valid `DT` (see the
+    // function's "caller obligation" docs).
     unsafe {
         let ptr = vec.as_mut_ptr() as *mut u8;
         std::ptr::write_bytes(ptr, 0, size * std::mem::size_of::<DT>()); // Fast zeroing
@@ -13,12 +30,6 @@ pub fn create_atomic_vec<DT>(size: usize) -> Vec<DT> {
         vec.set_len(size);
         std::mem::transmute(vec) // Convert MaybeUninit<Vec> -> Vec<AtomicU64>
     }
-}
-
-/// Creates an uninitialized array of the specified size, intended for use with `create_atomic_vec`.
-#[inline(always)]
-pub fn uninit_array<const N: usize>() -> MaybeUninit<[u64; N]> {
-    MaybeUninit::uninit()
 }
 
 /// Reinterprets a `Vec<T>` as a `Vec<U>` by transmuting the underlying memory.
@@ -39,13 +50,34 @@ pub fn uninit_array<const N: usize>() -> MaybeUninit<[u64; N]> {
 /// * `T` - Source element type
 /// * `U` - Destination element type
 ///
+/// # Safety / caller obligation
+///
+/// Although this function is not marked `unsafe`, the returned `Vec<U>` will be
+/// deallocated using `U`'s layout. For that to match the layout the buffer was
+/// allocated with, the caller must only use type pairs where
+/// `align_of::<U>() == align_of::<T>()` and the byte capacity divides evenly by
+/// `size_of::<U>()`. The runtime alignment check below only validates the pointer
+/// value, **not** the allocation layout, so a mismatched alignment (e.g. `u8` → `u64`)
+/// is undefined behaviour even when the `Ok` branch is taken.
+///
 /// # Errors
 ///
-/// Returns [`CommonError::Invalid`] if the resulting pointer is not properly aligned
-/// for `U`.
+/// - [`CommonError::Invalid`] if `U` is a zero-sized type (the reinterpretation is
+///   undefined for a ZST destination).
+/// - [`CommonError::Invalid`] if the resulting pointer is not properly aligned for `U`.
 pub fn reinterpret_vec<T: Default + Clone, U>(mut v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();
+
+    // A zero-sized `U` would make the `% size_u` / `/ size_u` arithmetic below divide
+    // by zero; reject it explicitly rather than panic.
+    if size_u == 0 {
+        return Err(CommonError::Invalid(format!(
+            "cannot reinterpret Vec<{}> as Vec<{}>: destination type is zero-sized",
+            std::any::type_name::<T>(),
+            std::any::type_name::<U>()
+        )));
+    }
 
     // Total bytes in Vec<T>
     let total_bytes = v.len() * size_t;
@@ -79,5 +111,12 @@ pub fn reinterpret_vec<T: Default + Clone, U>(mut v: Vec<T>) -> Result<Vec<U>> {
     let ptr = v.as_ptr() as *mut U;
 
     std::mem::forget(v);
+    // SAFETY: `ptr` comes from `v`, which was allocated by the global allocator and is
+    // forgotten just above so its buffer is not freed twice. `len`/`cap` are recomputed
+    // for `U` from the byte size of the original allocation, and the padding loop ensures
+    // the byte length is an exact multiple of `size_of::<U>()`, so no partial element is
+    // exposed. The alignment check above guarantees `ptr` is suitably aligned for `U`.
+    // The remaining layout precondition (equal alignment of `T`/`U` for the eventual
+    // deallocation) is the caller's obligation — see this function's "caller obligation" docs.
     Ok(unsafe { Vec::from_raw_parts(ptr, len, cap) })
 }

--- a/common/src/zisk_precompile.rs
+++ b/common/src/zisk_precompile.rs
@@ -231,8 +231,7 @@ macro_rules! zisk_precompile_explicit {
                             $crate::plan(&count[idx], instance.num_ops as u64)
                                 .into_iter()
                                 .map(|(check_point, collect_info)| {
-                                    let converted: ::std::boxed::Box<dyn ::std::any::Any> =
-                                        ::std::boxed::Box::new(collect_info);
+                                    let converted = ::std::boxed::Box::new(collect_info);
                                     $crate::Plan::new(
                                         instance.airgroup_id,
                                         instance.air_id,

--- a/emulator-asm/asm-runner/src/inputs_shmem.rs
+++ b/emulator-asm/asm-runner/src/inputs_shmem.rs
@@ -1,10 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use named_sem::NamedSemaphore;
-use zisk_common::{
-    io::{StreamError, StreamProcessor, StreamSink},
-    reinterpret_vec,
-};
+use zisk_common::io::{StreamError, StreamProcessor, StreamSink};
 use zisk_core::MAX_INPUT_SIZE;
 
 use crate::{sem_input_avail_name, shmem_input_name, AsmServices, ControlShmem, ShmemWriter};
@@ -122,8 +119,13 @@ impl InputsShmemWriter {
 
 impl StreamSink for InputsShmemWriter {
     fn submit(&self, hints: &[u64]) -> Result<(), StreamError> {
-        let bytes = reinterpret_vec(hints.to_vec()).map_err(StreamError::other)?;
-        self.append_input(&bytes).map_err(StreamError::other)
+        // SAFETY: viewing `&[u64]` as `&[u8]` is always sound — `u8`'s alignment (1)
+        // divides `u64`'s and every byte is a valid `u8`. The view borrows `hints` and
+        // is only read by `append_input`, which copies into shmem; no allocation.
+        let bytes = unsafe {
+            std::slice::from_raw_parts(hints.as_ptr() as *const u8, std::mem::size_of_val(hints))
+        };
+        self.append_input(bytes).map_err(StreamError::other)
     }
 
     fn reset(&self) {

--- a/state-machines/arith/src/arith_planner.rs
+++ b/state-machines/arith/src/arith_planner.rs
@@ -4,8 +4,6 @@
 //! It organizes execution plans for both regular instances and table instances,
 //! leveraging arithmetic operation counts and metadata to construct detailed plans.
 
-use std::any::Any;
-
 use crate::ArithCounterInputGen;
 use zisk_common::{
     plan_with_frops, BusDeviceMetrics, CheckPoint, ChunkId, InstFropsCount, InstanceInfo,
@@ -91,7 +89,7 @@ impl Planner for ArithPlanner {
             let plan: Vec<_> = plan_with_frops(&count[idx], instance.num_ops as u64)
                 .into_iter()
                 .map(|(check_point, collect_info)| {
-                    let converted: Box<dyn Any> = Box::new(collect_info);
+                    let converted = Box::new(collect_info);
                     Plan::new(
                         instance.airgroup_id,
                         instance.air_id,

--- a/state-machines/binary/src/binary_planner.rs
+++ b/state-machines/binary/src/binary_planner.rs
@@ -63,7 +63,7 @@ impl<F: PrimeField64> BinaryPlanner<F> {
         let plans: Vec<_> = plan_with_frops(&extension_counters, extension_num_rows as u64)
             .into_iter()
             .map(|(check_point, collect_info)| {
-                let converted: Box<dyn Any> = Box::new(collect_info);
+                let converted = Box::new(collect_info);
                 Plan::new(
                     BinaryExtensionTrace::<()>::AIRGROUP_ID,
                     BinaryExtensionTrace::<()>::AIR_ID,
@@ -100,7 +100,7 @@ impl<F: PrimeField64> BinaryPlanner<F> {
         let plans: Vec<_> = plan_with_frops(&basic_counters, basic_num_rows as u64)
             .into_iter()
             .map(|(check_point, collect_info)| {
-                let converted: Box<dyn Any> = Box::new((with_adds, collect_info));
+                let converted: Box<dyn Any + Send + Sync> = Box::new((with_adds, collect_info));
                 Plan::new(
                     BinaryTrace::<()>::AIRGROUP_ID,
                     BinaryTrace::<()>::AIR_ID,
@@ -128,7 +128,7 @@ impl<F: PrimeField64> BinaryPlanner<F> {
         plan_with_frops(&add_counters, add_num_rows as u64)
             .into_iter()
             .map(|(check_point, collect_info)| {
-                let converted: Box<dyn Any> = Box::new(collect_info);
+                let converted: Box<dyn Any + Send + Sync> = Box::new(collect_info);
                 Plan::new(
                     BinaryAddTrace::<()>::AIRGROUP_ID,
                     BinaryAddTrace::<()>::AIR_ID,

--- a/state-machines/main/src/main_planner.rs
+++ b/state-machines/main/src/main_planner.rs
@@ -4,7 +4,6 @@
 //! to a specific `Plan` instance.
 
 use crate::{MainSmError, Result};
-use std::any::Any;
 use zisk_common::{CheckPoint, ChunkId, EmuTrace, InstanceType, Plan, SegmentId};
 use zisk_pil::{MainTrace, MAIN_AIR_IDS, ZISK_AIRGROUP_ID};
 
@@ -62,7 +61,7 @@ impl MainPlanner {
                     Some(SegmentId(segment_id)),
                     InstanceType::Instance,
                     CheckPoint::Single(ChunkId(segment_id)),
-                    Some(Box::new(segment_id == num_instances - 1) as Box<dyn Any>),
+                    Some(Box::new(segment_id == num_instances - 1)),
                 )
             })
             .collect())

--- a/state-machines/main/src/main_sm.rs
+++ b/state-machines/main/src/main_sm.rs
@@ -448,7 +448,7 @@ mod tests {
     // `MainInstance<F>`, so the call site has to pick some concrete `F`.
     type MI = MainInstance<Goldilocks>;
 
-    fn make_plan(segment_id: Option<SegmentId>, meta: Option<Box<dyn Any>>) -> Plan {
+    fn make_plan(segment_id: Option<SegmentId>, meta: Option<Box<dyn Any + Send + Sync>>) -> Plan {
         Plan::new(0, 0, segment_id, InstanceType::Instance, CheckPoint::Single(ChunkId(0)), meta)
     }
 

--- a/stream/src/zisk_stream.rs
+++ b/stream/src/zisk_stream.rs
@@ -222,14 +222,16 @@ impl<P: StreamProcessor> Drop for ZiskStream<P> {
     }
 }
 
-/// Marker for types with no invalid bit patterns, so an arbitrary byte buffer can be
-/// reinterpreted into them without validation. Mirror of `zisk_common::AnyBitPattern`
-/// (this crate cannot depend on `zisk-common`).
+/// Marker for types that are sound to reinterpret raw bytes as, in either direction: an
+/// arbitrary byte buffer can be read as them, and their own bytes can be read raw. Mirror
+/// of `zisk_common::AnyBitPattern` (this crate cannot depend on `zisk-common`).
 ///
 /// # Safety
 ///
-/// Implementors must accept every bit pattern as a valid value (integer types qualify;
-/// `bool`, `char`, `NonZero*`, niche enums, and references do not).
+/// Implementors must both accept every bit pattern as a valid value (the destination
+/// requirement) and contain no padding or otherwise uninitialized bytes (the source
+/// requirement). Integer types qualify; `bool`, `char`, `NonZero*`, niche enums,
+/// references, and structs with padding do not.
 unsafe trait AnyBitPattern {}
 
 // SAFETY: `u8` has no invalid bit patterns.
@@ -250,13 +252,14 @@ unsafe impl AnyBitPattern for u64 {}
 /// result is sound to drop on any global allocator. A trailing partial `U` is
 /// zero-padded.
 ///
-/// The `U: AnyBitPattern` bound guarantees the reinterpreted bytes form valid `U`
-/// values, so this function is safe.
+/// The `T: AnyBitPattern` bound guarantees the source bytes are fully initialized (no
+/// padding to read as uninitialized memory) and the `U: AnyBitPattern` bound guarantees
+/// the reinterpreted bytes form valid `U` values, so this function is safe.
 ///
 /// # Errors
 ///
 /// Returns [`StreamError::Invalid`] if `U` is a zero-sized type.
-fn reinterpret_vec<T: Copy, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
+fn reinterpret_vec<T: Copy + AnyBitPattern, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();
 

--- a/stream/src/zisk_stream.rs
+++ b/stream/src/zisk_stream.rs
@@ -222,36 +222,96 @@ impl<P: StreamProcessor> Drop for ZiskStream<P> {
     }
 }
 
-/// Reinterpret a `Vec<T>` as a `Vec<U>` in place, zero-padding to a whole
-/// number of `U` elements when needed.
+/// Marker for types with no invalid bit patterns, so an arbitrary byte buffer can be
+/// reinterpreted into them without validation. Mirror of `zisk_common::AnyBitPattern`
+/// (this crate cannot depend on `zisk-common`).
 ///
-/// Returns an error if the backing allocation is not aligned for `U`.
-fn reinterpret_vec<T: Default + Clone, U>(mut v: Vec<T>) -> Result<Vec<U>> {
+/// # Safety
+///
+/// Implementors must accept every bit pattern as a valid value (integer types qualify;
+/// `bool`, `char`, `NonZero*`, niche enums, and references do not).
+unsafe trait AnyBitPattern {}
+
+// SAFETY: `u8` has no invalid bit patterns.
+unsafe impl AnyBitPattern for u8 {}
+// SAFETY: `u64` has no invalid bit patterns.
+unsafe impl AnyBitPattern for u64 {}
+
+/// Reinterprets a `Vec<T>` as a `Vec<U>` over the same bytes.
+///
+/// Mirror of `zisk_common::reinterpret_vec`, duplicated here because `zisk-common`
+/// depends on `zisk-stream` and so this crate cannot import it back — keep the two in
+/// sync.
+///
+/// When the source allocation matches `Vec<U>`'s layout (identical alignment and a byte
+/// length/capacity that are whole numbers of `U`) the buffer is reused in place;
+/// otherwise (e.g. `u8` → `u64`, where the alignment differs) the bytes are copied into
+/// a fresh `Vec<U>` allocated — and therefore freed — under `U`'s own layout, so the
+/// result is sound to drop on any global allocator. A trailing partial `U` is
+/// zero-padded.
+///
+/// The `U: AnyBitPattern` bound guarantees the reinterpreted bytes form valid `U`
+/// values, so this function is safe.
+///
+/// # Errors
+///
+/// Returns [`StreamError::Invalid`] if `U` is a zero-sized type.
+fn reinterpret_vec<T, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();
 
-    let total_bytes = v.len() * size_t;
-    let rem = total_bytes % size_u;
-
-    if rem != 0 {
-        let pad_bytes = size_u - rem;
-        let pad_t = pad_bytes.div_ceil(size_t);
-        v.extend(std::iter::repeat(T::default()).take(pad_t));
-    }
-
-    if v.as_ptr() as usize % std::mem::align_of::<U>() != 0 {
+    // A zero-sized `U` would make the `% size_u` / `/ size_u` arithmetic below divide by
+    // zero; reject it explicitly rather than panic.
+    if size_u == 0 {
         return Err(StreamError::Invalid(format!(
-            "Vec<{}> is not properly aligned for Vec<{}> (requires {}-byte alignment)",
+            "cannot reinterpret Vec<{}> as Vec<{}>: destination type is zero-sized",
             std::any::type_name::<T>(),
-            std::any::type_name::<U>(),
-            std::mem::align_of::<U>()
+            std::any::type_name::<U>()
         )));
     }
 
-    let len = (v.len() * size_t) / size_u;
-    let cap = (v.capacity() * size_t) / size_u;
-    let ptr = v.as_ptr() as *mut U;
+    let byte_len = v.len() * size_t;
+    let byte_cap = v.capacity() * size_t;
+    let len = byte_len.div_ceil(size_u); // whole `U` count, rounding a partial tail up
 
-    std::mem::forget(v);
-    Ok(unsafe { Vec::from_raw_parts(ptr, len, cap) })
+    // Zero-copy is sound only when the source allocation matches `Vec<U>`'s layout
+    // exactly: identical alignment (so `ptr` is aligned for `U` and the free-time
+    // `Layout` matches the allocation), a byte capacity that is a whole number of `U` (so
+    // `cap` is not truncated), and a byte length already a whole number of `U` (a reused
+    // buffer cannot grow to pad a partial tail).
+    if std::mem::align_of::<T>() == std::mem::align_of::<U>()
+        && byte_cap % size_u == 0
+        && byte_len % size_u == 0
+    {
+        let cap = byte_cap / size_u;
+        let ptr = v.as_ptr() as *mut U;
+        std::mem::forget(v);
+        // SAFETY: `ptr` comes from `v`'s allocation, forgotten just above so it is freed
+        // exactly once — by the returned `Vec`. Equal alignment makes `ptr` aligned for
+        // `U` and the layout identical under either type; `byte_cap % size_u == 0` makes
+        // `cap * size_u == byte_cap`, so the returned `Vec` frees precisely the original
+        // allocation, and `byte_len % size_u == 0` makes `len` cover it with no partial
+        // element. `U: AnyBitPattern` makes every byte a valid `U`.
+        return Ok(unsafe { Vec::from_raw_parts(ptr, len, cap) });
+    }
+
+    // Layouts differ (e.g. `u8` → `u64`): reusing the buffer would free it under a
+    // different `Layout` than it was allocated with — undefined behaviour, and not merely
+    // theoretical under jemalloc/mimalloc/Miri or a non-glibc libc. Copy into a fresh
+    // `Vec<U>` owned end-to-end under `U`'s own layout, zero-filling any partial trailing
+    // `U`. The source `v` is left untouched and dropped normally at end of scope.
+    let mut out: Vec<U> = Vec::with_capacity(len);
+    let out_bytes = len * size_u;
+    // SAFETY: `out` reserves `out_bytes >= byte_len` bytes in a distinct allocation, so
+    // copying the `byte_len` source bytes is in-bounds and non-overlapping; the remaining
+    // `[byte_len, out_bytes)` tail is then zeroed, so all `out_bytes` bytes are
+    // initialized and `set_len(len)` is sound. `U: AnyBitPattern` makes every byte
+    // pattern (source data and zero padding alike) a valid `U`.
+    unsafe {
+        let dst = out.as_mut_ptr() as *mut u8;
+        std::ptr::copy_nonoverlapping(v.as_ptr() as *const u8, dst, byte_len);
+        std::ptr::write_bytes(dst.add(byte_len), 0, out_bytes - byte_len);
+        out.set_len(len);
+    }
+    Ok(out)
 }

--- a/stream/src/zisk_stream.rs
+++ b/stream/src/zisk_stream.rs
@@ -256,7 +256,7 @@ unsafe impl AnyBitPattern for u64 {}
 /// # Errors
 ///
 /// Returns [`StreamError::Invalid`] if `U` is a zero-sized type.
-fn reinterpret_vec<T, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
+fn reinterpret_vec<T: Copy, U: AnyBitPattern>(v: Vec<T>) -> Result<Vec<U>> {
     let size_t = std::mem::size_of::<T>();
     let size_u = std::mem::size_of::<U>();
 


### PR DESCRIPTION
## Documentation
- Adds `# Errors` / `# Panics` Rustdoc across the public API (`proof.rs`,
  `hints.rs`, `io/stdin/zisk_stdin.rs`, `proof_log.rs`, `component_instance.rs`),
  cross-checked against the actual code paths.

## Unsafe hardening
- `lib.rs` — enables `clippy::undocumented_unsafe_blocks` +
  `unnecessary_safety_comment` so the SAFETY discipline is enforced.
- `data_bus_operation.rs` — replaces the UB `MaybeUninit::assume_init()` array
  pattern with `[0u64; N]` (verified identical codegen, no perf cost).
- `utils.rs` — `reinterpret_vec` gains explicit `# Preconditions` docs (byte
  length must be a multiple of `size_of::<U>()`; valid-bit-pattern `U`; the
  u8→u64 dealloc-alignment caveat) and a ZST guard; SAFETY comments added to
  `create_atomic_vec` / `reinterpret_vec`.
- `component_planner.rs`, `instance_context.rs` — document the `unsafe impl
  Send`/`Sync` invariants.