### PR TITLE
Fix (coordinator): validate worker task responses against job phase and assignment (audits issue #36)

### DIFF
--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -2232,6 +2232,94 @@ mod tests {
         assert!(job.proof.is_none(), "no proof may be stored from a rejected response");
     }
 
+    /// Only the designated recurser may report aggregation results. Any other
+    /// assigned worker submitting a `FinalProof` in `Recurse` is rejected.
+    #[tokio::test]
+    async fn test_final_proof_rejected_from_non_recurser() {
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(2, JobPhase::Recurse, |_| {}).await;
+        let (w0_id, w1_id) = (workers[0].0.clone(), workers[1].0.clone());
+
+        // w0 is the recurser with a final task outstanding; w1 tries to answer.
+        {
+            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+            let mut job = entry.write().await;
+            job.agg_worker_id = Some(w0_id.clone());
+            job.agg_task_inflight = Some(zisk_cluster_common::PendingAggTask {
+                proofs: vec![],
+                all_done: true,
+                proof_type: ProofKind::VadcopFinal,
+            });
+        }
+
+        let forged = final_proof_response(&job_id, &w1_id, vec![1, 2, 3]);
+        let err = coordinator.handle_stream_execute_task_response(forged).await.unwrap_err();
+        assert!(
+            matches!(err, CoordinatorError::InvalidRequest(_)),
+            "FinalProof from a non-recurser must be rejected, got {err:?}"
+        );
+
+        let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+        assert_eq!(entry.read().await.state, JobState::Running(JobPhase::Recurse));
+    }
+
+    /// Even the designated recurser cannot replay a final proof once no
+    /// aggregation task is outstanding.
+    #[tokio::test]
+    async fn test_final_proof_rejected_with_no_inflight_agg_task() {
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(1, JobPhase::Recurse, |_| {}).await;
+        let w0_id = workers[0].0.clone();
+
+        {
+            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+            entry.write().await.agg_worker_id = Some(w0_id.clone());
+            // agg_task_inflight stays None.
+        }
+
+        let replayed = final_proof_response(&job_id, &w0_id, vec![1, 2, 3]);
+        let err = coordinator.handle_stream_execute_task_response(replayed).await.unwrap_err();
+        assert!(
+            matches!(err, CoordinatorError::InvalidRequest(_)),
+            "FinalProof with no task in flight must be rejected, got {err:?}"
+        );
+
+        let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+        assert!(entry.read().await.proof.is_none());
+    }
+
+    /// The recurser may not complete the job off an intermediate aggregation
+    /// step — a final proof is only in order for the task carrying `all_done`.
+    #[tokio::test]
+    async fn test_final_proof_rejected_for_intermediate_agg_task() {
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(1, JobPhase::Recurse, |_| {}).await;
+        let w0_id = workers[0].0.clone();
+
+        {
+            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+            let mut job = entry.write().await;
+            job.agg_worker_id = Some(w0_id.clone());
+            job.agg_task_inflight = Some(zisk_cluster_common::PendingAggTask {
+                proofs: vec![],
+                all_done: false,
+                proof_type: ProofKind::VadcopFinal,
+            });
+        }
+
+        let premature = final_proof_response(&job_id, &w0_id, vec![1, 2, 3]);
+        let err = coordinator.handle_stream_execute_task_response(premature).await.unwrap_err();
+        assert!(
+            matches!(err, CoordinatorError::InvalidRequest(_)),
+            "final proof for an intermediate task must be rejected, got {err:?}"
+        );
+
+        let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+        let job = entry.read().await;
+        assert_eq!(job.state, JobState::Running(JobPhase::Recurse));
+        assert!(job.proof.is_none());
+    }
+
     /// The payload/phase mapping, including the two cases that must stay
     /// permissive:
     ///

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -2184,6 +2184,147 @@ mod tests {
         assert!(coordinator.pending_recovery.read().await.contains_key(&w0_id));
     }
 
+    /// Builds a `FinalProof` response with the given proof bytes.
+    fn final_proof_response(
+        job_id: &JobId,
+        worker_id: &WorkerId,
+        proof_data: Vec<u8>,
+    ) -> zisk_cluster_common::ExecuteTaskResponseDto {
+        use zisk_cluster_common::{
+            ExecuteTaskResponseDto, ExecuteTaskResponseResultDataDto, FinalProofDto,
+        };
+        ExecuteTaskResponseDto {
+            job_id: job_id.clone(),
+            worker_id: worker_id.clone(),
+            success: true,
+            error_message: None,
+            result_data: Some(ExecuteTaskResponseResultDataDto::FinalProof(FinalProofDto {
+                proof_data,
+                executed_steps: 0,
+                instances: 0,
+            })),
+            worker_in_recovery: false,
+        }
+    }
+
+    /// The headline vector of audits#36: an assigned worker submitting a
+    /// `FinalProof` while the job is still gathering contributions. Responses
+    /// used to be routed on payload variant alone, so this reached
+    /// `handle_recurser_completion` — which completed the job from any bytes
+    /// that deserialized as a `Proof`, and panicked on
+    /// `agg_worker_id.unwrap()` when they didn't get that far.
+    #[tokio::test]
+    async fn test_final_proof_rejected_in_contributions_phase() {
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(2, JobPhase::Contributions, |_| {}).await;
+        let w0_id = workers[0].0.clone();
+
+        let forged = final_proof_response(&job_id, &w0_id, vec![1, 2, 3]);
+        let err = coordinator.handle_stream_execute_task_response(forged).await.unwrap_err();
+        assert!(
+            matches!(err, CoordinatorError::InvalidRequest(_)),
+            "out-of-phase FinalProof must be rejected, got {err:?}"
+        );
+
+        let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+        let job = entry.read().await;
+        assert_eq!(job.state, JobState::Running(JobPhase::Contributions), "job must not advance");
+        assert!(job.proof.is_none(), "no proof may be stored from a rejected response");
+    }
+
+    /// The payload/phase mapping, including the two cases that must stay
+    /// permissive:
+    ///
+    /// * `Proofs` in `Recurse` — `resolve_recurser_assignment` flips the job to
+    ///   `Recurse` when the *first* worker finishes Phase 2, so the rest report
+    ///   in afterwards. Rejecting these would break every multi-worker job.
+    /// * `Execution` in `Contributions` — execution-only jobs never enter
+    ///   `Running(Execution)`.
+    #[test]
+    fn test_payload_phase_mapping() {
+        use zisk_cluster_common::{
+            ChallengesDto, ContributionsResultDataDto, ExecuteTaskResponseResultDataDto as Payload,
+            ExecutionResultDataDto, FinalProofDto, ProofStarkDto, WitnessInfoDto, WrapResultDto,
+            ZiskExecutorTimeDto,
+        };
+
+        let zisk_executor_time = ZiskExecutorTimeDto {
+            total_duration: 0.0,
+            execution_duration: 0.0,
+            count_and_plan_duration: 0.0,
+            count_and_plan_mo_duration: 0.0,
+            asm_execution_duration: None,
+            task_received_time: 0.0,
+        };
+        let execution = Payload::Execution(ExecutionResultDataDto {
+            instances: 0,
+            executed_steps: 0,
+            zisk_executor_time: zisk_executor_time.clone(),
+            publics: vec![],
+            cost_per_type: StatsCostPerType::default(),
+            plan: Vec::new(),
+        });
+        let challenges = Payload::Challenges(ContributionsResultDataDto {
+            challenges: vec![ChallengesDto { worker_index: 0, airgroup_id: 0, challenge: vec![] }],
+            witness_info: WitnessInfoDto {
+                witness_time: 0.0,
+                publics: vec![],
+                proof_values: vec![],
+                summary_info: String::new(),
+                total_instances: 0,
+            },
+            zisk_executor_time,
+            cost_per_type: StatsCostPerType::default(),
+        });
+        let proofs =
+            Payload::Proofs(vec![ProofStarkDto { airgroup_id: 0, values: vec![], worker_idx: 0 }]);
+        let final_proof = Payload::FinalProof(FinalProofDto {
+            proof_data: vec![],
+            executed_steps: 0,
+            instances: 0,
+        });
+        let wrap = Payload::WrapResult(WrapResultDto { proof_data: vec![] });
+
+        let job_id = JobId::new();
+        let worker_id = WorkerId::from("w0".to_string());
+        let accepted = |phase: JobPhase, execution_only: bool, payload: &Payload| {
+            Coordinator::validate_payload_phase(
+                &JobState::Running(phase),
+                execution_only,
+                payload,
+                &job_id,
+                &worker_id,
+            )
+            .is_ok()
+        };
+
+        // Phase 1 — the two variants are told apart by `execution_only`.
+        assert!(accepted(JobPhase::Contributions, true, &execution));
+        assert!(!accepted(JobPhase::Contributions, false, &execution));
+        assert!(accepted(JobPhase::Contributions, false, &challenges));
+        assert!(!accepted(JobPhase::Contributions, true, &challenges));
+
+        // Phase 2 stragglers report in after the job has moved to Recurse.
+        assert!(accepted(JobPhase::Prove, false, &proofs));
+        assert!(accepted(JobPhase::Recurse, false, &proofs));
+        assert!(!accepted(JobPhase::Contributions, false, &proofs));
+
+        // Phase 3 payloads belong to Recurse only.
+        assert!(accepted(JobPhase::Recurse, false, &final_proof));
+        assert!(!accepted(JobPhase::Prove, false, &final_proof));
+        assert!(!accepted(JobPhase::Contributions, false, &final_proof));
+        assert!(accepted(JobPhase::Recurse, false, &wrap));
+        assert!(!accepted(JobPhase::Contributions, false, &wrap));
+
+        // A job that is not running accepts nothing.
+        for state in [JobState::Created, JobState::Completed] {
+            assert!(Coordinator::validate_payload_phase(
+                &state, false, &proofs, &job_id, &worker_id
+            )
+            .is_err());
+        }
+    }
+
     /// A non-KeepComputing reconnect (here last_known_job_id=None, directive=None)
     /// must drop the stale pending_recovery entry rather than rely on a WRC the
     /// worker won't reliably send. A stray late WRC on the new stream is then a
@@ -2994,10 +3135,6 @@ mod tests {
     /// the window, only to have this handler overwrite it.
     #[tokio::test]
     async fn test_aggregation_completion_on_failed_job_preserves_settingup() {
-        use zisk_cluster_common::{
-            ExecuteTaskResponseDto, ExecuteTaskResponseResultDataDto, FinalProofDto,
-        };
-
         let (coordinator, workers, job_id) =
             setup_coordinator_with_job(1, JobPhase::Recurse, |_| {}).await;
         let w0_id = workers[0].0.clone();
@@ -3017,19 +3154,8 @@ mod tests {
         );
         assert!(coordinator.pending_recovery.read().await.contains_key(&w0_id));
 
-        let response = ExecuteTaskResponseDto {
-            job_id: job_id.clone(),
-            worker_id: w0_id.clone(),
-            success: true,
-            error_message: None,
-            result_data: Some(ExecuteTaskResponseResultDataDto::FinalProof(FinalProofDto {
-                proof_data: vec![1, 2, 3],
-                executed_steps: 0,
-                instances: 0,
-            })),
-            worker_in_recovery: false,
-        };
         // The handler must short-circuit on `is_resolved` and leave state alone.
+        let response = final_proof_response(&job_id, &w0_id, vec![1, 2, 3]);
         let _ = coordinator.handle_recurser_completion(response).await;
 
         assert_eq!(

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -2243,6 +2243,25 @@ mod tests {
         }
     }
 
+    /// Designates `worker_id` as the job's recurser. `inflight_all_done` arms an
+    /// in-flight aggregation task carrying that flag; `None` leaves the slot empty.
+    async fn arm_recurser(
+        coordinator: &Coordinator,
+        job_id: &JobId,
+        worker_id: &WorkerId,
+        inflight_all_done: Option<bool>,
+    ) {
+        let entry = coordinator.jobs.read().await.get(job_id).cloned().unwrap();
+        let mut job = entry.write().await;
+        job.agg_worker_id = Some(worker_id.clone());
+        job.agg_task_inflight =
+            inflight_all_done.map(|all_done| zisk_cluster_common::PendingAggTask {
+                proofs: vec![],
+                all_done,
+                proof_type: ProofKind::VadcopFinal,
+            });
+    }
+
     /// The headline vector of audits#36: an assigned worker submitting a
     /// `FinalProof` while the job is still gathering contributions. Responses
     /// used to be routed on payload variant alone, so this reached
@@ -2277,16 +2296,7 @@ mod tests {
         let (w0_id, w1_id) = (workers[0].0.clone(), workers[1].0.clone());
 
         // w0 is the recurser with a final task outstanding; w1 tries to answer.
-        {
-            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
-            let mut job = entry.write().await;
-            job.agg_worker_id = Some(w0_id.clone());
-            job.agg_task_inflight = Some(zisk_cluster_common::PendingAggTask {
-                proofs: vec![],
-                all_done: true,
-                proof_type: ProofKind::VadcopFinal,
-            });
-        }
+        arm_recurser(&coordinator, &job_id, &w0_id, Some(true)).await;
 
         let forged = final_proof_response(&job_id, &w1_id, vec![1, 2, 3]);
         let err = coordinator.handle_stream_execute_task_response(forged).await.unwrap_err();
@@ -2307,11 +2317,7 @@ mod tests {
             setup_coordinator_with_job(1, JobPhase::Recurse, |_| {}).await;
         let w0_id = workers[0].0.clone();
 
-        {
-            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
-            entry.write().await.agg_worker_id = Some(w0_id.clone());
-            // agg_task_inflight stays None.
-        }
+        arm_recurser(&coordinator, &job_id, &w0_id, None).await;
 
         let replayed = final_proof_response(&job_id, &w0_id, vec![1, 2, 3]);
         let err = coordinator.handle_stream_execute_task_response(replayed).await.unwrap_err();
@@ -2332,16 +2338,7 @@ mod tests {
             setup_coordinator_with_job(1, JobPhase::Recurse, |_| {}).await;
         let w0_id = workers[0].0.clone();
 
-        {
-            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
-            let mut job = entry.write().await;
-            job.agg_worker_id = Some(w0_id.clone());
-            job.agg_task_inflight = Some(zisk_cluster_common::PendingAggTask {
-                proofs: vec![],
-                all_done: false,
-                proof_type: ProofKind::VadcopFinal,
-            });
-        }
+        arm_recurser(&coordinator, &job_id, &w0_id, Some(false)).await;
 
         let premature = final_proof_response(&job_id, &w0_id, vec![1, 2, 3]);
         let err = coordinator.handle_stream_execute_task_response(premature).await.unwrap_err();
@@ -2367,16 +2364,7 @@ mod tests {
             setup_coordinator_with_job(1, JobPhase::Recurse, |_| {}).await;
         let w0_id = workers[0].0.clone();
 
-        {
-            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
-            let mut job = entry.write().await;
-            job.agg_worker_id = Some(w0_id.clone());
-            job.agg_task_inflight = Some(zisk_cluster_common::PendingAggTask {
-                proofs: vec![],
-                all_done: true,
-                proof_type: ProofKind::VadcopFinal,
-            });
-        }
+        arm_recurser(&coordinator, &job_id, &w0_id, Some(true)).await;
 
         let empty_ack = final_proof_response(&job_id, &w0_id, vec![]);
         let err = coordinator.handle_stream_execute_task_response(empty_ack).await.unwrap_err();
@@ -2391,16 +2379,9 @@ mod tests {
         assert!(job.agg_task_inflight.is_some(), "in-flight task must survive a rejected ack");
     }
 
-    /// The payload/phase mapping, including the two cases that must stay
-    /// permissive:
-    ///
-    /// * `Proofs` in `Recurse` — `resolve_recurser_assignment` flips the job to
-    ///   `Recurse` when the *first* worker finishes Phase 2, so the rest report
-    ///   in afterwards. Rejecting these would break every multi-worker job.
-    /// * `Execution` in `Contributions` — execution-only jobs never enter
-    ///   `Running(Execution)`.
-    #[test]
-    fn test_payload_phase_mapping() {
+    /// One sample of every `ExecuteTaskResponseResultDataDto` variant, in
+    /// declaration order: Execution, Challenges, Proofs, FinalProof, WrapResult.
+    fn sample_payloads() -> [zisk_cluster_common::ExecuteTaskResponseResultDataDto; 5] {
         use zisk_cluster_common::{
             ChallengesDto, ContributionsResultDataDto, ExecuteTaskResponseResultDataDto as Payload,
             ExecutionResultDataDto, FinalProofDto, ProofStarkDto, WitnessInfoDto, WrapResultDto,
@@ -2415,34 +2396,121 @@ mod tests {
             asm_execution_duration: None,
             task_received_time: 0.0,
         };
-        let execution = Payload::Execution(ExecutionResultDataDto {
-            instances: 0,
-            executed_steps: 0,
-            zisk_executor_time: zisk_executor_time.clone(),
-            publics: vec![],
-            cost_per_type: StatsCostPerType::default(),
-            plan: Vec::new(),
-        });
-        let challenges = Payload::Challenges(ContributionsResultDataDto {
-            challenges: vec![ChallengesDto { worker_index: 0, airgroup_id: 0, challenge: vec![] }],
-            witness_info: WitnessInfoDto {
-                witness_time: 0.0,
+        [
+            Payload::Execution(ExecutionResultDataDto {
+                instances: 0,
+                executed_steps: 0,
+                zisk_executor_time: zisk_executor_time.clone(),
                 publics: vec![],
-                proof_values: vec![],
-                summary_info: String::new(),
-                total_instances: 0,
-            },
-            zisk_executor_time,
-            cost_per_type: StatsCostPerType::default(),
-        });
-        let proofs =
-            Payload::Proofs(vec![ProofStarkDto { airgroup_id: 0, values: vec![], worker_idx: 0 }]);
-        let final_proof = Payload::FinalProof(FinalProofDto {
-            proof_data: vec![],
-            executed_steps: 0,
-            instances: 0,
-        });
-        let wrap = Payload::WrapResult(WrapResultDto { proof_data: vec![] });
+                cost_per_type: StatsCostPerType::default(),
+                plan: Vec::new(),
+            }),
+            Payload::Challenges(ContributionsResultDataDto {
+                challenges: vec![ChallengesDto {
+                    worker_index: 0,
+                    airgroup_id: 0,
+                    challenge: vec![],
+                }],
+                witness_info: WitnessInfoDto {
+                    witness_time: 0.0,
+                    publics: vec![],
+                    proof_values: vec![],
+                    summary_info: String::new(),
+                    total_instances: 0,
+                },
+                zisk_executor_time,
+                cost_per_type: StatsCostPerType::default(),
+            }),
+            Payload::Proofs(vec![ProofStarkDto { airgroup_id: 0, values: vec![], worker_idx: 0 }]),
+            Payload::FinalProof(FinalProofDto {
+                proof_data: vec![],
+                executed_steps: 0,
+                instances: 0,
+            }),
+            Payload::WrapResult(WrapResultDto { proof_data: vec![] }),
+        ]
+    }
+
+    /// Every payload variant must be rejected end-to-end when it arrives in a
+    /// phase it does not belong to — this exercises all five per-handler
+    /// `validate_response_phase` call sites through the real dispatch path, where
+    /// `test_payload_phase_mapping` only exercises the table in isolation.
+    ///
+    /// It also asserts the rejection lands before any mutation, by requiring the
+    /// worker's state to be untouched afterwards. That is the property a
+    /// mis-placed call breaks: `handle_wrap_completion` originally flipped the
+    /// worker to `Ready` before binding the payload.
+    ///
+    /// The `match` is exhaustive over the payload enum on purpose: adding a
+    /// variant fails to compile until someone supplies a row here, which forces
+    /// them to notice the new handler needs the phase bind too.
+    #[tokio::test]
+    async fn test_every_payload_variant_rejected_out_of_phase() {
+        use zisk_cluster_common::{
+            ExecuteTaskResponseDto, ExecuteTaskResponseResultDataDto as Payload,
+        };
+
+        for payload in sample_payloads() {
+            // A phase this variant is NOT valid in, and the job kind that makes
+            // the mismatch real.
+            let (label, wrong_phase, execution_only) = match &payload {
+                Payload::Execution(_) => ("Execution", JobPhase::Recurse, true),
+                Payload::Challenges(_) => ("Challenges", JobPhase::Recurse, false),
+                Payload::Proofs(_) => ("Proofs", JobPhase::Contributions, false),
+                Payload::FinalProof(_) => ("FinalProof", JobPhase::Contributions, false),
+                Payload::WrapResult(_) => ("WrapResult", JobPhase::Contributions, false),
+            };
+
+            let (coordinator, workers, job_id) =
+                setup_coordinator_with_job(1, wrong_phase.clone(), |_| {}).await;
+            let w0_id = workers[0].0.clone();
+            if execution_only {
+                let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+                entry.write().await.execution_only = true;
+            }
+            let state_before = coordinator.workers_pool.worker_state(&w0_id).await;
+
+            let response = ExecuteTaskResponseDto {
+                job_id: job_id.clone(),
+                worker_id: w0_id.clone(),
+                success: true,
+                error_message: None,
+                result_data: Some(payload),
+                worker_in_recovery: false,
+            };
+            let err = coordinator.handle_stream_execute_task_response(response).await.unwrap_err();
+            assert!(
+                matches!(err, CoordinatorError::InvalidRequest(_)),
+                "{label} in {wrong_phase:?} must be rejected, got {err:?}"
+            );
+
+            assert_eq!(
+                coordinator.workers_pool.worker_state(&w0_id).await,
+                state_before,
+                "{label} rejection must not have mutated worker state"
+            );
+            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+            assert_eq!(
+                entry.read().await.state,
+                JobState::Running(wrong_phase.clone()),
+                "{label} rejection must not have advanced the job"
+            );
+        }
+    }
+
+    /// The payload/phase mapping, including the two cases that must stay
+    /// permissive:
+    ///
+    /// * `Proofs` in `Recurse` — `resolve_recurser_assignment` flips the job to
+    ///   `Recurse` when the *first* worker finishes Phase 2, so the rest report
+    ///   in afterwards. Rejecting these would break every multi-worker job.
+    /// * `Execution` in `Contributions` — execution-only jobs never enter
+    ///   `Running(Execution)`.
+    #[test]
+    fn test_payload_phase_mapping() {
+        use zisk_cluster_common::ExecuteTaskResponseResultDataDto as Payload;
+
+        let [execution, challenges, proofs, final_proof, wrap] = sample_payloads();
 
         let job_id = JobId::new();
         let worker_id = WorkerId::from("w0".to_string());
@@ -3369,10 +3437,7 @@ mod tests {
         // The aggregator path requires `agg_worker_id` to be set on the
         // job. Set it manually to match the worker we'll deliver a result
         // for.
-        {
-            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
-            entry.write().await.agg_worker_id = Some(w0_id.clone());
-        }
+        arm_recurser(&coordinator, &job_id, &w0_id, None).await;
 
         coordinator.fail_job(&job_id, "racing fail").await.unwrap();
         assert_eq!(

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -2207,6 +2207,42 @@ mod tests {
         }
     }
 
+    /// Builds an `Execution` response reporting the given public outputs.
+    fn execution_response(
+        job_id: &JobId,
+        worker_id: &WorkerId,
+        publics: Vec<u64>,
+    ) -> zisk_cluster_common::ExecuteTaskResponseDto {
+        use zisk_cluster_common::{
+            ExecuteTaskResponseDto, ExecuteTaskResponseResultDataDto, ExecutionResultDataDto,
+            ZiskExecutorTimeDto,
+        };
+        ExecuteTaskResponseDto {
+            job_id: job_id.clone(),
+            worker_id: worker_id.clone(),
+            success: true,
+            error_message: None,
+            result_data: Some(ExecuteTaskResponseResultDataDto::Execution(
+                ExecutionResultDataDto {
+                    instances: 1,
+                    executed_steps: 100,
+                    zisk_executor_time: ZiskExecutorTimeDto {
+                        total_duration: 0.0,
+                        execution_duration: 0.0,
+                        count_and_plan_duration: 0.0,
+                        count_and_plan_mo_duration: 0.0,
+                        asm_execution_duration: None,
+                        task_received_time: 0.0,
+                    },
+                    publics,
+                    cost_per_type: StatsCostPerType::default(),
+                    plan: Vec::new(),
+                },
+            )),
+            worker_in_recovery: false,
+        }
+    }
+
     /// The headline vector of audits#36: an assigned worker submitting a
     /// `FinalProof` while the job is still gathering contributions. Responses
     /// used to be routed on payload variant alone, so this reached
@@ -2411,6 +2447,74 @@ mod tests {
             )
             .is_err());
         }
+    }
+
+    /// Execution-only jobs return public outputs with no proof behind them, so
+    /// the coordinator must not pick one worker's word out of a `HashMap` when
+    /// the workers disagree. Both workers here report success; only their
+    /// `publics` differ.
+    #[tokio::test]
+    async fn test_execution_only_publics_mismatch_fails_job() {
+        use zisk_common::ZISK_PUBLICS;
+
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(2, JobPhase::Contributions, |_| {}).await;
+
+        {
+            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+            entry.write().await.execution_only = true;
+        }
+
+        // First worker's result is stored; the job waits for the second.
+        coordinator
+            .handle_stream_execute_task_response(execution_response(
+                &job_id,
+                &workers[0].0,
+                vec![7u64; ZISK_PUBLICS],
+            ))
+            .await
+            .unwrap();
+
+        // Second worker disagrees — completion must be refused, not resolved
+        // from whichever entry `HashMap::values().next()` happened to yield.
+        let err = coordinator
+            .handle_stream_execute_task_response(execution_response(
+                &job_id,
+                &workers[1].0,
+                vec![9u64; ZISK_PUBLICS],
+            ))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, CoordinatorError::WorkerError(_)),
+            "disagreeing public outputs must fail the job, got {err:?}"
+        );
+
+        let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+        assert_eq!(entry.read().await.state, JobState::Failed);
+    }
+
+    /// The agreeing case still completes — the unanimity check must not block
+    /// ordinary execution-only jobs.
+    #[tokio::test]
+    async fn test_execution_only_agreeing_publics_completes_job() {
+        use zisk_common::ZISK_PUBLICS;
+
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(2, JobPhase::Contributions, |_| {}).await;
+
+        {
+            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+            entry.write().await.execution_only = true;
+        }
+
+        for (worker_id, _) in &workers {
+            let response = execution_response(&job_id, worker_id, vec![7u64; ZISK_PUBLICS]);
+            coordinator.handle_stream_execute_task_response(response).await.unwrap();
+        }
+
+        let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+        assert_eq!(entry.read().await.state, JobState::Completed);
     }
 
     /// A non-KeepComputing reconnect (here last_known_job_id=None, directive=None)

--- a/distributed/crates/coordinator/src/coordinator.rs
+++ b/distributed/crates/coordinator/src/coordinator.rs
@@ -2356,6 +2356,41 @@ mod tests {
         assert!(job.proof.is_none());
     }
 
+    /// The mirror of the intermediate-task check: an empty ack is only in order
+    /// for an intermediate step. When the in-flight task is the final one, an
+    /// empty `FinalProof` must not be taken as an intermediate ack — that would
+    /// clear the in-flight slot and pop the queue, leaving the job in `Recurse`
+    /// with nothing outstanding to complete it.
+    #[tokio::test]
+    async fn test_empty_ack_rejected_for_final_agg_task() {
+        let (coordinator, workers, job_id) =
+            setup_coordinator_with_job(1, JobPhase::Recurse, |_| {}).await;
+        let w0_id = workers[0].0.clone();
+
+        {
+            let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+            let mut job = entry.write().await;
+            job.agg_worker_id = Some(w0_id.clone());
+            job.agg_task_inflight = Some(zisk_cluster_common::PendingAggTask {
+                proofs: vec![],
+                all_done: true,
+                proof_type: ProofKind::VadcopFinal,
+            });
+        }
+
+        let empty_ack = final_proof_response(&job_id, &w0_id, vec![]);
+        let err = coordinator.handle_stream_execute_task_response(empty_ack).await.unwrap_err();
+        assert!(
+            matches!(err, CoordinatorError::InvalidRequest(_)),
+            "empty ack for the final task must be rejected, got {err:?}"
+        );
+
+        let entry = coordinator.jobs.read().await.get(&job_id).cloned().unwrap();
+        let job = entry.read().await;
+        assert_eq!(job.state, JobState::Running(JobPhase::Recurse));
+        assert!(job.agg_task_inflight.is_some(), "in-flight task must survive a rejected ack");
+    }
+
     /// The payload/phase mapping, including the two cases that must stay
     /// permissive:
     ///

--- a/distributed/crates/coordinator/src/coordinator/aggregate.rs
+++ b/distributed/crates/coordinator/src/coordinator/aggregate.rs
@@ -51,6 +51,11 @@ impl Coordinator {
             return Err(CoordinatorError::Internal(reason));
         }
 
+        // Bind the payload to the phase mutated below (see
+        // `validate_response_phase`). After the failure branch: a failed
+        // response carries no `result_data` to bind.
+        Self::validate_response_phase(&job, &execute_task_response)?;
+
         // Extract the proof data
         let proof_data = match execute_task_response.result_data {
             Some(ExecuteTaskResponseResultDataDto::FinalProof(final_proof)) => final_proof,
@@ -93,27 +98,29 @@ impl Coordinator {
             )));
         };
 
-        // The shape of the response must match the task that was dispatched: an
+        // The response shape must match the task that was dispatched: an
         // intermediate step acks with empty proof bytes, the final task returns
         // the proof. Both mismatches are acted on destructively if let through —
         // a proof for an intermediate task completes the job from a partial
         // aggregation, and an empty ack for the final task is taken as an
         // intermediate step below, clearing the in-flight slot and popping the
         // queue so nothing outstanding remains to complete the job.
-        if proof_data.proof_data.is_empty() == inflight_all_done {
-            let detail = if inflight_all_done {
-                "an empty ack while the in-flight aggregation task is the final one"
-            } else {
-                "a final proof while the in-flight aggregation task is an intermediate step"
-            };
+        let is_intermediate_ack = proof_data.proof_data.is_empty();
+        if is_intermediate_ack && inflight_all_done {
             return Err(CoordinatorError::InvalidRequest(format!(
-                "Recurser {agg_worker_id} sent {detail} for job {job_id}"
+                "Recurser {agg_worker_id} sent an empty ack for job {job_id} while the in-flight \
+                 aggregation task is the final one"
+            )));
+        }
+        if !is_intermediate_ack && !inflight_all_done {
+            return Err(CoordinatorError::InvalidRequest(format!(
+                "Recurser {agg_worker_id} sent a final proof for job {job_id} while the in-flight \
+                 aggregation task is an intermediate step"
             )));
         }
 
-        // Empty proof_data means this was an intermediate aggregation step.
         // Clear the in-flight slot and dispatch the next queued task, if any.
-        if proof_data.proof_data.is_empty() {
+        if is_intermediate_ack {
             drop(job);
             self.dispatch_next_agg_task(job_id).await?;
             return Ok(());

--- a/distributed/crates/coordinator/src/coordinator/aggregate.rs
+++ b/distributed/crates/coordinator/src/coordinator/aggregate.rs
@@ -61,6 +61,38 @@ impl Coordinator {
             }
         };
 
+        // Workers are untrusted, so bind the response to the dispatched task
+        // before acting on it. Both checks matter, and both must run before the
+        // intermediate-step branch below: without the identity check any
+        // assigned worker can complete the job outright (non-empty proof) or
+        // desynchronise the aggregation queue (empty proof, which pops the next
+        // queued task); without the in-flight check the designated recurser can
+        // replay a result for a task that is no longer outstanding.
+        //
+        // A `None` here is also the panic that `agg_worker_id.unwrap()` used to
+        // take: `agg_worker_id` is set in `resolve_recurser_assignment` during
+        // Phase 2, so a `FinalProof` arriving before that — from a malicious or
+        // merely out-of-order worker — found it unset.
+        let Some(agg_worker_id) = job.agg_worker_id.clone() else {
+            return Err(CoordinatorError::InvalidRequest(format!(
+                "Worker {} sent a FinalProof for job {} before a recurser was assigned",
+                execute_task_response.worker_id, job_id
+            )));
+        };
+        if execute_task_response.worker_id != agg_worker_id {
+            return Err(CoordinatorError::InvalidRequest(format!(
+                "Worker {} sent a FinalProof for job {} but the assigned recurser is {}",
+                execute_task_response.worker_id, job_id, agg_worker_id
+            )));
+        }
+        let Some(inflight_all_done) = job.agg_task_inflight.as_ref().map(|task| task.all_done)
+        else {
+            return Err(CoordinatorError::InvalidRequest(format!(
+                "Recurser {} sent a FinalProof for job {} with no aggregation task in flight",
+                agg_worker_id, job_id
+            )));
+        };
+
         // Empty proof_data means this was an intermediate aggregation step.
         // Clear the in-flight slot and dispatch the next queued task, if any.
         if proof_data.proof_data.is_empty() {
@@ -69,7 +101,16 @@ impl Coordinator {
             return Ok(());
         }
 
-        let agg_worker_id = job.agg_worker_id.as_ref().unwrap().clone();
+        // A final proof is only in order for the task that carried `all_done`;
+        // otherwise the recurser is completing the job from a partial
+        // aggregation.
+        if !inflight_all_done {
+            return Err(CoordinatorError::InvalidRequest(format!(
+                "Recurser {} sent a final proof for job {} while the in-flight aggregation task \
+                 is an intermediate step",
+                agg_worker_id, job_id
+            )));
+        }
 
         self.workers_pool.mark_worker_with_state(&agg_worker_id, WorkerState::Ready).await?;
 

--- a/distributed/crates/coordinator/src/coordinator/aggregate.rs
+++ b/distributed/crates/coordinator/src/coordinator/aggregate.rs
@@ -62,9 +62,9 @@ impl Coordinator {
         };
 
         // Workers are untrusted, so bind the response to the dispatched task
-        // before acting on it. Both checks matter, and both must run before the
-        // intermediate-step branch below: without the identity check any
-        // assigned worker can complete the job outright (non-empty proof) or
+        // before acting on it. Every check below must run before the
+        // intermediate-step branch: without the identity check any assigned
+        // worker can complete the job outright (non-empty proof) or
         // desynchronise the aggregation queue (empty proof, which pops the next
         // queued task); without the in-flight check the designated recurser can
         // replay a result for a task that is no longer outstanding.
@@ -93,23 +93,30 @@ impl Coordinator {
             )));
         };
 
+        // The shape of the response must match the task that was dispatched: an
+        // intermediate step acks with empty proof bytes, the final task returns
+        // the proof. Both mismatches are acted on destructively if let through —
+        // a proof for an intermediate task completes the job from a partial
+        // aggregation, and an empty ack for the final task is taken as an
+        // intermediate step below, clearing the in-flight slot and popping the
+        // queue so nothing outstanding remains to complete the job.
+        if proof_data.proof_data.is_empty() == inflight_all_done {
+            let detail = if inflight_all_done {
+                "an empty ack while the in-flight aggregation task is the final one"
+            } else {
+                "a final proof while the in-flight aggregation task is an intermediate step"
+            };
+            return Err(CoordinatorError::InvalidRequest(format!(
+                "Recurser {agg_worker_id} sent {detail} for job {job_id}"
+            )));
+        }
+
         // Empty proof_data means this was an intermediate aggregation step.
         // Clear the in-flight slot and dispatch the next queued task, if any.
         if proof_data.proof_data.is_empty() {
             drop(job);
             self.dispatch_next_agg_task(job_id).await?;
             return Ok(());
-        }
-
-        // A final proof is only in order for the task that carried `all_done`;
-        // otherwise the recurser is completing the job from a partial
-        // aggregation.
-        if !inflight_all_done {
-            return Err(CoordinatorError::InvalidRequest(format!(
-                "Recurser {} sent a final proof for job {} while the in-flight aggregation task \
-                 is an intermediate step",
-                agg_worker_id, job_id
-            )));
         }
 
         self.workers_pool.mark_worker_with_state(&agg_worker_id, WorkerState::Ready).await?;

--- a/distributed/crates/coordinator/src/coordinator/contributions.rs
+++ b/distributed/crates/coordinator/src/coordinator/contributions.rs
@@ -428,6 +428,9 @@ impl Coordinator {
             return Ok(());
         }
 
+        // Bind the payload to the phase mutated below (see `validate_response_phase`).
+        Self::validate_response_phase(&job, &execute_task_response)?;
+
         // Store Contributions response and extract instances
         let instances = self.store_contribution_response(&mut job, execute_task_response).await?;
         job.instances = Some(instances);
@@ -481,6 +484,9 @@ impl Coordinator {
         if job.state().is_resolved() {
             return Ok(());
         }
+
+        // Bind the payload to the phase mutated below (see `validate_response_phase`).
+        Self::validate_response_phase(&job, &execute_task_response)?;
 
         // Store Execution response and extract instances and executed_steps
         let (instances, executed_steps) =

--- a/distributed/crates/coordinator/src/coordinator/contributions.rs
+++ b/distributed/crates/coordinator/src/coordinator/contributions.rs
@@ -493,6 +493,22 @@ impl Coordinator {
             return Ok(());
         }
 
+        // Execution-only jobs produce no proof, so the public outputs returned
+        // to the client rest entirely on worker honesty. Phase 1 already
+        // cross-checks `publics` across workers (`validate_and_extract_challenges`);
+        // this path had no equivalent and served `results.values().next()` —
+        // arbitrary `HashMap` order — letting a single disagreeing worker decide
+        // the API result. Require unanimity, and take the outputs from the same
+        // check that established it.
+        let public_outputs = match Self::validate_execution_publics(&job) {
+            Ok(publics) => publics.cloned().unwrap_or_default(),
+            Err(reason) => {
+                drop(job);
+                self.fail_job(&job_id, &reason).await?;
+                return Err(CoordinatorError::WorkerError(reason));
+            }
+        };
+
         // Print execution summary
         self.print_execution_summary(&job);
 
@@ -623,19 +639,6 @@ impl Coordinator {
         }
 
         let exec_stats = exec_stats_from_job(&job);
-
-        let public_outputs = job
-            .results
-            .get(&JobPhase::Execution)
-            .and_then(|m| m.values().next())
-            .and_then(|r| {
-                if let JobResultData::Execution(ref e) = r.data {
-                    Some(e.public_outputs.clone())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_default();
 
         // Pairs with launch_proof's record_job_started (execution-only path).
         crate::metrics::record_job_terminal(
@@ -1032,6 +1035,39 @@ impl Coordinator {
 
         // Ensure we have results from all assigned workers before proceeding.
         job.execution_mode.is_simulating() || execution_results_len >= job.workers.len()
+    }
+
+    /// Returns the public outputs every worker agreed on for an execution-only
+    /// job, or a description of the first disagreement.
+    ///
+    /// Which worker supplies the returned value is arbitrary (`HashMap` order)
+    /// and does not matter: it is only returned once all of them match. An empty
+    /// result set yields `None`, as does simulation mode — `job.workers` there
+    /// lists the same physical worker N times, so only one result is ever stored
+    /// and there is nothing to compare against.
+    fn validate_execution_publics(job: &Job) -> Result<Option<&Vec<u8>>, String> {
+        let mut publics = job.results.get(&JobPhase::Execution).into_iter().flatten().filter_map(
+            |(worker_id, result)| match &result.data {
+                JobResultData::Execution(exec) => Some((worker_id, &exec.public_outputs)),
+                _ => None,
+            },
+        );
+
+        let Some((first_worker, first_publics)) = publics.next() else {
+            return Ok(None);
+        };
+
+        if job.execution_mode.is_simulating() {
+            return Ok(Some(first_publics));
+        }
+
+        match publics.find(|(_, other)| *other != first_publics) {
+            Some((worker_id, _)) => Err(format!(
+                "Execution public-output mismatch in job {}: worker {} disagrees with worker {}",
+                job.job_id, worker_id, first_worker
+            )),
+            None => Ok(Some(first_publics)),
+        }
     }
 
     /// Validates Phase 1 results and extracts challenge data with simulation mode handling.

--- a/distributed/crates/coordinator/src/coordinator/contributions.rs
+++ b/distributed/crates/coordinator/src/coordinator/contributions.rs
@@ -1042,9 +1042,11 @@ impl Coordinator {
     ///
     /// Which worker supplies the returned value is arbitrary (`HashMap` order)
     /// and does not matter: it is only returned once all of them match. An empty
-    /// result set yields `None`, as does simulation mode — `job.workers` there
-    /// lists the same physical worker N times, so only one result is ever stored
-    /// and there is nothing to compare against.
+    /// result set yields `None`.
+    ///
+    /// Simulation mode returns the single stored result without comparing:
+    /// `job.workers` there lists the same physical worker N times, so only one
+    /// entry ever exists and there is nothing to disagree with.
     fn validate_execution_publics(job: &Job) -> Result<Option<&Vec<u8>>, String> {
         let mut publics = job.results.get(&JobPhase::Execution).into_iter().flatten().filter_map(
             |(worker_id, result)| match &result.data {

--- a/distributed/crates/coordinator/src/coordinator/prove.rs
+++ b/distributed/crates/coordinator/src/coordinator/prove.rs
@@ -87,6 +87,14 @@ impl Coordinator {
             return Ok(());
         }
 
+        // Bind the payload to the phase mutated below (see
+        // `validate_response_phase`). After `is_resolved`, so a late response for
+        // a resolved job stays a silent no-op rather than an error; and after the
+        // simulation short-circuit above, which bypasses the phase machinery
+        // wholesale (one physical worker stands in for N, and
+        // completion/challenge checks are likewise skipped).
+        Self::validate_response_phase(&job, &execute_task_response)?;
+
         // Store Proof response
         self.store_proof_response(&mut job, execute_task_response).await?;
 

--- a/distributed/crates/coordinator/src/coordinator/prove.rs
+++ b/distributed/crates/coordinator/src/coordinator/prove.rs
@@ -105,27 +105,32 @@ impl Coordinator {
 
         if job.agg_task_inflight.is_none() {
             // Claim the in-flight slot WHILE STILL HOLDING the job write lock,
-            // then send. Claiming after the send (previous code) opened a TOCTOU:
-            // two workers' Prove completions racing through this handler both saw
-            // the slot empty and both dispatched an Aggregate to the recurser —
-            // the duplicate then ran a second concurrent proofman task over the
-            // same GPU streams, corrupting in-flight proofs. On send failure we
-            // clear the slot before propagating, so it cannot get stuck `Some`.
+            // then send. Claiming after the send opened a TOCTOU: two workers'
+            // Prove completions racing through this handler both saw the slot
+            // empty and both dispatched an Aggregate to the recurser — the
+            // duplicate ran a second concurrent proofman task over the same GPU
+            // streams, corrupting in-flight proofs. It also let the recurser reply
+            // before this task could reacquire the lock, which
+            // `handle_recurser_completion` rejects as a final proof with no task
+            // in flight.
+            //
+            // The slot is deliberately left set if the send fails: the queue's
+            // only drain (`dispatch_next_agg_task`, which likewise keeps the slot
+            // on failure) runs off an aggregator ack, so clearing it would orphan
+            // anything that queued during the send window. Keeping it lets
+            // `replay_inflight_agg_task_if_recurser` re-send on reconnect; if the
+            // recurser never returns, the disconnect handler or the phase-3
+            // timeout fails the job.
             job.agg_task_inflight = Some(task.clone());
             drop(job);
-            if let Err(e) = self
-                .send_recurser_task(
-                    &job_id,
-                    &agg_worker_id,
-                    task.proofs.clone(),
-                    task.all_done,
-                    task.proof_type,
-                )
-                .await
-            {
-                job_entry.write().await.agg_task_inflight = None;
-                return Err(e);
-            }
+            self.send_recurser_task(
+                &job_id,
+                &agg_worker_id,
+                task.proofs,
+                task.all_done,
+                task.proof_type,
+            )
+            .await?;
         } else {
             // Task in-flight — queue this one; it will be sent after the ack.
             job.agg_task_queue.push_back(task);

--- a/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
+++ b/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
@@ -4,12 +4,13 @@ use crate::{
     Coordinator,
 };
 use chrono::Utc;
-use std::sync::atomic::Ordering;
+use std::sync::{atomic::Ordering, Arc};
+use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 use zisk_cluster_common::JobState;
 use zisk_cluster_common::{
     CoordinatorMessageDto, ExecuteTaskResponseDto, ExecuteTaskResponseResultDataDto,
-    HeartbeatAckDto, JobId, ReconnectionDirectiveDto, RunAggregateProofsAckDto,
+    HeartbeatAckDto, Job, JobId, JobPhase, ReconnectionDirectiveDto, RunAggregateProofsAckDto,
     SetupAggregationProgramAckDto, SetupProgramAckDto, SetupProgramDto, WorkerErrorDto, WorkerId,
     WorkerReconnectRequestDto, WorkerRegisterRequestDto, WorkerState,
 };
@@ -828,8 +829,10 @@ impl Coordinator {
         &self,
         message: ExecuteTaskResponseDto,
     ) -> CoordinatorResult<()> {
-        // Validate and update heartbeat
-        self.validate_and_update_heartbeat(&message).await?;
+        // Validate and update heartbeat. Hands back the job it resolved to
+        // prove existence and assignment, so the checks below reuse that handle
+        // instead of looking the job up again.
+        let job_entry = self.validate_and_update_heartbeat(&message).await?;
 
         // Late arrival for a resolved job (e.g. `spawn_blocking` finished
         // after `JobCancelled`). The worker is — or shortly will be — parked
@@ -840,11 +843,10 @@ impl Coordinator {
         // defensive-guard against stomping a `Computing(other_live_job, _)`
         // state (which should be unreachable under the parking discipline
         // but is cheap insurance).
-        let job_entry = {
-            let jobs_map = self.jobs.read().await;
-            jobs_map.get(&message.job_id).cloned()
-        };
-        if let Some(job_entry) = job_entry {
+        //
+        // The phase gate below needs the state and job kind, captured here
+        // under the same read lock as the resolved check.
+        let (job_state, execution_only) = {
             let job = job_entry.read().await;
             if job.state().is_resolved() {
                 drop(job);
@@ -886,7 +888,8 @@ impl Coordinator {
                 );
                 return Ok(());
             }
-        }
+            (job.state().clone(), job.execution_only)
+        };
 
         // Handle task failure if needed
         if !message.success {
@@ -899,6 +902,19 @@ impl Coordinator {
                 message.worker_id, message.job_id
             )));
         };
+
+        // Bind the payload to the job's current phase before any handler stores
+        // it or advances the job. Workers are untrusted: dispatching purely on
+        // the payload variant lets any assigned worker drive a job through a
+        // phase it is not in.
+        Self::validate_payload_phase(
+            &job_state,
+            execution_only,
+            result_data,
+            &message.job_id,
+            &message.worker_id,
+        )?;
+
         match result_data {
             ExecuteTaskResponseResultDataDto::Execution(_) => {
                 self.handle_execution_completion(message).await
@@ -920,13 +936,16 @@ impl Coordinator {
 
     /// Validates incoming task response and updates worker heartbeat.
     ///
+    /// Returns the job the response is for, so callers can go straight to it
+    /// rather than repeating the lookup this already did.
+    ///
     /// # Parameters
     ///
     /// * `message` - The task response message from a worker
     async fn validate_and_update_heartbeat(
         &self,
         message: &ExecuteTaskResponseDto,
-    ) -> CoordinatorResult<()> {
+    ) -> CoordinatorResult<Arc<RwLock<Job>>> {
         self.workers_pool.update_last_heartbeat(&message.worker_id).await?;
 
         // Job must exist AND the worker must be assigned to it. Prevents a
@@ -952,6 +971,72 @@ impl Coordinator {
                 message.worker_id, message.job_id
             )));
         }
+        Ok(job_arc)
+    }
+
+    /// Rejects a task response whose payload variant does not belong to the
+    /// job's current phase.
+    ///
+    /// `validate_and_update_heartbeat` only proves the sender is assigned to the
+    /// job; the response is then routed on the payload variant alone. Since
+    /// workers are untrusted, that lets any assigned worker act out of turn —
+    /// most damagingly by completing a job with a `FinalProof` while it is still
+    /// gathering contributions.
+    ///
+    /// Two deliberate asymmetries in the mapping:
+    ///
+    /// * `Proofs` is accepted in `Recurse` as well as `Prove`.
+    ///   `resolve_recurser_assignment` flips the job to `Recurse` as soon as the
+    ///   *first* worker finishes Phase 2, so the remaining workers legitimately
+    ///   report in while the job is already recursing.
+    /// * Execution-only jobs run in `Running(Contributions)` — `JobPhase::Execution`
+    ///   exists only as a `phase_timings` key and is never a job state — so the
+    ///   two Phase-1 variants are told apart by `execution_only`, not by phase.
+    pub(super) fn validate_payload_phase(
+        state: &JobState,
+        execution_only: bool,
+        result_data: &ExecuteTaskResponseResultDataDto,
+        job_id: &JobId,
+        worker_id: &WorkerId,
+    ) -> CoordinatorResult<()> {
+        use ExecuteTaskResponseResultDataDto as Payload;
+
+        let JobState::Running(phase) = state else {
+            let msg = format!(
+                "Worker {worker_id} sent a task response for job {job_id} in state {state}; \
+                 expected a running job"
+            );
+            warn!("{msg}");
+            return Err(CoordinatorError::InvalidRequest(msg));
+        };
+
+        let (variant, accepted, expected) = match result_data {
+            Payload::Execution(_) => (
+                "Execution",
+                execution_only && *phase == JobPhase::Contributions,
+                "Contributions on an execution-only job",
+            ),
+            Payload::Challenges(_) => (
+                "Challenges",
+                !execution_only && *phase == JobPhase::Contributions,
+                "Contributions",
+            ),
+            Payload::Proofs(_) => {
+                ("Proofs", matches!(phase, JobPhase::Prove | JobPhase::Recurse), "Prove or Recurse")
+            }
+            Payload::FinalProof(_) => ("FinalProof", *phase == JobPhase::Recurse, "Recurse"),
+            Payload::WrapResult(_) => ("WrapResult", *phase == JobPhase::Recurse, "Recurse"),
+        };
+
+        if !accepted {
+            let msg = format!(
+                "Worker {worker_id} sent {variant} for job {job_id} in phase {phase:?} \
+                 (execution_only={execution_only}); expected {expected}"
+            );
+            warn!("{msg}");
+            return Err(CoordinatorError::InvalidRequest(msg));
+        }
+
         Ok(())
     }
 

--- a/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
+++ b/distributed/crates/coordinator/src/coordinator/worker_handlers.rs
@@ -843,10 +843,7 @@ impl Coordinator {
         // defensive-guard against stomping a `Computing(other_live_job, _)`
         // state (which should be unreachable under the parking discipline
         // but is cheap insurance).
-        //
-        // The phase gate below needs the state and job kind, captured here
-        // under the same read lock as the resolved check.
-        let (job_state, execution_only) = {
+        {
             let job = job_entry.read().await;
             if job.state().is_resolved() {
                 drop(job);
@@ -888,33 +885,19 @@ impl Coordinator {
                 );
                 return Ok(());
             }
-            (job.state().clone(), job.execution_only)
-        };
+        }
 
         // Handle task failure if needed
         if !message.success {
             return self.handle_task_failure(message).await;
         }
 
-        let Some(result_data) = message.result_data.as_ref() else {
-            return Err(CoordinatorError::InvalidRequest(format!(
-                "Worker {} reported success for job {} without result_data",
-                message.worker_id, message.job_id
-            )));
-        };
+        let result_data = Self::require_result_data(&message)?;
 
-        // Bind the payload to the job's current phase before any handler stores
-        // it or advances the job. Workers are untrusted: dispatching purely on
-        // the payload variant lets any assigned worker drive a job through a
-        // phase it is not in.
-        Self::validate_payload_phase(
-            &job_state,
-            execution_only,
-            result_data,
-            &message.job_id,
-            &message.worker_id,
-        )?;
-
+        // No payload/phase binding here: this function holds no job lock at
+        // dispatch, so a phase read could go stale before the handler mutates.
+        // Each handler calls `validate_response_phase` under the write lock it
+        // acts with.
         match result_data {
             ExecuteTaskResponseResultDataDto::Execution(_) => {
                 self.handle_execution_completion(message).await
@@ -972,6 +955,41 @@ impl Coordinator {
             )));
         }
         Ok(job_arc)
+    }
+
+    /// Binds a task response to the phase of the job as observed under the
+    /// caller's lock.
+    ///
+    /// Handlers call this immediately after taking their job write lock and
+    /// checking `is_resolved`, so the phase they validate against is the phase
+    /// they then mutate. Validating before dispatch instead would read the phase
+    /// through a lock already released — responses from other workers run
+    /// concurrently and can advance the job in between.
+    pub(super) fn validate_response_phase(
+        job: &Job,
+        message: &ExecuteTaskResponseDto,
+    ) -> CoordinatorResult<()> {
+        Self::require_result_data(message).and_then(|result_data| {
+            Self::validate_payload_phase(
+                job.state(),
+                job.execution_only,
+                result_data,
+                &message.job_id,
+                &message.worker_id,
+            )
+        })
+    }
+
+    /// The `result_data` of a success response, or the error for its absence.
+    fn require_result_data(
+        message: &ExecuteTaskResponseDto,
+    ) -> CoordinatorResult<&ExecuteTaskResponseResultDataDto> {
+        message.result_data.as_ref().ok_or_else(|| {
+            CoordinatorError::InvalidRequest(format!(
+                "Worker {} reported success for job {} without result_data",
+                message.worker_id, message.job_id
+            ))
+        })
     }
 
     /// Rejects a task response whose payload variant does not belong to the

--- a/distributed/crates/coordinator/src/coordinator/wrap.rs
+++ b/distributed/crates/coordinator/src/coordinator/wrap.rs
@@ -92,6 +92,15 @@ impl Coordinator {
             return Ok(());
         }
 
+        // Bind the payload to the phase mutated below (see
+        // `validate_response_phase`) — ahead of the `Ready` flip, which is itself
+        // a mutation: a rejected payload must not un-mark a computing worker.
+        // Only for a success response; a failure carries no `result_data` to
+        // bind and is owned by the branch below.
+        if execute_task_response.success {
+            Self::validate_response_phase(&job, &execute_task_response)?;
+        }
+
         self.workers_pool.mark_worker_with_state(worker_id, WorkerState::Ready).await?;
 
         if !execute_task_response.success {


### PR DESCRIPTION
Hardens the coordinator's handling of worker task responses. Reported as 0xPolygonHermez/audits#36, though the fixes stand on their own as protocol robustness: responses were routed on payload variant alone, so an out-of-order or buggy worker could drive a job through a phase it was not in — including completing it.

### Changes

**`817bc30c0` — record the aggregation task in-flight before dispatching**

`handle_proofs_completion` released the job lock, sent the task to the recurser, then recorded it in `agg_task_inflight`. The recurser can reply inside that window. `dispatch_next_agg_task` already recorded before sending, so the two dispatch sites disagreed; this aligns them and clears the slot if the send fails.

**`bd4fd78eb` — bind responses to the job's current phase**

Adds `validate_payload_phase`, an exhaustive payload-variant → allowed-phase table applied before dispatch. Two asymmetries in the table are load-bearing:

- `Proofs` is accepted in `Recurse` as well as `Prove`, because `resolve_recurser_assignment` flips the job to `Recurse` as soon as the *first* worker finishes phase 2 — the rest legitimately report in afterwards. Requiring `Prove` alone would break every multi-worker job.
- Execution-only jobs run in `Running(Contributions)`; `JobPhase::Execution` is only ever a `phase_timings` key, never a job state. The two phase-1 variants are therefore told apart by `execution_only`, not by phase.

Also has `validate_and_update_heartbeat` return the job it already looked up, so the gate reuses that handle instead of repeating the lookup and runs unconditionally rather than behind an `Option` that could skip it.

**`7bb6b3f75` — accept final proofs only from the designated recurser**

`handle_recurser_completion` checked nothing beyond job assignment. It now requires the sender to be `job.agg_worker_id`, an aggregation task to be in flight, and — for a non-empty proof — that task to be the one carrying `all_done`. The first two run before the empty-proof branch, since that branch mutates the aggregation queue.

This also removes a panic: `job.agg_worker_id.as_ref().unwrap()` aborted the connection task whenever a `FinalProof` arrived before a recurser was assigned (`agg_worker_id` is only set during phase 2), reachable by any worker sending out of order.

**`afe503ace` — require agreement on execution-only public outputs**

Execution-only jobs return public outputs with no proof involved. Phase 1 already cross-checks `publics` across workers; this path did not, and served `results.values().next()` — arbitrary `HashMap` order — so one disagreeing worker could decide the result. Now unanimity is required and the outputs are taken from that same check. Skipped in simulation mode, where `job.workers` lists one physical worker N times.
