### PR TITLE
Fix DMA call template: update for correctness on dynamic jump mid-sequence

### DIFF
--- a/cli/src/commands/user/toolchain/support.rs
+++ b/cli/src/commands/user/toolchain/support.rs
@@ -61,7 +61,7 @@ pub(crate) fn is_supported_target() -> bool {
 /// release published for `0xPolygonHermez/rust` (greatest minor, then patch),
 /// instead of whatever `releases/latest` happens to point at. Bump this when the
 /// toolchain moves to a new incompatible major.
-const TOOLCHAIN_MAJOR: u64 = 2;
+const TOOLCHAIN_MAJOR: u64 = 3;
 
 /// Git URL of the ZisK Rust fork, used to list toolchain tags with `git ls-remote`
 /// (git protocol, so no REST API rate limit).

--- a/transpilers/riscv/src/riscv2zisk_context.rs
+++ b/transpilers/riscv/src/riscv2zisk_context.rs
@@ -87,17 +87,19 @@ pub struct Riscv2ZiskContext<'a> {
     /// - read and increment rom.build_counter when creating instructions (i.e. in creation order)
     /// - insert the created instructions in the rom.insts map, using the instruction pc as key
     pub rom: &'a mut ZiskRom,
-
-    // to store csr-port used on CSR instrucction for next instruction
-    pub input_precompile: Option<u32>,
-    pub output_precompile: Option<u32>,
-    // to store register used on CSR instrucction for next instruction as arg1
-    // precompile (arg1, previous_arg1, arg2 || immediate)
-    pub input_precompile_reg: Option<u32>,
-    pub output_precompile_reg: Option<u32>,
+    pub deprecated: bool,
 }
 
-impl Riscv2ZiskContext<'_> {
+impl<'a> Riscv2ZiskContext<'a> {
+    pub fn new(rom: &'a mut ZiskRom) -> Self {
+        Self { rom, deprecated: false }
+    }
+    fn notify_deprecated(&mut self, msg: &str) {
+        if !self.deprecated {
+            // self.deprecated = true;
+            println!("*** DEPRECATED INSTRUCTION: {}. Please update toolchain/zisklibs/ziskos and recompile your code. ***", msg);
+        }
+    }
     /// Converts an input RISCV instruction into a ZisK instruction and stores it into the internal
     /// map.  C instrucions are already expanded into their equivalent RISCV instructions, so we
     /// only have to map them to their corresponding IMA 32-bits equivalent instructions.
@@ -113,25 +115,7 @@ impl Riscv2ZiskContext<'_> {
 
             // I.1. Integer Computational (Register-Register)
             RiscvInstName::Add => {
-                if riscv_instruction.rd == 0
-                    && self.input_precompile == Some(SYSCALL_DMA_MEMCPY_ID as u32)
-                {
-                    self.create_precompiled_op(
-                        riscv_instruction,
-                        "dma_memcpy",
-                        riscv_instruction.rs1,
-                        self.input_precompile_reg.unwrap(),
-                        4,
-                    );
-                } else if self.input_precompile == Some(SYSCALL_DMA_MEMCMP_ID as u32) {
-                    self.create_precompiled_op(
-                        riscv_instruction,
-                        "dma_memcmp",
-                        riscv_instruction.rs1,
-                        self.input_precompile_reg.unwrap(),
-                        4,
-                    );
-                } else if riscv_instruction.rs1 == 0 {
+                if riscv_instruction.rs1 == 0 {
                     if !next_instructions.is_empty() {
                         // rd = rs1(0) + rs2 = rs2 followed by ret
                         self.copyb(riscv_instruction, 4, 2);
@@ -985,11 +969,10 @@ impl Riscv2ZiskContext<'_> {
         rd: u32,
         extended_arg: i64,
         is_rs2_an_imm: bool,
-        inst_size: u64,
+        next_pc: u64,
     ) {
         // inst_size == 8 used for special cases where take arguments of precompiled of
         // next instruction but no need to read again
-        assert!(inst_size == 2 || inst_size == 4 || inst_size == 8 || inst_size == 12);
         let mut zib = ZiskInstBuilder::new_from_riscv(i.rom_address, i.inst_name.to_string());
         zib.src_a("reg", rs1 as u64, false);
         if is_rs2_an_imm {
@@ -999,9 +982,10 @@ impl Riscv2ZiskContext<'_> {
         }
         zib.op(op).unwrap();
         zib.store("reg", rd as i64, false, false);
-        zib.j(extended_arg, inst_size as i64);
+        let jmp_offset = next_pc as i64 - i.rom_address as i64;
+        zib.j(extended_arg, jmp_offset as i64);
         zib.verbose(&format!(
-            "{} r{}, r{}, r{} (precompiled {op} r{rd},r{rs1},r{rs2},{extended_arg} + jmp +{inst_size})",
+            "{} r{}, r{}, r{} (precompiled {op} r{rd},r{rs1},r{rs2},{extended_arg} + jmp +{jmp_offset})",
             i.inst_name,
             i.rd,
             i.rs1,
@@ -1010,20 +994,47 @@ impl Riscv2ZiskContext<'_> {
         zib.build(self.rom);
     }
 
-    /// Creates a Zisk operation that implements a RISC-V precompiles set extra param this
-    /// operation store in fixed address the value.
-    pub fn create_set_precompiles_param_op(&mut self, i: &RiscvInst, rs1: u32, inst_size: u64) {
-        assert!(inst_size == 2 || inst_size == 4);
-        let mut zib = ZiskInstBuilder::new_from_riscv(i.rom_address, i.inst_name.to_string());
-        zib.src_a("imm", 0, false);
-        zib.src_b("reg", rs1 as u64, false);
-        zib.op("copyb").unwrap();
-        zib.store("mem", EXTRA_PARAMS_ADDR as i64, false, false);
-        zib.j(0, inst_size as i64);
-        zib.verbose(&format!("sd r{}, (0x{:X}) (param 0x{:03X})", rs1, EXTRA_PARAMS_ADDR, i.csr));
-        zib.build(self.rom);
-        self.output_precompile = Some(i.csr);
-        self.output_precompile_reg = Some(i.rs1);
+    /// Creates a Zisk precompile call with 3 params, how 3rd param isn't an immediate, it's necessary
+    /// add previous instruccion to set EXTRA_PARAMS_ADDR
+    pub fn create_precompiles_triple_param_op(
+        &mut self,
+        i: &RiscvInst,
+        next_pc: u64,
+        rd: u32,
+        op: &str,
+        rs1: u32,
+        rs2: u32,
+        rs3: u32,
+    ) {
+        // Get addresses of the required instructions to implement this function
+        let rom_address = i.rom_address;
+        let internal_address_1 = self.rom.get_internal_address();
+        {
+            let mut zib = ZiskInstBuilder::new_from_riscv(rom_address, i.inst_name.to_string());
+            zib.src_a("imm", 0, false);
+            zib.src_b("reg", rs3 as u64, false);
+            zib.op("copyb").unwrap();
+            zib.store("mem", EXTRA_PARAMS_ADDR as i64, false, false);
+            zib.set_next_internal_address(internal_address_1);
+            let jump_address = internal_address_1 as i64 - i.rom_address as i64;
+            zib.j(jump_address, jump_address);
+            zib.verbose(&format!(
+                "sd r{}, (0x{:X}) (param 0x{:03X}) 1/2",
+                rs3, EXTRA_PARAMS_ADDR, i.csr
+            ));
+            zib.build(self.rom);
+        }
+        {
+            let mut zib = ZiskInstBuilder::new_internal(internal_address_1, rom_address);
+            zib.src_a("reg", rs1 as u64, false);
+            zib.src_b("reg", rs2 as u64, false);
+            zib.op(op).unwrap();
+            zib.store("reg", rd as i64, false, false);
+            let jump_address = next_pc as i64 - internal_address_1 as i64;
+            zib.j(jump_address, jump_address);
+            zib.verbose(&format!("{} r{}, r{}, r{} 2/2", op, rd, rs1, rs2));
+            zib.build(self.rom);
+        }
     }
 
     // beq rs1, rs2, label
@@ -1709,6 +1720,18 @@ impl Riscv2ZiskContext<'_> {
     /// if that CSR bit is writable.
     pub fn csrrs(&mut self, i: &RiscvInst, next_instructions: &[RiscvInst]) {
         let rom_address = i.rom_address;
+        // Special DMA patterns that can have rd != 0
+        match i.csr as u16 {
+            SYSCALL_DMA_MEMCPY_ID | SYSCALL_DMA_MEMCMP_ID => {
+                assert!(!next_instructions.is_empty());
+                return self.transpile_dma_memcpy_memcmp_pattern(i, next_instructions);
+            }
+            SYSCALL_DMA_MEMSET_ID => {
+                assert!(!next_instructions.is_empty());
+                return self.transpile_dma_memset_pattern(i, next_instructions);
+            }
+            _ => {}
+        }
         if i.rd == i.rs1 {
             if i.rd == 0 {
                 let mut zib = ZiskInstBuilder::new_from_riscv(rom_address, i.inst_name.to_string());
@@ -1767,17 +1790,9 @@ impl Riscv2ZiskContext<'_> {
             }
         } else if i.rd == 0 {
             match i.csr as u16 {
-                SYSCALL_DMA_MEMCPY_ID | SYSCALL_DMA_MEMCMP_ID => {
-                    assert!(!next_instructions.is_empty());
-                    self.transpile_dma_memcpy_memcmp_pattern(i, next_instructions);
-                }
                 SYSCALL_DMA_INPUTCPY_ID => {
                     assert!(!next_instructions.is_empty());
                     self.transpile_dma_inputcpy_pattern(i, next_instructions);
-                }
-                SYSCALL_DMA_MEMSET_ID => {
-                    assert!(!next_instructions.is_empty());
-                    self.transpile_dma_memset_pattern(i, next_instructions);
                 }
                 SYSCALL_PROFILE_ID => {
                     assert!(!next_instructions.is_empty());
@@ -1815,7 +1830,11 @@ impl Riscv2ZiskContext<'_> {
                     zib.verbose(precompiled);
                     // NOTE: if precompiles don't use extended static parameter (jmp_offset1), must be set to 0
                     // to match with that precompiles proves
-                    zib.j(0, 4);
+                    assert!(!next_instructions.is_empty());
+                    let jmp_offset = next_instructions[0].rom_address as i64 - rom_address as i64;
+                    // jmp_offset1 is used for extended static parameter, which is not used in this case
+                    zib.j(0, jmp_offset);
+
                     zib.build(self.rom);
                 }
                 CSR_FCALL_PARAM_ADDR_START..=CSR_FCALL_PARAM_ADDR_END => {
@@ -1830,7 +1849,9 @@ impl Riscv2ZiskContext<'_> {
                         "csrrs 0x{0:X}, rs1={1} => copyb[fcall_param(r{1},{2})]",
                         i.csr, i.rs1, words
                     ));
-                    zib.j(4, 4);
+                    assert!(!next_instructions.is_empty());
+                    let jmp_offset = next_instructions[0].rom_address as i64 - rom_address as i64;
+                    zib.j(jmp_offset, jmp_offset);
                     zib.build(self.rom);
                 }
                 _ => {
@@ -1844,7 +1865,9 @@ impl Riscv2ZiskContext<'_> {
                         "{} r{}, 0x{:x}, r{} # rs!=rd=0",
                         i.inst_name, i.rd, i.csr, i.rs1
                     ));
-                    zib.j(4, 4);
+                    assert!(!next_instructions.is_empty());
+                    let jmp_offset = next_instructions[0].rom_address as i64 - rom_address as i64;
+                    zib.j(jmp_offset, jmp_offset);
                     zib.build(self.rom);
                 }
             }
@@ -1867,7 +1890,9 @@ impl Riscv2ZiskContext<'_> {
                 ));
             }
             zib.store("reg", i.rd as i64, false, false);
-            zib.j(4, 4);
+            assert!(!next_instructions.is_empty());
+            let jmp_offset = next_instructions[0].rom_address as i64 - rom_address as i64;
+            zib.j(jmp_offset, jmp_offset);
             zib.build(self.rom);
         } else if i.csr == SYSCALL_ADD256_ID as u32 {
             let mut zib = ZiskInstBuilder::new_from_riscv(rom_address, i.inst_name.to_string());
@@ -1876,7 +1901,10 @@ impl Riscv2ZiskContext<'_> {
             zib.op("add256").unwrap();
             zib.verbose("add256");
             zib.store("reg", i.rd as i64, false, false);
-            zib.j(0, 4);
+            assert!(!next_instructions.is_empty());
+            let jmp_offset = next_instructions[0].rom_address as i64 - rom_address as i64;
+            // jmp_offset1 is used for extended static parameter, which is not used in this case
+            zib.j(0, jmp_offset);
             zib.build(self.rom);
         } else {
             let internal_address_1 = self.rom.get_internal_address();
@@ -2397,7 +2425,7 @@ impl Riscv2ZiskContext<'_> {
 
     fn transpile_dma_memset_pattern(&mut self, i: &RiscvInst, next_instructions: &[RiscvInst]) {
         if i.imme == 2 {
-            if next_instructions.len() > 1
+            if next_instructions.len() > 2
                 && next_instructions[0].inst_name == RiscvInstName::Addi
                 && next_instructions[1].inst_name == RiscvInstName::Addi
             {
@@ -2412,6 +2440,7 @@ impl Riscv2ZiskContext<'_> {
                 let rs2 = next_instructions[0].imm; // count
                 let rd = next_instructions[0].rd;
                 let fill_byte = next_instructions[1].imm; // fill_byte
+                let next_pc = next_instructions[2].rom_address;
                 assert!((0..=0xFF).contains(&fill_byte));
                 self.create_extended_precompiles_op(
                     i,
@@ -2421,7 +2450,7 @@ impl Riscv2ZiskContext<'_> {
                     rd,
                     fill_byte as i64,
                     true,
-                    12,
+                    next_pc,
                 );
             } else {
                 let next_0 =
@@ -2434,8 +2463,7 @@ impl Riscv2ZiskContext<'_> {
                         i.csr, i.rom_address, next_0, next_1);
             }
         } else if i.imme == 0 {
-            if !next_instructions.is_empty()
-                && next_instructions[0].inst_name == RiscvInstName::Addi
+            if next_instructions.len() > 1 && next_instructions[0].inst_name == RiscvInstName::Addi
             {
                 // xmemset transpilation pattern:
                 //
@@ -2447,6 +2475,8 @@ impl Riscv2ZiskContext<'_> {
                 let rs2 = next_instructions[0].rs1; // count
                 let rd = next_instructions[0].rd;
                 let fill_byte = next_instructions[0].imm; // byte (fill_byte)
+                let next_pc = next_instructions[1].rom_address;
+
                 assert!((0..=0xFF).contains(&fill_byte));
                 self.create_extended_precompiles_op(
                     i,
@@ -2456,7 +2486,7 @@ impl Riscv2ZiskContext<'_> {
                     rd,
                     fill_byte as i64,
                     false,
-                    8,
+                    next_pc,
                 );
             } else {
                 let next_0 =
@@ -2475,34 +2505,80 @@ impl Riscv2ZiskContext<'_> {
         i: &RiscvInst,
         next_instructions: &[RiscvInst],
     ) {
-        if i.imme == 0 && !next_instructions.is_empty() {
-            if next_instructions[0].inst_name == RiscvInstName::Add {
-                // memcpy/memcmp transpilation pattern:
-                //
-                //  csrs  0x81x, reg(src)          ===>  sd reg(count), [EXTRA_PARAM]
-                //  add   rd, reg(dst), reg(count)       memcxx rd, reg(dst), reg(src)
-                //  ..........                           ..........
+        if i.imme == 0 && next_instructions.len() > 1 {
+            let rd = i.rd;
+            let src = i.rs1;
+            let dst = next_instructions[0].rs1;
+            let next_pc = next_instructions[1].rom_address;
 
-                self.create_set_precompiles_param_op(i, next_instructions[0].rs2, 4);
-                return;
+            if next_instructions[0].inst_name == RiscvInstName::Add && next_instructions.len() > 1 {
+                let op =
+                    if i.csr == SYSCALL_DMA_MEMCPY_ID as u32 { "dma_memcpy" } else { "dma_memcmp" };
+                if next_instructions[0].rd == 0 {
+                    // memcpy/memcmp transpilation pattern:
+                    //
+                    //  i:  csrrs  rd, 0x81x, reg(src)          ===>  sd reg(count), [EXTRA_PARAM] ─┐
+                    //                                           [internal_pc]  memcxx rd, reg(dst), reg(src) ─┐
+                    //  n0: add   r0, reg(dst), reg(count)       add   rd, reg(dst), reg(count)                │ jmp
+                    //  n1: ..........                           ..........   <────────────────────────────────┘ next[1]
+                    let count = next_instructions[0].rs2;
+                    self.create_precompiles_triple_param_op(i, next_pc, rd, op, dst, src, count);
+
+                    return;
+                } else {
+                    // DEPRECATED: memcpy/memcmp transpilation pattern:
+                    // memcpy/memcmp transpilation pattern:
+                    //
+                    //  i:  csrs  0x81x, reg(src)          ===>  sd reg(count), [EXTRA_PARAM] ─┐
+                    //                                           [internal_pc]  memcxx rd, reg(dst), reg(src) ─┐
+                    //  n0: addi   rd, reg(dst), reg(count)       add   rd, reg(dst), reg(count)               │ jmp
+                    //  n1: ..........                           ..........   <────────────────────────────────┘ next[1]
+                    self.notify_deprecated(&format!(
+                        "{op} transpilation pattern on pc 0x{:08x}",
+                        i.rom_address
+                    ));
+                    let count = next_instructions[0].rs2;
+                    let rd = next_instructions[0].rd;
+                    self.create_precompiles_triple_param_op(i, next_pc, rd, op, dst, src, count);
+
+                    return;
+                }
             }
             if next_instructions[0].inst_name == RiscvInstName::Addi {
-                // memcpy/memcmp transpilation pattern:
-                //
-                //  csrs  0x81x, reg(src)          ===>  memcxx rd, reg(dst), reg(src), count ─┐
-                //  addi  rd, reg(dst), count            addi rd, reg(dst), count              │ jmp+8
-                //  ..........                           ..........   <────────────────────────┘
-                let rs1 = next_instructions[0].rs1;
-                let rs2 = i.rs1;
-                let rd = next_instructions[0].rd;
-                let count = next_instructions[0].imm as i64; // count
                 let op = if i.csr == SYSCALL_DMA_MEMCPY_ID as u32 {
                     "dma_xmemcpy"
                 } else {
                     "dma_xmemcmp"
                 };
-                self.create_extended_precompiles_op(i, op, rs1, rs2 as u64, rd, count, false, 8);
-                return;
+                if next_instructions[0].rd == 0 {
+                    // memcpy/memcmp transpilation pattern:
+                    //
+                    //  csrs  0x81x, reg(src)          ===>  memcxx rd, reg(dst), reg(src), count ─┐
+                    //  addi  rd, reg(dst), count            addi rd, reg(dst), count              │ jmp+8
+                    //  ..........                           ..........   <────────────────────────┘
+                    let count = next_instructions[0].imm as i64; // count
+                    self.create_extended_precompiles_op(
+                        i, op, dst, src as u64, rd, count, false, next_pc,
+                    );
+                    return;
+                } else {
+                    // DEPRECATED: memcpy/memcmp transpilation pattern:
+                    // memcpy/memcmp transpilation pattern:
+                    //
+                    //  csrs  0x81x, reg(src)          ===>  memcxx rd, reg(dst), reg(src), count ─┐
+                    //  addi  rd, reg(dst), count            addi rd, reg(dst), count              │ jmp+8
+                    //  ..........                           ..........   <────────────────────────┘
+                    let count = next_instructions[0].imm as i64; // count
+                    let rd = next_instructions[0].rd;
+                    self.notify_deprecated(&format!(
+                        "{op} transpilation pattern on pc 0x{:08x}",
+                        i.rom_address
+                    ));
+                    self.create_extended_precompiles_op(
+                        i, op, dst, src as u64, rd, count, false, next_pc,
+                    );
+                    return;
+                }
             }
         }
         let next_0 = next_instructions.first().map(|inst| inst.inst_name.as_str()).unwrap_or("");
@@ -2513,12 +2589,13 @@ impl Riscv2ZiskContext<'_> {
         );
     }
     fn transpile_dma_inputcpy_pattern(&mut self, i: &RiscvInst, next_instructions: &[RiscvInst]) {
-        if i.imme == 0 && !next_instructions.is_empty() {
+        if i.imme == 0 && next_instructions.len() > 1 {
+            let next_pc = next_instructions[1].rom_address;
             if next_instructions[0].inst_name == RiscvInstName::Add {
                 // inputcpy transpilation pattern:
                 //
                 //  csrs  0x815, reg(count)        ===>  inputcpy rd, reg(dst), reg(count) ─┐
-                //  add   rd, reg(dst), reg(count)       addi rd, reg(dst), reg(count)      │ jmp+8
+                //  add   r0, reg(dst), reg(count)       add r0, reg(dst), reg(count)       │ jmp+8
                 //  ..........                           ..........   <─────────────────────┘
                 let rs1 = next_instructions[0].rs1;
                 let rs2 = next_instructions[0].rs2;
@@ -2531,7 +2608,7 @@ impl Riscv2ZiskContext<'_> {
                     rd,
                     0,
                     false,
-                    8,
+                    next_pc,
                 );
                 return;
             }
@@ -2539,12 +2616,21 @@ impl Riscv2ZiskContext<'_> {
                 // inputcpy transpilation pattern:
                 //
                 //  csrs  0x815, reg(dst)          ===>  inputcpy rd, reg(dst), count ────┐
-                //  addi  rd, reg(dst), count            addi rd, reg(dst), count         │ jmp+8
+                //  addi  r0, reg(dst), count            addi r0, reg(dst), count         │ jmp+8
                 //  ..........                           ..........   <───────────────────┘
                 let rs1 = next_instructions[0].rs1;
                 let imm2 = next_instructions[0].imm as u64;
                 let rd = next_instructions[0].rd;
-                self.create_extended_precompiles_op(i, "dma_inputcpy", rs1, imm2, rd, 0, true, 8);
+                self.create_extended_precompiles_op(
+                    i,
+                    "dma_inputcpy",
+                    rs1,
+                    imm2,
+                    rd,
+                    0,
+                    true,
+                    next_pc,
+                );
                 return;
             }
         }
@@ -2556,10 +2642,12 @@ impl Riscv2ZiskContext<'_> {
         );
     }
     fn transpile_profile_pattern(&mut self, i: &RiscvInst, next_instructions: &[RiscvInst]) {
-        assert!(!next_instructions.is_empty());
+        assert!(next_instructions.len() > 1);
         assert!(next_instructions[0].inst_name == RiscvInstName::Addi);
         assert!(next_instructions[0].rd == 0);
         assert!(next_instructions[0].rs1 == 0);
+        let next_pc = next_instructions[1].rom_address;
+
         // profile transpilation pattern:
         //
         //  csrs  0x81A, reg(tag)    ===>  profile x0, reg(tag), imm(cmd_id) ─┐
@@ -2567,7 +2655,7 @@ impl Riscv2ZiskContext<'_> {
         //  ..........                     ..........   <─────────────────────┘
         let rs1 = i.rs1;
         let rs2 = next_instructions[0].imm as u32;
-        self.create_extended_precompiles_op(i, "profile", rs1, rs2 as u64, 0, 0, true, 8);
+        self.create_extended_precompiles_op(i, "profile", rs1, rs2 as u64, 0, 0, true, next_pc);
     }
 
     pub fn create_single_source_register_op(
@@ -2608,13 +2696,7 @@ pub fn add_zisk_code(rom: &mut ZiskRom, addr: u64, data: &[u8], _dma_addrs: (u64
     let riscv_instructions = riscv_interpreter(addr, &code_vector);
 
     // Create a context to convert RISCV instructions to ZisK instructions, using rom.insts
-    let mut ctx = Riscv2ZiskContext {
-        rom,
-        input_precompile: None,
-        output_precompile: None,
-        input_precompile_reg: None,
-        output_precompile_reg: None,
-    };
+    let mut ctx = Riscv2ZiskContext::new(rom);
 
     // For all RISCV instructions
     for (i, riscv_instruction) in riscv_instructions.iter().enumerate() {
@@ -2625,10 +2707,6 @@ pub fn add_zisk_code(rom: &mut ZiskRom, addr: u64, data: &[u8], _dma_addrs: (u64
         let next_instructions = &riscv_instructions[(i + 1)..];
 
         // Convert RICV instruction to ZisK instruction and store it in rom.insts
-        ctx.input_precompile = ctx.output_precompile;
-        ctx.output_precompile = None;
-        ctx.input_precompile_reg = ctx.output_precompile_reg;
-        ctx.output_precompile_reg = None;
         ctx.convert(riscv_instruction, next_instructions);
         //print!("   to: {}", ctx.insts.iter().last().)
     }

--- a/transpilers/riscv/src/riscv2zisk_context.rs
+++ b/transpilers/riscv/src/riscv2zisk_context.rs
@@ -96,7 +96,7 @@ impl<'a> Riscv2ZiskContext<'a> {
     }
     fn notify_deprecated(&mut self, msg: &str) {
         if !self.deprecated {
-            // self.deprecated = true;
+            self.deprecated = true;
             println!("*** DEPRECATED INSTRUCTION: {}. Please update toolchain/zisklibs/ziskos and recompile your code. ***", msg);
         }
     }
@@ -983,7 +983,7 @@ impl<'a> Riscv2ZiskContext<'a> {
         zib.op(op).unwrap();
         zib.store("reg", rd as i64, false, false);
         let jmp_offset = next_pc as i64 - i.rom_address as i64;
-        zib.j(extended_arg, jmp_offset as i64);
+        zib.j(extended_arg, jmp_offset);
         zib.verbose(&format!(
             "{} r{}, r{}, r{} (precompiled {op} r{rd},r{rs1},r{rs2},{extended_arg} + jmp +{jmp_offset})",
             i.inst_name,
@@ -994,8 +994,9 @@ impl<'a> Riscv2ZiskContext<'a> {
         zib.build(self.rom);
     }
 
-    /// Creates a Zisk precompile call with 3 params, how 3rd param isn't an immediate, it's necessary
-    /// add previous instruccion to set EXTRA_PARAMS_ADDR
+    /// Creates a Zisk precompile call with 3 params; since the 3rd param isn't an immediate, it's necessary to
+    /// add the previous instruction to set EXTRA_PARAMS_ADDR
+    #[allow(clippy::too_many_arguments)]
     pub fn create_precompiles_triple_param_op(
         &mut self,
         i: &RiscvInst,

--- a/transpilers/riscv/src/riscv2zisk_context.rs
+++ b/transpilers/riscv/src/riscv2zisk_context.rs
@@ -1032,7 +1032,8 @@ impl<'a> Riscv2ZiskContext<'a> {
             zib.op(op).unwrap();
             zib.store("reg", rd as i64, false, false);
             let jump_address = next_pc as i64 - internal_address_1 as i64;
-            zib.j(jump_address, jump_address);
+            // jmp_offset1 is set to 0 because the it's precompiled and it's used as extended param
+            zib.j(0, jump_address);
             zib.verbose(&format!("{} r{}, r{}, r{} 2/2", op, rd, rs1, rs2));
             zib.build(self.rom);
         }

--- a/transpilers/riscv/src/riscv2zisk_context.rs
+++ b/transpilers/riscv/src/riscv2zisk_context.rs
@@ -97,7 +97,7 @@ impl<'a> Riscv2ZiskContext<'a> {
     fn notify_deprecated(&mut self, msg: &str) {
         if !self.deprecated {
             self.deprecated = true;
-            println!("*** DEPRECATED INSTRUCTION: {}. Please update toolchain/zisklibs/ziskos and recompile your code. ***", msg);
+            eprintln!("*** DEPRECATED INSTRUCTION: {}. Please update toolchain/zisklibs/ziskos and recompile your code. ***", msg);
         }
     }
     /// Converts an input RISCV instruction into a ZisK instruction and stores it into the internal
@@ -2529,7 +2529,6 @@ impl<'a> Riscv2ZiskContext<'a> {
                     return;
                 } else {
                     // DEPRECATED: memcpy/memcmp transpilation pattern:
-                    // memcpy/memcmp transpilation pattern:
                     //
                     //  i:  csrs  0x81x, reg(src)          ===>  sd reg(count), [EXTRA_PARAM] ─┐
                     //                                           [internal_pc]  memcxx rd, reg(dst), reg(src) ─┐
@@ -2565,7 +2564,6 @@ impl<'a> Riscv2ZiskContext<'a> {
                     return;
                 } else {
                     // DEPRECATED: memcpy/memcmp transpilation pattern:
-                    // memcpy/memcmp transpilation pattern:
                     //
                     //  csrs  0x81x, reg(src)          ===>  memcxx rd, reg(dst), reg(src), count ─┐
                     //  addi  rd, reg(dst), count            addi rd, reg(dst), count              │ jmp+8
@@ -2586,7 +2584,7 @@ impl<'a> Riscv2ZiskContext<'a> {
         let next_0 = next_instructions.first().map(|inst| inst.inst_name.as_str()).unwrap_or("");
         panic!(
             "Invalid use of CSR (0x{:03X}) at address 0x{:08x}, must be used as memcpy/memcmp with a \
-                        consecutive add/i (next[0]:{})",
+                        consecutive add/addi (next[0]:{})",
             i.csr, i.rom_address, next_0
         );
     }
@@ -2639,7 +2637,7 @@ impl<'a> Riscv2ZiskContext<'a> {
         let next_0 = next_instructions.first().map(|inst| inst.inst_name.as_str()).unwrap_or("");
         panic!(
             "Invalid use of CSR (0x{:03X}) at address 0x{:08x}, must be used as inputcpy with a \
-                        consecutive add/i (next[0]:{})",
+                        consecutive add/addi (next[0]:{})",
             i.csr, i.rom_address, next_0
         );
     }

--- a/transpilers/riscv/src/riscv2zisk_context.rs
+++ b/transpilers/riscv/src/riscv2zisk_context.rs
@@ -2533,7 +2533,7 @@ impl<'a> Riscv2ZiskContext<'a> {
                     //
                     //  i:  csrs  0x81x, reg(src)          ===>  sd reg(count), [EXTRA_PARAM] ─┐
                     //                                           [internal_pc]  memcxx rd, reg(dst), reg(src) ─┐
-                    //  n0: addi   rd, reg(dst), reg(count)       add   rd, reg(dst), reg(count)               │ jmp
+                    //  n0: add   rd, reg(dst), reg(count)       add   rd, reg(dst), reg(count)                │ jmp
                     //  n1: ..........                           ..........   <────────────────────────────────┘ next[1]
                     self.notify_deprecated(&format!(
                         "{op} transpilation pattern on pc 0x{:08x}",
@@ -2586,7 +2586,7 @@ impl<'a> Riscv2ZiskContext<'a> {
         let next_0 = next_instructions.first().map(|inst| inst.inst_name.as_str()).unwrap_or("");
         panic!(
             "Invalid use of CSR (0x{:03X}) at address 0x{:08x}, must be used as memcpy/memcmp with a \
-                        consecutive addi (next[0]:{})",
+                        consecutive add/i (next[0]:{})",
             i.csr, i.rom_address, next_0
         );
     }
@@ -2639,7 +2639,7 @@ impl<'a> Riscv2ZiskContext<'a> {
         let next_0 = next_instructions.first().map(|inst| inst.inst_name.as_str()).unwrap_or("");
         panic!(
             "Invalid use of CSR (0x{:03X}) at address 0x{:08x}, must be used as inputcpy with a \
-                        consecutive addi (next[0]:{})",
+                        consecutive add/i (next[0]:{})",
             i.csr, i.rom_address, next_0
         );
     }

--- a/ziskos/entrypoint/src/dma.rs
+++ b/ziskos/entrypoint/src/dma.rs
@@ -130,8 +130,8 @@ macro_rules! ziskos_memcmp {
         let v: i64;
         unsafe {
             core::arch::asm!(
-                "csrs {port}, {src}",
-                "addi {res}, {dst}, {size}",
+                "csrrs {res}, {port}, {src}",
+                "addi x0, {dst}, {size}",
                 port = const zisk_definitions::SYSCALL_DMA_MEMCMP_ID,
                 size = const $size,
                 dst = in(reg) $dst.as_ptr(),
@@ -146,8 +146,8 @@ macro_rules! ziskos_memcmp {
         let v: i64;
         unsafe {
             core::arch::asm!(
-                "csrs {port}, {src}",
-                "add {res}, {dst}, {size}",
+                "csrrs {res}, {port}, {src}",
+                "add x0, {dst}, {size}",
                 port = const zisk_definitions::SYSCALL_DMA_MEMCMP_ID,
                 size = in(reg) $size,
                 dst = in(reg) $dst.as_ptr(),

--- a/ziskos/entrypoint/src/dma/memcmp.s
+++ b/ziskos/entrypoint/src/dma/memcmp.s
@@ -6,8 +6,8 @@
         .p2align        4
         .type   memcmp,@function
 memcmp:
-        csrrs   a0,0x814, a1  # Marker: Write count (a2) to CSR 0x814
-        add	x0,a0,a2        
+        csrrs   a0,0x814, a1  # DMA memcmp: result -> a0, src -> a1
+        add	x0,a0,a2      # Marker: dst (a0), count (a2)       
         ret
                
         .size memcmp, .-memcmp

--- a/ziskos/entrypoint/src/dma/memcmp.s
+++ b/ziskos/entrypoint/src/dma/memcmp.s
@@ -6,8 +6,8 @@
         .p2align        4
         .type   memcmp,@function
 memcmp:
-        csrs    0x814, a1  # Marker: Write count (a2) to CSR 0x814
-        add	a0,a0,a2        
+        csrrs   a0,0x814, a1  # Marker: Write count (a2) to CSR 0x814
+        add	x0,a0,a2        
         ret
                
         .size memcmp, .-memcmp


### PR DESCRIPTION
## Summary

This PR changes the DMA calling template (memcpy/memcmp/memset/inputcpy) used between the guest (`ziskos`) and the transpiler.

The DMA pattern is encoded in the guest as **two RISC-V instructions**: a CSR write on the DMA port followed by an `add`/`addi` carrying the remaining arguments. In the previous scheme, the transpiler **replaced the second instruction** with the precompiled DMA call. This was incorrect in one scenario: if a **dynamic jump landed in the middle of the pattern** (directly on the second instruction), execution ran the precompiled call instead of the original `add`/`addi`, producing an unexpected result.

## New scheme

The transpilation is now anchored **entirely on the first instruction** (the CSR write):

- The CSR instruction is expanded into two Zisk instructions: the extra-parameter store, plus the precompiled DMA call placed at an **internal address**, which then jumps directly past the pattern.
- The **second instruction is no longer substituted** — it is only a *marker* that carries arguments for the transpiler. It remains transpiled as a plain RISC-V instruction at its own address, so a dynamic jump landing on it now behaves exactly like a normal program.

The calling template also changes accordingly: the result register moves to the `rd` of the CSR instruction (`csrrs rd, port, src`), and the marker instruction writes to `x0`:

```asm
# new template (memcmp)
csrrs   a0, 0x814, a1     # result in rd, src in rs1
add     x0, a0, a2        # marker: dst, count — plain add if reached directly
```

## Backward compatibility

The legacy template (result in the `rd` of the `add`/`addi`) is still detected and transpiled correctly, but emits a **deprecation warning** asking to update the toolchain/ziskos and recompile.

## Toolchain impact

The DMA memcmp implementation is also **injected into the Rust toolchain**, so this change requires a new toolchain release: `TOOLCHAIN_MAJOR` is bumped from 2 to 3. Guests built with the previous toolchain keep working through the deprecated legacy path.

## Changes

- `transpilers/riscv/src/riscv2zisk_context.rs`: DMA patterns transpiled from the CSR instruction; marker instruction left intact; legacy pattern detection with deprecation notice; jump targets computed from real instruction addresses instead of hardcoded sizes.
- `ziskos/entrypoint/src/dma.rs`: `ziskos_memcmp!` updated to the new template.
- `ziskos/entrypoint/src/dma/memcmp.s`: `memcmp` implementation updated to the new template.
- `cli/src/commands/user/toolchain/support.rs`: `TOOLCHAIN_MAJOR` 2 → 3.
