### PR TITLE
Overlap Main witness computation with ASM minimal-trace execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,7 @@ dependencies = [
  "mem-common",
  "mem-planner-cpp",
  "named-sem",
+ "proofman-starks-lib-c",
  "proofman-util",
  "rayon",
  "thiserror 2.0.19",
@@ -758,9 +759,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -768,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ proofman-common = { git = "https://github.com/0xPolygonHermez/pil2-proofman.git"
 proofman-macros = { git = "https://github.com/0xPolygonHermez/pil2-proofman.git", branch = "pre-develop-1.1.0-alpha" }
 proofman-verifier = { git = "https://github.com/0xPolygonHermez/pil2-proofman.git", branch = "pre-develop-1.1.0-alpha" }
 proofman-util = { git = "https://github.com/0xPolygonHermez/pil2-proofman.git", branch = "pre-develop-1.1.0-alpha" }
+proofman-starks-lib-c = { git = "https://github.com/0xPolygonHermez/pil2-proofman.git", branch = "pre-develop-1.1.0-alpha" }
 pil-std-lib = { git = "https://github.com/0xPolygonHermez/pil2-proofman.git", branch = "pre-develop-1.1.0-alpha" }
 witness = { git = "https://github.com/0xPolygonHermez/pil2-proofman.git", branch = "pre-develop-1.1.0-alpha" }
 fields = { git = "https://github.com/0xPolygonHermez/pil2-proofman.git", branch = "pre-develop-1.1.0-alpha" }

--- a/emulator-asm/asm-runner/Cargo.toml
+++ b/emulator-asm/asm-runner/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 zisk-common = { workspace = true }
 zisk-core = { workspace = true }
 proofman-util = { workspace = true }
+proofman-starks-lib-c = { workspace = true }
 mem-planner-cpp = { workspace = true }
 mem-common = { workspace = true }
 
@@ -33,7 +34,7 @@ named-sem = { workspace = true }
 [features]
 stats = []
 save_mem_plans = []
-cpu-only = ["mem-planner-cpp/cpu-only"]
+cpu-only = ["mem-planner-cpp/cpu-only", "proofman-starks-lib-c/cpu-only"]
 
 [lints.rust]
 # `gpu` is set by build.rs only when CUDA is detected; declare it so the

--- a/emulator-asm/asm-runner/src/asm_mo_runner.rs
+++ b/emulator-asm/asm-runner/src/asm_mo_runner.rs
@@ -372,6 +372,17 @@ impl AsmRunnerMO {
         // In the GPU case no-op since the GPU planner has no background threads
         mem_planner.set_completed();
 
+        // Quiesce the prover's streaming-commit slots before the final GPU
+        // planning phase: that phase is host-paced micro-ops whose latency
+        // amplifies ~40x under concurrent commit kernels, delaying the buffer
+        // release (and everything mem-plan dependent with it). Backend-
+        // dispatched in libstarks: no-op when slots are disabled or on the
+        // CPU backend.
+        #[cfg(gpu)]
+        if gpu_count_and_plan_opt.is_some() {
+            proofman_starks_lib_c::stream_commit_pause_c();
+        }
+
         // GPU path: evaluate metas
         #[cfg(gpu)]
         timer_start_info!(GPU_MOPS_TIME);

--- a/emulator-asm/asm-runner/src/asm_mt_runner.rs
+++ b/emulator-asm/asm-runner/src/asm_mt_runner.rs
@@ -54,6 +54,11 @@ impl AsmRunnerMT {
     }
 
     /// Runs the assembly code in a separate process, collects the MT trace chunks, and generates execution info.
+    ///
+    /// `on_chunk` is called on this thread once per published chunk, in chunk
+    /// order, with every chunk published so far (`idx` is the last) and whether
+    /// `idx` ends the execution. Returning `Err` aborts the run: the ASM
+    /// children are signalled and the error is propagated to the caller.
     #[allow(clippy::too_many_arguments)]
     pub fn run_and_count<F, R>(
         preloaded: &mut MTShmemReader,
@@ -65,7 +70,7 @@ impl AsmRunnerMT {
         _stats: ExecutorStatsHandle,
     ) -> Result<(Vec<Arc<EmuTrace>>, AsmExecutionInfo)>
     where
-        F: FnMut(usize, &[Arc<EmuTrace>], bool),
+        F: FnMut(usize, &[Arc<EmuTrace>], bool) -> Result<()>,
         R: FnOnce() -> Result<()>,
     {
         stats_begin!(_stats, 0, _runner_scope, "ASM_MT_RUNNER", 0);
@@ -171,7 +176,10 @@ impl AsmRunnerMT {
                     let should_exit = emu_trace.end;
 
                     emu_traces.push(emu_trace);
-                    on_chunk(chunk_id.0, &emu_traces, should_exit);
+                    if let Err(e) = on_chunk(chunk_id.0, &emu_traces, should_exit) {
+                        signal_runner_failure();
+                        break Err(e.context("MT chunk callback failed"));
+                    }
 
                     if should_exit {
                         break Ok(0);
@@ -188,11 +196,15 @@ impl AsmRunnerMT {
 
                     signal_runner_failure();
 
-                    if chunk_id.0 == 0 {
-                        break Ok(1);
-                    }
-
-                    break Ok(preloaded.output_shmem.map_header().exit_code);
+                    // The loop only ends cleanly on the chunk flagged `end`, so
+                    // reaching here means the chunk stream was truncated: never
+                    // report success. The header's code is preferred when it says
+                    // the child failed, but an unpopulated (or "fine") header must
+                    // not turn a truncated run into `Ok`.
+                    break Ok(match preloaded.output_shmem.map_header().exit_code {
+                        0 => 1,
+                        exit_code => exit_code,
+                    });
                 }
             }
         };

--- a/emulator-asm/asm-runner/src/asm_mt_runner.rs
+++ b/emulator-asm/asm-runner/src/asm_mt_runner.rs
@@ -65,7 +65,7 @@ impl AsmRunnerMT {
         _stats: ExecutorStatsHandle,
     ) -> Result<(Vec<Arc<EmuTrace>>, AsmExecutionInfo)>
     where
-        F: FnMut(usize, Arc<EmuTrace>),
+        F: FnMut(usize, &[Arc<EmuTrace>], bool),
         R: FnOnce() -> Result<()>,
     {
         stats_begin!(_stats, 0, _runner_scope, "ASM_MT_RUNNER", 0);
@@ -170,8 +170,8 @@ impl AsmRunnerMT {
                     let emu_trace = Arc::new(AsmMTChunk::to_emu_trace(&mut data_ptr));
                     let should_exit = emu_trace.end;
 
-                    on_chunk(chunk_id.0, emu_trace.clone());
                     emu_traces.push(emu_trace);
+                    on_chunk(chunk_id.0, &emu_traces, should_exit);
 
                     if should_exit {
                         break Ok(0);

--- a/emulator-asm/asm-runner/src/asm_mt_runner_stub.rs
+++ b/emulator-asm/asm-runner/src/asm_mt_runner_stub.rs
@@ -38,7 +38,7 @@ impl AsmRunnerMT {
         _: ExecutorStatsHandle,
     ) -> Result<Vec<Arc<EmuTrace>>>
     where
-        F: FnMut(usize, Arc<EmuTrace>),
+        F: FnMut(usize, &[Arc<EmuTrace>], bool) -> Result<()>,
         R: FnOnce() -> Result<()>,
     {
         Err(anyhow::anyhow!("AsmRunnerMT::run_and_count() is not supported on this platform. Only Linux x86_64 is supported."))

--- a/emulator/src/emu.rs
+++ b/emulator/src/emu.rs
@@ -2494,12 +2494,11 @@ impl<'a> Emu<'a> {
     /// Run a slice of the program to generate full traces
     pub fn process_emu_traces<T, DB: DataBusTrait<u64, T>>(
         &mut self,
-        vec_traces: &[EmuTrace],
-        chunk_id: usize,
+        chunk: &EmuTrace,
         data_bus: &mut DB,
     ) {
         // Set initial state
-        let emu_trace_start = &vec_traces[chunk_id].start_state;
+        let emu_trace_start = &chunk.start_state;
         self.ctx.inst_ctx.pc = emu_trace_start.pc;
         self.ctx.inst_ctx.sp = emu_trace_start.sp;
         self.ctx.inst_ctx.step = emu_trace_start.step;
@@ -2510,11 +2509,7 @@ impl<'a> Emu<'a> {
         let mut current_step_idx = 0;
         let mut mem_reads_index: usize = 0;
         loop {
-            if !self.step_emu_traces(
-                &vec_traces[chunk_id].mem_reads,
-                &mut mem_reads_index,
-                data_bus,
-            ) {
+            if !self.step_emu_traces(&chunk.mem_reads, &mut mem_reads_index, data_bus) {
                 break;
             }
 
@@ -2523,7 +2518,7 @@ impl<'a> Emu<'a> {
             }
 
             current_step_idx += 1;
-            if current_step_idx == vec_traces[chunk_id].steps {
+            if current_step_idx == chunk.steps {
                 break;
             }
         }

--- a/emulator/src/emulator.rs
+++ b/emulator/src/emulator.rs
@@ -256,18 +256,17 @@ impl ZiskEmulator {
 
     /// EXPAND phase
     /// Third phase of the witness computation
-    /// I have a
+    /// Replays a single minimal-trace chunk, publishing its operations on the data bus.
     pub fn process_emu_traces<F: PrimeField, T, DB: DataBusTrait<u64, T>>(
         rom: &ZiskRom,
-        min_traces: &[EmuTrace],
-        chunk_id: usize,
+        chunk: &EmuTrace,
         data_bus: &mut DB,
     ) {
         // Create a emulator instance with this rom
         let mut emu = Emu::new_with_memory_data(rom, false);
 
         // Run the emulation
-        emu.process_emu_traces(min_traces, chunk_id, data_bus);
+        emu.process_emu_traces(chunk, data_bus);
     }
 
     /// Finds all files in a directory and returns a vector with their full paths

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
  "mem-common",
  "mem-planner-cpp",
  "named-sem",
+ "proofman-starks-lib-c",
  "proofman-util",
  "rayon",
  "thiserror 2.0.19",
@@ -709,9 +710,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -719,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -1907,6 +1908,7 @@ dependencies = [
  "precomp-big-int",
  "precomp-blake2",
  "precomp-dma",
+ "precomp-evm",
  "precomp-keccakf",
  "precomp-poseidon",
  "precomp-sha256f",
@@ -2025,6 +2027,7 @@ dependencies = [
  "cfg-if",
  "num-bigint",
  "paste",
+ "proofman-starks-lib-c",
  "serde",
 ]
 
@@ -3862,6 +3865,21 @@ dependencies = [
  "proofman-util",
  "rayon",
  "tracing",
+ "zisk-common",
+ "zisk-core",
+ "zisk-pil",
+]
+
+[[package]]
+name = "precomp-evm"
+version = "1.1.0-alpha"
+dependencies = [
+ "clap",
+ "fields",
+ "pil-std-lib",
+ "precompiles-common",
+ "precompiles-helpers",
+ "proofman-common",
  "zisk-common",
  "zisk-core",
  "zisk-pil",

--- a/executor/src/error.rs
+++ b/executor/src/error.rs
@@ -11,7 +11,7 @@ pub enum ExecutorError {
     /// The ASM MT reader delivered a chunk whose index does not extend the
     /// progressive minimal-trace store contiguously (main-witness advancement
     /// relies on in-order delivery).
-    #[error("main advancement: chunk {got} delivered with store at {expected}")]
+    #[error("main advancement: expected next chunk index {expected}, got {got}")]
     ChunkOutOfOrder {
         /// Index the reader delivered.
         got: usize,

--- a/executor/src/error.rs
+++ b/executor/src/error.rs
@@ -8,6 +8,17 @@ use thiserror::Error;
 /// Crate-wide error type for the executor.
 #[derive(Debug, Error)]
 pub enum ExecutorError {
+    /// The ASM MT reader delivered a chunk whose index does not extend the
+    /// progressive minimal-trace store contiguously (main-witness advancement
+    /// relies on in-order delivery).
+    #[error("main advancement: chunk {got} delivered with store at {expected}")]
+    ChunkOutOfOrder {
+        /// Index the reader delivered.
+        got: usize,
+        /// Store length (the only index that extends it contiguously).
+        expected: usize,
+    },
+
     /// The `global_id` referenced by the chunk's plan is missing from the supplied `instances` map.
     #[error("instance not found for global_id={global_id}")]
     InstanceNotFound {

--- a/executor/src/execution.rs
+++ b/executor/src/execution.rs
@@ -126,8 +126,8 @@ impl ExecutionPhase {
                 caller_stats_scope,
                 chunk_hook,
             ),
-            // Rust emulator returns only on completion: the hook is not called
-            // per chunk; the caller's finalize covers all segments instead.
+            // Rust emulator returns only on completion: the hook is never called;
+            // the caller's post-run batch path releases every Main instance.
             None => self.emulator_rust.execute::<F>(zisk_rom, stdin),
         }
     }

--- a/executor/src/execution.rs
+++ b/executor/src/execution.rs
@@ -16,12 +16,15 @@ use fields::PrimeField64;
 use zisk_common::{io::ZiskStdin, AsmExecutionInfo, ExecutorStatsHandle, StatsScope};
 use zisk_core::ZiskRom;
 
-/// Per-chunk callback invoked by the ASM MT reader thread, in chunk order,
-/// as each minimal-trace chunk is published. Used for main-witness
-/// advancement: the executor pushes the chunk into the progressive store and
-/// releases fully-covered Main segments for witness computation while the
-/// emulation is still running. Runs on the reader thread — must be cheap.
-pub type ChunkHook<'a> = Option<&'a dyn Fn(usize, &std::sync::Arc<zisk_common::EmuTrace>)>;
+/// Per-chunk callback invoked by the ASM MT reader thread, in chunk order, as
+/// each minimal-trace chunk is published. Receives every chunk published so far
+/// (`idx` is the last) and whether `idx` ends the execution, which is all the
+/// executor needs to release a Main instance the moment its chunks are complete
+/// — while the emulation is still running. Runs on the reader thread, so it
+/// does real work only on the chunks that complete an instance. Returning `Err`
+/// aborts the ASM run.
+pub type ChunkHook<'a> =
+    Option<&'a dyn Fn(usize, &[Arc<zisk_common::EmuTrace>], bool) -> ExecutorResult<()>>;
 
 /// Phase-1 actor: runs the chosen emulator backend, returns a  [`ExecutionOutput`]
 /// regardless of which backend ran.

--- a/executor/src/execution.rs
+++ b/executor/src/execution.rs
@@ -24,7 +24,7 @@ use zisk_core::ZiskRom;
 /// does real work only on the chunks that complete an instance. Returning `Err`
 /// aborts the ASM run.
 pub type ChunkHook<'a> =
-    Option<&'a dyn Fn(usize, &[Arc<zisk_common::EmuTrace>], bool) -> ExecutorResult<()>>;
+    &'a dyn Fn(usize, &[Arc<zisk_common::EmuTrace>], bool) -> ExecutorResult<()>;
 
 /// Phase-1 actor: runs the chosen emulator backend, returns a  [`ExecutionOutput`]
 /// regardless of which backend ran.

--- a/executor/src/execution.rs
+++ b/executor/src/execution.rs
@@ -16,6 +16,13 @@ use fields::PrimeField64;
 use zisk_common::{io::ZiskStdin, AsmExecutionInfo, ExecutorStatsHandle, StatsScope};
 use zisk_core::ZiskRom;
 
+/// Per-chunk callback invoked by the ASM MT reader thread, in chunk order,
+/// as each minimal-trace chunk is published. Used for main-witness
+/// advancement: the executor pushes the chunk into the progressive store and
+/// releases fully-covered Main segments for witness computation while the
+/// emulation is still running. Runs on the reader thread — must be cheap.
+pub type ChunkHook<'a> = Option<&'a dyn Fn(usize, &std::sync::Arc<zisk_common::EmuTrace>)>;
+
 /// Phase-1 actor: runs the chosen emulator backend, returns a  [`ExecutionOutput`]
 /// regardless of which backend ran.
 pub struct ExecutionPhase {
@@ -95,6 +102,7 @@ impl ExecutionPhase {
 
     /// Runs the active emulator and returns its [`ExecutionOutput`].
     /// `is_first_process` controls ROM-SM ownership on the ASM path.
+    #[allow(clippy::too_many_arguments)]
     pub fn run<F: PrimeField64>(
         &self,
         zisk_rom: &ZiskRom,
@@ -103,6 +111,7 @@ impl ExecutionPhase {
         use_hints: bool,
         stats: &ExecutorStatsHandle,
         caller_stats_scope: &StatsScope,
+        chunk_hook: ChunkHook<'_>,
     ) -> ExecutorResult<ExecutionOutput> {
         match self.asm_emulator() {
             Some(asm) => asm.execute::<F>(
@@ -112,7 +121,10 @@ impl ExecutionPhase {
                 use_hints,
                 stats,
                 caller_stats_scope,
+                chunk_hook,
             ),
+            // Rust emulator returns only on completion: the hook is not called
+            // per chunk; the caller's finalize covers all segments instead.
             None => self.emulator_rust.execute::<F>(zisk_rom, stdin),
         }
     }

--- a/executor/src/execution/asm/emulator.rs
+++ b/executor/src/execution/asm/emulator.rs
@@ -211,10 +211,7 @@ impl EmulatorAsm {
                 // Main-instance advancement: runs on the reader thread, in chunk
                 // order, once the counting task is on its way. Does real work only
                 // on the chunks that complete a Main instance (or end the run).
-                if let Some(hook) = chunk_hook {
-                    hook(idx, emu_traces, last).map_err(anyhow::Error::from)?;
-                }
-                Ok(())
+                chunk_hook(idx, emu_traces, last).map_err(anyhow::Error::from)
             };
 
             let asm_resources = self.transport.resources()?;

--- a/executor/src/execution/asm/emulator.rs
+++ b/executor/src/execution/asm/emulator.rs
@@ -127,6 +127,7 @@ impl EmulatorAsm {
         use_hints: bool,
         stats: &ExecutorStatsHandle,
         _caller_stats_scope: &StatsScope,
+        chunk_hook: crate::ChunkHook<'_>,
     ) -> ExecutorResult<ExecutionOutput> {
         let asm_resources = self.transport.resources()?;
 
@@ -151,7 +152,7 @@ impl EmulatorAsm {
         let supervisor =
             AsmRunnerSupervisor::spawn_on(&asm_resources, self.chunk_size, has_rom_sm, stats);
 
-        let mt_result = self.run_mt_assembly::<F>(zisk_rom, stats);
+        let mt_result = self.run_mt_assembly::<F>(zisk_rom, stats, chunk_hook);
 
         let output = match mt_result {
             Ok((min_traces, counters, pub_outs)) => {
@@ -185,7 +186,9 @@ impl EmulatorAsm {
         &self,
         zisk_rom: &ZiskRom,
         stats: &ExecutorStatsHandle,
-    ) -> ExecutorResult<(Vec<EmuTrace>, CountersChunkMetrics, PubOutsCollector)> {
+        chunk_hook: crate::ChunkHook<'_>,
+    ) -> ExecutorResult<(Vec<std::sync::Arc<EmuTrace>>, CountersChunkMetrics, PubOutsCollector)>
+    {
         stats_begin!(stats, 0, _mt_scope, "RUN_MT_ASSEMBLY", 0);
 
         let processor: MtChunkProcessor<F> = MtChunkProcessor::new();
@@ -197,6 +200,12 @@ impl EmulatorAsm {
         let scope_result: ExecutorResult<_> = rayon::in_place_scope(|scope| {
             let processor_ref = &processor;
             let on_chunk = |idx: usize, emu_trace: std::sync::Arc<EmuTrace>| {
+                // Main-witness advancement: runs on the reader thread, in chunk
+                // order, BEFORE the counting task is spawned. Cheap (store push +
+                // occasional per-segment instance assignment).
+                if let Some(hook) = chunk_hook {
+                    hook(idx, &emu_trace);
+                }
                 let chunk_id = ChunkId(idx);
                 scope.spawn(move |_| {
                     processor_ref.process_chunk(chunk_id, &emu_trace, zisk_rom, stats, mt_scope_id);
@@ -227,16 +236,7 @@ impl EmulatorAsm {
 
         self.asm_execution_info.lock_or_poison("asm_execution_info")?.replace(asm_execution_info);
 
-        // Unwrap the Arc pointers now that all rayon tasks have completed.
-        let emu_traces = emu_traces
-            .into_iter()
-            .map(|arc| {
-                Arc::try_unwrap(arc).map_err(|_| ExecutorError::ArcStillReferenced {
-                    what: "EmuTrace after rayon scope",
-                })
-            })
-            .collect::<ExecutorResult<Vec<_>>>()?;
-
+        // Kept as `Arc`s: the progressive main-witness store shares them.
         let (counters, pub_outs) = processor.finalize()?;
 
         stats_end!(stats, &_mt_scope);

--- a/executor/src/execution/asm/emulator.rs
+++ b/executor/src/execution/asm/emulator.rs
@@ -199,7 +199,8 @@ impl EmulatorAsm {
 
         let scope_result: ExecutorResult<_> = rayon::in_place_scope(|scope| {
             let processor_ref = &processor;
-            let on_chunk = |idx: usize, emu_trace: std::sync::Arc<EmuTrace>| {
+            let on_chunk = |idx: usize, emu_traces: &[std::sync::Arc<EmuTrace>], last: bool| {
+                let emu_trace = emu_traces[idx].clone();
                 // Main-witness advancement: runs on the reader thread, in chunk
                 // order, BEFORE the counting task is spawned. Cheap (store push +
                 // occasional per-segment instance assignment).

--- a/executor/src/execution/asm/emulator.rs
+++ b/executor/src/execution/asm/emulator.rs
@@ -199,18 +199,22 @@ impl EmulatorAsm {
 
         let scope_result: ExecutorResult<_> = rayon::in_place_scope(|scope| {
             let processor_ref = &processor;
-            let on_chunk = |idx: usize, emu_traces: &[std::sync::Arc<EmuTrace>], last: bool| {
+            let on_chunk = |idx: usize,
+                            emu_traces: &[std::sync::Arc<EmuTrace>],
+                            last: bool|
+             -> anyhow::Result<()> {
                 let emu_trace = emu_traces[idx].clone();
-                // Main-witness advancement: runs on the reader thread, in chunk
-                // order, BEFORE the counting task is spawned. Cheap (store push +
-                // occasional per-segment instance assignment).
-                if let Some(hook) = chunk_hook {
-                    hook(idx, &emu_trace);
-                }
                 let chunk_id = ChunkId(idx);
                 scope.spawn(move |_| {
                     processor_ref.process_chunk(chunk_id, &emu_trace, zisk_rom, stats, mt_scope_id);
                 });
+                // Main-instance advancement: runs on the reader thread, in chunk
+                // order, once the counting task is on its way. Does real work only
+                // on the chunks that complete a Main instance (or end the run).
+                if let Some(hook) = chunk_hook {
+                    hook(idx, emu_traces, last).map_err(anyhow::Error::from)?;
+                }
+                Ok(())
             };
 
             let asm_resources = self.transport.resources()?;

--- a/executor/src/execution/asm/stub.rs
+++ b/executor/src/execution/asm/stub.rs
@@ -85,6 +85,7 @@ impl EmulatorAsm {
         _use_hints: bool,
         _stats: &ExecutorStatsHandle,
         _caller_stats_scope: &StatsScope,
+        _chunk_hook: crate::ChunkHook<'_>,
     ) -> ExecutorResult<ExecutionOutput> {
         unsupported()
     }

--- a/executor/src/execution/output.rs
+++ b/executor/src/execution/output.rs
@@ -29,8 +29,9 @@ use crate::CountersChunkMetrics;
 
 /// Uniform return type for all `Emulator<F>` impls.
 pub struct ExecutionOutput {
-    /// Minimal traces produced by the emulator.
-    pub min_traces: Vec<EmuTrace>,
+    /// Minimal traces produced by the emulator (shared with the progressive
+    /// main-witness advancement store, hence `Arc` elements).
+    pub min_traces: Vec<std::sync::Arc<EmuTrace>>,
     /// Device metrics for secondary devices (counter-phase output).
     pub counters: CountersChunkMetrics,
     /// Public outputs accumulated during execution.

--- a/executor/src/execution/output.rs
+++ b/executor/src/execution/output.rs
@@ -18,7 +18,7 @@
 //! On the Rust path the calls yield `vec![]` / `None` instantly; on
 //! the ASM path they join the corresponding runner thread.
 
-use std::thread::JoinHandle;
+use std::{sync::Arc, thread::JoinHandle};
 
 use asm_runner::{AsmRunnerMO, AsmRunnerRH};
 use zisk_common::{EmuTrace, Plan};
@@ -31,7 +31,7 @@ use crate::CountersChunkMetrics;
 pub struct ExecutionOutput {
     /// Minimal traces produced by the emulator (shared with the progressive
     /// main-witness advancement store, hence `Arc` elements).
-    pub min_traces: Vec<std::sync::Arc<EmuTrace>>,
+    pub min_traces: Vec<Arc<EmuTrace>>,
     /// Device metrics for secondary devices (counter-phase output).
     pub counters: CountersChunkMetrics,
     /// Public outputs accumulated during execution.

--- a/executor/src/execution/rust.rs
+++ b/executor/src/execution/rust.rs
@@ -52,6 +52,10 @@ impl EmulatorRust {
         let (counters, pub_outs) = self.count::<F>(zisk_rom, &min_traces)?;
         timer_stop_and_log_info!(COUNT);
 
+        // Wrap once at the boundary: downstream (planning, witness, the
+        // progressive main store) shares chunks as Arcs.
+        let min_traces = min_traces.into_iter().map(std::sync::Arc::new).collect();
+
         Ok(ExecutionOutput {
             min_traces,
             counters,

--- a/executor/src/execution/rust.rs
+++ b/executor/src/execution/rust.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     pub_outs_collector::PubOutsCollector, BackendArtifacts, CountersChunkMetrics, ExecutionOutput,
@@ -54,7 +54,7 @@ impl EmulatorRust {
 
         // Wrap once at the boundary: downstream (planning, witness, the
         // progressive main store) shares chunks as Arcs.
-        let min_traces = min_traces.into_iter().map(std::sync::Arc::new).collect();
+        let min_traces = min_traces.into_iter().map(Arc::new).collect();
 
         Ok(ExecutionOutput {
             min_traces,

--- a/executor/src/executor.rs
+++ b/executor/src/executor.rs
@@ -56,6 +56,24 @@ pub struct PlanSummaryEntry {
 /// The maximum number of steps to execute in the emulator or assembly runner.
 pub(crate) const MAX_NUM_STEPS: u64 = 1 << 36;
 
+/// Appends to the progressive minimal-trace store every chunk it has not seen
+/// yet, up to and including `idx`. `traces` is the emulator's own buffer, so
+/// `traces[idx]` is its last element.
+///
+/// In-order delivery is an invariant of the ASM reader; a chunk that does not
+/// extend the store contiguously is rejected rather than silently skipped.
+fn publish_chunks(
+    store: &mut Vec<Arc<EmuTrace>>,
+    traces: &[Arc<EmuTrace>],
+    idx: usize,
+) -> ExecutorResult<()> {
+    if store.len() > idx {
+        return Err(ExecutorError::ChunkOutOfOrder { got: idx, expected: store.len() });
+    }
+    store.extend_from_slice(&traces[store.len()..=idx]);
+    Ok(())
+}
+
 /// The `ZiskExecutor` struct orchestrates the execution of the ZisK ROM program, managing state
 /// machines, planning, and witness computation.
 pub struct ZiskExecutor<F: PrimeField64> {
@@ -274,31 +292,26 @@ impl<F: PrimeField64> ZiskExecutor<F> {
         // No-op in standalone mode and never called by the Rust emulator; both
         // keep the post-run batch path below.
         let num_within = MainPlanner::traces_per_segment(self.plan.chunk_size())?;
-        let on_chunk = |idx: usize,
-                        traces: &[Arc<EmuTrace>],
-                        is_last: bool|
-         -> ExecutorResult<()> {
-            let Some(witness) = self.witness.as_ref() else { return Ok(()) };
+        let on_chunk =
+            |idx: usize, traces: &[Arc<EmuTrace>], is_last: bool| -> ExecutorResult<()> {
+                let Some(witness) = self.witness.as_ref() else { return Ok(()) };
 
-            // Neither a complete Main instance nor the end of the execution.
-            if (idx + 1) % num_within != 0 && !is_last {
-                return Ok(());
-            }
+                // This chunk neither completes a Main instance nor ends the execution.
+                let Some(segment) = MainPlanner::segment_completed_by(idx, num_within, is_last)
+                else {
+                    return Ok(());
+                };
 
-            {
-                let mut guard = self.state.min_traces.write_or_poison("min_traces")?;
-                let store = guard.get_or_insert_with(Vec::new);
-                if store.len() > idx {
-                    return Err(ExecutorError::ChunkOutOfOrder { got: idx, expected: store.len() });
+                {
+                    let mut guard = self.state.min_traces.write_or_poison("min_traces")?;
+                    publish_chunks(guard.get_or_insert_with(Vec::new), traces, idx)?;
                 }
-                store.extend_from_slice(&traces[store.len()..=idx]);
-            }
 
-            let plan = MainPlanner::plan_segment(idx / num_within, is_last);
-            let assignments =
-                InstanceAssigner::assign_main_instances(registry, global_ids, vec![plan])?;
-            witness.populate_main_instances(registry, &self.state, assignments)
-        };
+                let plan = MainPlanner::plan_segment(segment, is_last);
+                let assignments =
+                    InstanceAssigner::assign_main_instances(registry, global_ids, vec![plan])?;
+                witness.populate_main_instances(registry, &self.state, assignments)
+            };
         let chunk_hook = &on_chunk;
 
         timer_start_info!(COMPUTE_MINIMAL_TRACE);
@@ -599,5 +612,131 @@ impl<F: PrimeField64> WitnessComponent<F> for ZiskExecutor<F> {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sm_main::MainPlanner;
+    use zisk_pil::MainTrace;
+
+    /// `n` distinct chunks — `steps` is used only as an identity marker here.
+    fn chunks(n: usize) -> Vec<Arc<EmuTrace>> {
+        (0..n).map(|i| Arc::new(EmuTrace { steps: i as u64 + 1, ..EmuTrace::default() })).collect()
+    }
+
+    #[test]
+    fn publish_chunks_fills_an_empty_store_up_to_idx() {
+        // First release of a 4-chunk segment: the store catches up in one call.
+        let traces = chunks(4);
+        let mut store = Vec::new();
+        publish_chunks(&mut store, &traces, 3).expect("contiguous");
+        assert_eq!(store.len(), 4);
+        assert!(
+            store.iter().zip(&traces).all(|(a, b)| Arc::ptr_eq(a, b)),
+            "chunks are published in stream order, not cloned or reordered"
+        );
+    }
+
+    #[test]
+    fn publish_chunks_appends_only_the_unseen_tail() {
+        // Segment 1 of a num_within = 2 run: chunks 0..=1 are already published.
+        let traces = chunks(4);
+        let mut store: Vec<Arc<EmuTrace>> = traces[..2].to_vec();
+        publish_chunks(&mut store, &traces, 3).expect("contiguous");
+        assert_eq!(store.len(), 4, "only chunks 2 and 3 were appended");
+        assert!(Arc::ptr_eq(&store[2], &traces[2]));
+        assert!(Arc::ptr_eq(&store[3], &traces[3]));
+    }
+
+    #[test]
+    fn publish_chunks_is_idempotent_per_chunk_index() {
+        // Re-delivering an already-published chunk must not duplicate it.
+        let traces = chunks(2);
+        let mut store = Vec::new();
+        publish_chunks(&mut store, &traces, 1).expect("contiguous");
+        let err = publish_chunks(&mut store, &traces, 1).expect_err("already published");
+        assert!(matches!(err, ExecutorError::ChunkOutOfOrder { got: 1, expected: 2 }));
+        assert_eq!(store.len(), 2, "store is left untouched on rejection");
+    }
+
+    #[test]
+    fn publish_chunks_rejects_a_gap() {
+        // A store at 0 asked to publish chunk 1 would skip chunk 0 — reject instead
+        // of leaving a hole the Main witness would read as the wrong chunk.
+        let traces = chunks(3);
+        let mut store: Vec<Arc<EmuTrace>> = traces[..2].to_vec();
+        let err = publish_chunks(&mut store, &traces, 0).expect_err("goes backwards");
+        assert!(matches!(err, ExecutorError::ChunkOutOfOrder { got: 0, expected: 2 }));
+    }
+
+    /// Replays the hook's decisions over a whole run: for each streamed chunk,
+    /// publish + release when `segment_completed_by` says so. Returns the
+    /// released `(segment, is_last_segment)` pairs and the final store length.
+    fn replay(num_chunks: usize, num_within: usize) -> (Vec<(usize, bool)>, usize) {
+        let traces = chunks(num_chunks);
+        let mut store = Vec::new();
+        let mut released = Vec::new();
+
+        for idx in 0..num_chunks {
+            let is_last = idx == num_chunks - 1;
+            if let Some(segment) = MainPlanner::segment_completed_by(idx, num_within, is_last) {
+                publish_chunks(&mut store, &traces, idx).expect("in-order stream");
+                released.push((segment, is_last));
+            }
+        }
+        (released, store.len())
+    }
+
+    #[test]
+    fn replay_releases_every_segment_exactly_once_and_publishes_every_chunk() {
+        let num_within = MainPlanner::traces_per_segment(CHUNK_SIZE).expect("valid chunk size");
+        assert_eq!(num_within, MainTrace::<()>::NUM_ROWS / CHUNK_SIZE as usize);
+
+        for num_chunks in 1..=(2 * num_within + 1) {
+            let (released, published) = replay(num_chunks, num_within);
+
+            let expected: Vec<usize> = (0..num_chunks.div_ceil(num_within)).collect();
+            assert_eq!(
+                released.iter().map(|(s, _)| *s).collect::<Vec<_>>(),
+                expected,
+                "segments released in order, once each ({num_chunks} chunks)"
+            );
+            assert!(
+                released.iter().rev().skip(1).all(|(_, is_last)| !is_last),
+                "only the final release is flagged as the last segment"
+            );
+            assert_eq!(
+                released.last().map(|(_, is_last)| *is_last),
+                Some(true),
+                "the final segment is always released, partial or not"
+            );
+            assert_eq!(
+                published, num_chunks,
+                "every chunk reaches the store before its segment is released"
+            );
+        }
+    }
+
+    #[test]
+    fn replay_publishes_a_segments_chunks_before_releasing_it() {
+        // The Main witness for segment `s` reads store[s * num_within ..], so the
+        // store must already cover that range at release time.
+        let num_within = 4;
+        let num_chunks = 10;
+        let traces = chunks(num_chunks);
+        let mut store = Vec::new();
+
+        for idx in 0..num_chunks {
+            let is_last = idx == num_chunks - 1;
+            if let Some(segment) = MainPlanner::segment_completed_by(idx, num_within, is_last) {
+                publish_chunks(&mut store, &traces, idx).expect("in-order stream");
+                let start = segment * num_within;
+                let end = if is_last { store.len() } else { start + num_within };
+                assert!(store.len() >= end, "segment {segment} released with a short store");
+                assert!(start < store.len(), "segment {segment} released empty");
+            }
+        }
     }
 }

--- a/executor/src/executor.rs
+++ b/executor/src/executor.rs
@@ -299,7 +299,7 @@ impl<F: PrimeField64> ZiskExecutor<F> {
                 InstanceAssigner::assign_main_instances(registry, global_ids, vec![plan])?;
             witness.populate_main_instances(registry, &self.state, assignments)
         };
-        let chunk_hook: crate::ChunkHook<'_> = Some(&on_chunk);
+        let chunk_hook = &on_chunk;
 
         timer_start_info!(COMPUTE_MINIMAL_TRACE);
         let start_partial = Instant::now();

--- a/executor/src/executor.rs
+++ b/executor/src/executor.rs
@@ -22,14 +22,14 @@ use crate::{
 use fields::PrimeField64;
 use proofman_common::{lease_pool, BufferPool, ProofCtx, ProofmanError, ProofmanResult, SetupCtx};
 use proofman_util::{timer_start_info, timer_stop_and_log_info};
-use sm_main::MainSM;
+use sm_main::{MainPlanner, MainSM};
 use std::{
-    sync::{Arc, RwLock},
+    sync::{atomic::AtomicUsize, atomic::Ordering, Arc, Mutex, RwLock},
     time::Instant,
 };
 use witness::{WitnessComponent, WitnessManager};
 use zisk_common::{
-    io::ZiskStdin, stats_begin, stats_end, AirInstanceCount, BusDeviceMetrics, ChunkId,
+    io::ZiskStdin, stats_begin, stats_end, AirInstanceCount, BusDeviceMetrics, ChunkId, EmuTrace,
     ExecutorStatsHandle, Plan, ZiskExecutorSummary, ZiskExecutorTime,
 };
 use zisk_core::{ZiskRom, CHUNK_SIZE};
@@ -55,6 +55,114 @@ pub struct PlanSummaryEntry {
 
 /// The maximum number of steps to execute in the emulator or assembly runner.
 pub(crate) const MAX_NUM_STEPS: u64 = 1 << 36;
+
+/// Incremental Main-instance advancement: as the ASM emulator streams chunks
+/// (in order, on the MT reader thread), chunks are pushed into the progressive
+/// `state.min_traces` store and every Main segment whose chunks are all
+/// published is planned, assigned and marked witness-ready IMMEDIATELY — so
+/// main witness computation (and its GPU streaming-slot commit) overlaps the
+/// rest of the emulation and the gpu-mops window instead of waiting for
+/// `await_mem_plans`.
+///
+/// A full segment `s` is only released once a chunk BEYOND it exists
+/// (`watermark > (s+1)*num_within`), which is the moment `is_last_segment =
+/// false` becomes a fact rather than a guess. The final (possibly partial)
+/// segment is released by [`Self::finalize`] once the total chunk count is
+/// known. Global-id order is identical to the previous batch path: ROM first
+/// (assigned before the run), then Main segments in order, then secondary.
+struct MainAdvancer<'a, F: PrimeField64> {
+    registry: &'a dyn ProofRegistry,
+    global_ids: &'a RwLock<Vec<usize>>,
+    witness: &'a WitnessPhase<F>,
+    state: &'a ExecutionState<F>,
+    /// Minimal-trace chunks per Main segment.
+    num_within: usize,
+    /// Next segment to release (all below are already assigned + ready).
+    next_segment: AtomicUsize,
+    /// First error hit on the reader thread; checked by `finalize`.
+    error: Mutex<Option<crate::error::ExecutorError>>,
+}
+
+impl<'a, F: PrimeField64> MainAdvancer<'a, F> {
+    fn new(
+        registry: &'a dyn ProofRegistry,
+        global_ids: &'a RwLock<Vec<usize>>,
+        witness: &'a WitnessPhase<F>,
+        state: &'a ExecutionState<F>,
+        num_within: usize,
+    ) -> Self {
+        Self {
+            registry,
+            global_ids,
+            witness,
+            state,
+            num_within,
+            next_segment: AtomicUsize::new(0),
+            error: Mutex::new(None),
+        }
+    }
+
+    /// Per-chunk hook body (reader thread, sequential, chunk order). Errors are
+    /// latched: the run itself is never interrupted, `finalize` surfaces them.
+    fn on_chunk(&self, idx: usize, trace: &Arc<EmuTrace>) {
+        if self.error.lock().map(|g| g.is_some()).unwrap_or(true) {
+            return;
+        }
+        if let Err(e) = self.on_chunk_inner(idx, trace) {
+            *self.error.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(e);
+        }
+    }
+
+    fn on_chunk_inner(&self, idx: usize, trace: &Arc<EmuTrace>) -> ExecutorResult<()> {
+        let watermark = {
+            let mut guard = self.state.min_traces.write_or_poison("min_traces")?;
+            let store = guard.get_or_insert_with(Vec::new);
+            if store.len() != idx {
+                return Err(crate::error::ExecutorError::ChunkOutOfOrder {
+                    got: idx,
+                    expected: store.len(),
+                });
+            }
+            store.push(trace.clone());
+            store.len()
+        };
+
+        // Release every full segment that now has a chunk beyond it.
+        loop {
+            let segment = self.next_segment.load(Ordering::Relaxed);
+            if (segment + 1) * self.num_within >= watermark {
+                break;
+            }
+            self.release_segment(segment, false)?;
+            self.next_segment.store(segment + 1, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+
+    fn release_segment(&self, segment: usize, is_last: bool) -> ExecutorResult<()> {
+        let plan = MainPlanner::plan_segment(segment, is_last);
+        let assignments =
+            InstanceAssigner::assign_main_instances(self.registry, self.global_ids, vec![plan])?;
+        self.witness.populate_main_instances(self.registry, self.state, assignments)
+    }
+
+    /// Releases the remaining segments (at least the final one) and returns the
+    /// total Main instance count. Call after the run, once `num_chunks` is final.
+    fn finalize(&self, num_chunks: usize) -> ExecutorResult<usize> {
+        if let Some(e) = self.error.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take()
+        {
+            return Err(e);
+        }
+        let total = num_chunks.div_ceil(self.num_within);
+        let mut segment = self.next_segment.load(Ordering::Relaxed);
+        while segment < total {
+            self.release_segment(segment, segment == total - 1)?;
+            segment += 1;
+        }
+        self.next_segment.store(segment, Ordering::Relaxed);
+        Ok(total)
+    }
+}
 
 /// The `ZiskExecutor` struct orchestrates the execution of the ZisK ROM program, managing state
 /// machines, planning, and witness computation.
@@ -255,8 +363,34 @@ impl<F: PrimeField64> ZiskExecutor<F> {
         }
 
         // ────────────────────────────────────────────────────────────
-        // Phase 1.1: Emulate
+        // Phase 1.1: Emulate (+ incremental Main advancement)
         // ────────────────────────────────────────────────────────────
+        // ROM instance is assigned BEFORE the run so the global-id sequence
+        // (ROM, Main segments in order, secondary) is identical to the old
+        // batch path while Main segments are now assigned mid-emulation.
+        InstanceAssigner::assign_rom_instance(registry)?;
+
+        // Main advancement: witness mode only (standalone keeps the batch path).
+        let advancer = match self.witness.as_ref() {
+            Some(witness) => Some(MainAdvancer::new(
+                registry,
+                global_ids,
+                witness,
+                &self.state,
+                MainPlanner::traces_per_segment(self.plan.chunk_size())?,
+            )),
+            None => None,
+        };
+        if advancer.is_some() {
+            // Progressive store: the hook fills it chunk by chunk.
+            *self.state.min_traces.write_or_poison("min_traces")? = Some(Vec::new());
+        }
+        let chunk_hook_closure = advancer
+            .as_ref()
+            .map(|adv| move |idx: usize, trace: &Arc<EmuTrace>| adv.on_chunk(idx, trace));
+        let chunk_hook: crate::ChunkHook<'_> =
+            chunk_hook_closure.as_ref().map(|h| h as &dyn Fn(usize, &Arc<EmuTrace>));
+
         timer_start_info!(COMPUTE_MINIMAL_TRACE);
         let start_partial = Instant::now();
 
@@ -269,6 +403,7 @@ impl<F: PrimeField64> ZiskExecutor<F> {
             self.state.use_hints.load(std::sync::atomic::Ordering::SeqCst),
             &self.state.stats,
             &_exec_scope,
+            chunk_hook,
         )?;
 
         let execution_duration = start_partial.elapsed();
@@ -282,16 +417,26 @@ impl<F: PrimeField64> ZiskExecutor<F> {
         let crate::ExecutionOutput { min_traces, mut counters, pub_outs, mut backend, .. } = output;
         let num_chunks = min_traces.len();
 
-        InstanceAssigner::assign_rom_instance(registry)?;
-        let main_plans = self.plan.run_main(&min_traces, &self.state.stats, &_exec_scope)?;
+        // The store must hold every chunk BEFORE the final segment is released
+        // (its witness computation reads the tail). Idempotent when the hook
+        // already filled it progressively; the whole vector on the Rust path.
         *self.state.min_traces.write_or_poison("min_traces")? = Some(min_traces);
 
-        let main_assignments =
-            InstanceAssigner::assign_main_instances(registry, global_ids, main_plans)?;
-        let main_instances_count = main_assignments.len();
-        if let Some(witness) = self.witness.as_ref() {
-            witness.populate_main_instances(registry, &self.state, main_assignments)?;
-        }
+        let main_instances_count = match advancer.as_ref() {
+            // Releases the remaining segments (at least the final one) and
+            // surfaces any error latched on the reader thread.
+            Some(adv) => adv.finalize(num_chunks)?,
+            None => {
+                let main_plans = self.plan.run_main(num_chunks, &self.state.stats, &_exec_scope)?;
+                let main_assignments =
+                    InstanceAssigner::assign_main_instances(registry, global_ids, main_plans)?;
+                let count = main_assignments.len();
+                if let Some(witness) = self.witness.as_ref() {
+                    witness.populate_main_instances(registry, &self.state, main_assignments)?;
+                }
+                count
+            }
+        };
 
         // ────────────────────────────────────────────────────────────
         // Phase 1.3: Plan secondary, await async, configure + populate (witness only)

--- a/executor/src/executor.rs
+++ b/executor/src/executor.rs
@@ -24,7 +24,7 @@ use proofman_common::{lease_pool, BufferPool, ProofCtx, ProofmanError, ProofmanR
 use proofman_util::{timer_start_info, timer_stop_and_log_info};
 use sm_main::{MainPlanner, MainSM};
 use std::{
-    sync::{atomic::AtomicUsize, atomic::Ordering, Arc, Mutex, RwLock},
+    sync::{Arc, RwLock},
     time::Instant,
 };
 use witness::{WitnessComponent, WitnessManager};
@@ -34,7 +34,7 @@ use zisk_common::{
 };
 use zisk_core::{ZiskRom, CHUNK_SIZE};
 
-use crate::error::{ExecutorResult, RwLockExt};
+use crate::error::{ExecutorError, ExecutorResult, RwLockExt};
 
 /// `(chunk_id, metrics)` pair — the per-chunk device-metrics output
 /// produced by counter-phase processing.
@@ -55,114 +55,6 @@ pub struct PlanSummaryEntry {
 
 /// The maximum number of steps to execute in the emulator or assembly runner.
 pub(crate) const MAX_NUM_STEPS: u64 = 1 << 36;
-
-/// Incremental Main-instance advancement: as the ASM emulator streams chunks
-/// (in order, on the MT reader thread), chunks are pushed into the progressive
-/// `state.min_traces` store and every Main segment whose chunks are all
-/// published is planned, assigned and marked witness-ready IMMEDIATELY — so
-/// main witness computation (and its GPU streaming-slot commit) overlaps the
-/// rest of the emulation and the gpu-mops window instead of waiting for
-/// `await_mem_plans`.
-///
-/// A full segment `s` is only released once a chunk BEYOND it exists
-/// (`watermark > (s+1)*num_within`), which is the moment `is_last_segment =
-/// false` becomes a fact rather than a guess. The final (possibly partial)
-/// segment is released by [`Self::finalize`] once the total chunk count is
-/// known. Global-id order is identical to the previous batch path: ROM first
-/// (assigned before the run), then Main segments in order, then secondary.
-struct MainAdvancer<'a, F: PrimeField64> {
-    registry: &'a dyn ProofRegistry,
-    global_ids: &'a RwLock<Vec<usize>>,
-    witness: &'a WitnessPhase<F>,
-    state: &'a ExecutionState<F>,
-    /// Minimal-trace chunks per Main segment.
-    num_within: usize,
-    /// Next segment to release (all below are already assigned + ready).
-    next_segment: AtomicUsize,
-    /// First error hit on the reader thread; checked by `finalize`.
-    error: Mutex<Option<crate::error::ExecutorError>>,
-}
-
-impl<'a, F: PrimeField64> MainAdvancer<'a, F> {
-    fn new(
-        registry: &'a dyn ProofRegistry,
-        global_ids: &'a RwLock<Vec<usize>>,
-        witness: &'a WitnessPhase<F>,
-        state: &'a ExecutionState<F>,
-        num_within: usize,
-    ) -> Self {
-        Self {
-            registry,
-            global_ids,
-            witness,
-            state,
-            num_within,
-            next_segment: AtomicUsize::new(0),
-            error: Mutex::new(None),
-        }
-    }
-
-    /// Per-chunk hook body (reader thread, sequential, chunk order). Errors are
-    /// latched: the run itself is never interrupted, `finalize` surfaces them.
-    fn on_chunk(&self, idx: usize, trace: &Arc<EmuTrace>) {
-        if self.error.lock().map(|g| g.is_some()).unwrap_or(true) {
-            return;
-        }
-        if let Err(e) = self.on_chunk_inner(idx, trace) {
-            *self.error.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(e);
-        }
-    }
-
-    fn on_chunk_inner(&self, idx: usize, trace: &Arc<EmuTrace>) -> ExecutorResult<()> {
-        let watermark = {
-            let mut guard = self.state.min_traces.write_or_poison("min_traces")?;
-            let store = guard.get_or_insert_with(Vec::new);
-            if store.len() != idx {
-                return Err(crate::error::ExecutorError::ChunkOutOfOrder {
-                    got: idx,
-                    expected: store.len(),
-                });
-            }
-            store.push(trace.clone());
-            store.len()
-        };
-
-        // Release every full segment that now has a chunk beyond it.
-        loop {
-            let segment = self.next_segment.load(Ordering::Relaxed);
-            if (segment + 1) * self.num_within >= watermark {
-                break;
-            }
-            self.release_segment(segment, false)?;
-            self.next_segment.store(segment + 1, Ordering::Relaxed);
-        }
-        Ok(())
-    }
-
-    fn release_segment(&self, segment: usize, is_last: bool) -> ExecutorResult<()> {
-        let plan = MainPlanner::plan_segment(segment, is_last);
-        let assignments =
-            InstanceAssigner::assign_main_instances(self.registry, self.global_ids, vec![plan])?;
-        self.witness.populate_main_instances(self.registry, self.state, assignments)
-    }
-
-    /// Releases the remaining segments (at least the final one) and returns the
-    /// total Main instance count. Call after the run, once `num_chunks` is final.
-    fn finalize(&self, num_chunks: usize) -> ExecutorResult<usize> {
-        if let Some(e) = self.error.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take()
-        {
-            return Err(e);
-        }
-        let total = num_chunks.div_ceil(self.num_within);
-        let mut segment = self.next_segment.load(Ordering::Relaxed);
-        while segment < total {
-            self.release_segment(segment, segment == total - 1)?;
-            segment += 1;
-        }
-        self.next_segment.store(segment, Ordering::Relaxed);
-        Ok(total)
-    }
-}
 
 /// The `ZiskExecutor` struct orchestrates the execution of the ZisK ROM program, managing state
 /// machines, planning, and witness computation.
@@ -370,26 +262,44 @@ impl<F: PrimeField64> ZiskExecutor<F> {
         // batch path while Main segments are now assigned mid-emulation.
         InstanceAssigner::assign_rom_instance(registry)?;
 
-        // Main advancement: witness mode only (standalone keeps the batch path).
-        let advancer = match self.witness.as_ref() {
-            Some(witness) => Some(MainAdvancer::new(
-                registry,
-                global_ids,
-                witness,
-                &self.state,
-                MainPlanner::traces_per_segment(self.plan.chunk_size())?,
-            )),
-            None => None,
+        // Incremental Main-instance advancement. The ASM MT reader calls this on
+        // this thread, in chunk order: as soon as a chunk completes a Main
+        // instance — or ends the execution — that instance's chunks are published
+        // to `state.min_traces` and the instance is planned, assigned and marked
+        // witness-ready, so main witness computation (and its GPU streaming-slot
+        // commit) overlaps the rest of the emulation instead of waiting for the
+        // run to finish. Global-id order is unchanged: ROM (assigned above), then
+        // Main segments in order, then secondary.
+        //
+        // No-op in standalone mode and never called by the Rust emulator; both
+        // keep the post-run batch path below.
+        let num_within = MainPlanner::traces_per_segment(self.plan.chunk_size())?;
+        let on_chunk = |idx: usize,
+                        traces: &[Arc<EmuTrace>],
+                        is_last: bool|
+         -> ExecutorResult<()> {
+            let Some(witness) = self.witness.as_ref() else { return Ok(()) };
+
+            // Neither a complete Main instance nor the end of the execution.
+            if (idx + 1) % num_within != 0 && !is_last {
+                return Ok(());
+            }
+
+            {
+                let mut guard = self.state.min_traces.write_or_poison("min_traces")?;
+                let store = guard.get_or_insert_with(Vec::new);
+                if store.len() > idx {
+                    return Err(ExecutorError::ChunkOutOfOrder { got: idx, expected: store.len() });
+                }
+                store.extend_from_slice(&traces[store.len()..=idx]);
+            }
+
+            let plan = MainPlanner::plan_segment(idx / num_within, is_last);
+            let assignments =
+                InstanceAssigner::assign_main_instances(registry, global_ids, vec![plan])?;
+            witness.populate_main_instances(registry, &self.state, assignments)
         };
-        if advancer.is_some() {
-            // Progressive store: the hook fills it chunk by chunk.
-            *self.state.min_traces.write_or_poison("min_traces")? = Some(Vec::new());
-        }
-        let chunk_hook_closure = advancer
-            .as_ref()
-            .map(|adv| move |idx: usize, trace: &Arc<EmuTrace>| adv.on_chunk(idx, trace));
-        let chunk_hook: crate::ChunkHook<'_> =
-            chunk_hook_closure.as_ref().map(|h| h as &dyn Fn(usize, &Arc<EmuTrace>));
+        let chunk_hook: crate::ChunkHook<'_> = Some(&on_chunk);
 
         timer_start_info!(COMPUTE_MINIMAL_TRACE);
         let start_partial = Instant::now();
@@ -417,25 +327,31 @@ impl<F: PrimeField64> ZiskExecutor<F> {
         let crate::ExecutionOutput { min_traces, mut counters, pub_outs, mut backend, .. } = output;
         let num_chunks = min_traces.len();
 
-        // The store must hold every chunk BEFORE the final segment is released
-        // (its witness computation reads the tail). Idempotent when the hook
-        // already filled it progressively; the whole vector on the Rust path.
-        *self.state.min_traces.write_or_poison("min_traces")? = Some(min_traces);
+        // The hook published every chunk it saw, so on the ASM path the store is
+        // already complete and a read lock is enough (an exclusive lock here would
+        // stall main witnesses that are already computing). The Rust emulator
+        // never calls the hook, so its store is still empty and gets the whole
+        // vector at once.
+        let published =
+            self.state.min_traces.read_or_poison("min_traces")?.as_ref().map_or(0, Vec::len);
+        if published != num_chunks {
+            *self.state.min_traces.write_or_poison("min_traces")? = Some(min_traces);
+        }
 
-        let main_instances_count = match advancer.as_ref() {
-            // Releases the remaining segments (at least the final one) and
-            // surfaces any error latched on the reader thread.
-            Some(adv) => adv.finalize(num_chunks)?,
-            None => {
-                let main_plans = self.plan.run_main(num_chunks, &self.state.stats, &_exec_scope)?;
-                let main_assignments =
-                    InstanceAssigner::assign_main_instances(registry, global_ids, main_plans)?;
-                let count = main_assignments.len();
-                if let Some(witness) = self.witness.as_ref() {
-                    witness.populate_main_instances(registry, &self.state, main_assignments)?;
-                }
-                count
+        // ASM + witness: the hook already released every Main instance during the
+        // run (the runner only returns `Ok` after delivering the final chunk).
+        let main_instances_count = if is_asm_emulator && self.witness.is_some() {
+            num_chunks.div_ceil(num_within)
+        } else {
+            // Rust emulator / standalone: plan and release every segment now.
+            let main_plans = self.plan.run_main(num_chunks, &self.state.stats, &_exec_scope)?;
+            let main_assignments =
+                InstanceAssigner::assign_main_instances(registry, global_ids, main_plans)?;
+            let count = main_assignments.len();
+            if let Some(witness) = self.witness.as_ref() {
+                witness.populate_main_instances(registry, &self.state, main_assignments)?;
             }
+            count
         };
 
         // ────────────────────────────────────────────────────────────

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -18,6 +18,7 @@ mod witness;
 // External API
 pub use asm_runner::GpuBufferSource;
 pub use execution::asm::{AsmResources, AsmSharedResources, EmulatorAsm}; // (Linux x86_64) / stub elsewhere
+pub use execution::ChunkHook; // per-chunk main-witness advancement callback
 pub use executor::*; // ZiskExecutor
 pub use witness::AirClassifier; // AIR id → display name (used to label remote execution plans)
 

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -18,7 +18,6 @@ mod witness;
 // External API
 pub use asm_runner::GpuBufferSource;
 pub use execution::asm::{AsmResources, AsmSharedResources, EmulatorAsm}; // (Linux x86_64) / stub elsewhere
-pub use execution::ChunkHook; // per-chunk main-witness advancement callback
 pub use executor::*; // ZiskExecutor
 pub use witness::AirClassifier; // AIR id → display name (used to label remote execution plans)
 

--- a/executor/src/plan.rs
+++ b/executor/src/plan.rs
@@ -15,7 +15,7 @@ use crate::error::ExecutorResult;
 use fields::PrimeField64;
 use proofman_util::{timer_start_info, timer_stop_and_log_info};
 use sm_main::MainPlanner;
-use zisk_common::{stats_begin, stats_end, EmuTrace, ExecutorStatsHandle, Plan, StatsScope};
+use zisk_common::{stats_begin, stats_end, ExecutorStatsHandle, Plan, StatsScope};
 
 use crate::sm::{extend_mem_plans, plan_sec};
 use crate::{BackendArtifacts, CountersChunkMetrics};
@@ -43,9 +43,14 @@ impl<F: PrimeField64> PlanPhase<F> {
         Self { chunk_size, _marker: std::marker::PhantomData }
     }
 
-    /// Plan the main SM instances. Pure: unit-testable on synthetic `EmuTrace`.
-    pub fn plan_main(min_traces: &[EmuTrace], chunk_size: u64) -> ExecutorResult<Vec<Plan>> {
-        Ok(MainPlanner::plan(min_traces, chunk_size)?)
+    /// Minimal-trace chunk size this phase plans with.
+    pub fn chunk_size(&self) -> u64 {
+        self.chunk_size
+    }
+
+    /// Plan the main SM instances. Pure: depends only on the chunk count.
+    pub fn plan_main(num_chunks: usize, chunk_size: u64) -> ExecutorResult<Vec<Plan>> {
+        Ok(MainPlanner::plan_count(num_chunks, chunk_size)?)
     }
 
     /// Plan the secondary SM instances from per-chunk counters via static dispatch.
@@ -61,13 +66,13 @@ impl<F: PrimeField64> PlanPhase<F> {
     #[allow(unused_variables)]
     pub fn run_main(
         &self,
-        min_traces: &[EmuTrace],
+        num_chunks: usize,
         stats: &ExecutorStatsHandle,
         exec_scope: &StatsScope,
     ) -> ExecutorResult<Vec<Plan>> {
         stats_begin!(stats, exec_scope, _main_plan_scope, "MAIN_PLAN", 0);
         timer_start_info!(PLAN_MAIN);
-        let plans = Self::plan_main(min_traces, self.chunk_size)?;
+        let plans = Self::plan_main(num_chunks, self.chunk_size)?;
         timer_stop_and_log_info!(PLAN_MAIN);
         stats_end!(stats, &_main_plan_scope);
         Ok(plans)
@@ -127,20 +132,15 @@ mod tests {
 
     const NUM_ROWS: usize = MainTrace::<()>::NUM_ROWS;
 
-    fn synthetic_traces(n: usize) -> Vec<EmuTrace> {
-        vec![EmuTrace::default(); n]
-    }
-
     #[test]
     fn plan_main_empty_traces_yields_empty_plan() {
-        let plans =
-            PlanPhase::<F>::plan_main(&[], NUM_ROWS as u64).expect("empty traces planned ok");
+        let plans = PlanPhase::<F>::plan_main(0, NUM_ROWS as u64).expect("empty traces planned ok");
         assert!(plans.is_empty());
     }
 
     #[test]
     fn plan_main_single_full_trace_yields_one_plan() {
-        let plans = PlanPhase::<F>::plan_main(&synthetic_traces(1), NUM_ROWS as u64).expect("ok");
+        let plans = PlanPhase::<F>::plan_main(1, NUM_ROWS as u64).expect("ok");
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].airgroup_id, ZISK_AIRGROUP_ID);
         assert_eq!(plans[0].air_id, MAIN_AIR_IDS[0]);
@@ -148,14 +148,13 @@ mod tests {
 
     #[test]
     fn plan_main_segments_via_ceil_div() {
-        let plans =
-            PlanPhase::<F>::plan_main(&synthetic_traces(3), (NUM_ROWS as u64) / 2).expect("ok");
+        let plans = PlanPhase::<F>::plan_main(3, (NUM_ROWS as u64) / 2).expect("ok");
         assert_eq!(plans.len(), 2);
     }
 
     #[test]
     fn plan_main_rejects_non_power_of_two_chunk_size() {
-        match PlanPhase::<F>::plan_main(&synthetic_traces(1), 3) {
+        match PlanPhase::<F>::plan_main(1, 3) {
             Ok(_) => panic!("non-power-of-two chunk_size must error"),
             Err(err) => {
                 assert!(err.to_string().to_lowercase().contains("power of two"));

--- a/executor/src/state.rs
+++ b/executor/src/state.rs
@@ -41,7 +41,10 @@ pub struct ExecutionState<F: PrimeField64> {
     pub stdin: ArcSwap<ZiskStdin>,
 
     /// Planning information for main state machines (minimal traces from emulation).
-    pub min_traces: Arc<RwLock<Option<Vec<EmuTrace>>>>,
+    /// `Arc<EmuTrace>` elements so the store can be filled progressively while the
+    /// emulator streams chunks (main witness advancement) and readers can clone the
+    /// cheap Arc vector instead of holding the lock across a witness computation.
+    pub min_traces: Arc<RwLock<Option<Vec<Arc<EmuTrace>>>>>,
 
     /// Main + secondary instance maps populated by `PlanPhase`.
     pub instance_set: Arc<InstanceSet<F>>,

--- a/executor/src/state/instance_set.rs
+++ b/executor/src/state/instance_set.rs
@@ -10,7 +10,11 @@ use zisk_common::Instance;
 /// Populated main + secondary instance maps, keyed by `global_id`.
 pub struct InstanceSet<F: PrimeField64> {
     /// Main state machine instances, indexed by their global ID.
-    pub main_instances: RwLock<HashMap<usize, MainInstance<F>>>,
+    // `Arc` values: the main witness handler clones the instance out and
+    // drops the guard before computing, so the incremental main advancement
+    // (which takes the write lock from the emulator's reader thread) is never
+    // blocked behind a witness computation.
+    pub main_instances: RwLock<HashMap<usize, std::sync::Arc<MainInstance<F>>>>,
 
     /// Secondary state machine instances, indexed by their global ID.
     pub secn_instances: RwLock<HashMap<usize, Box<dyn Instance<F>>>>,

--- a/executor/src/state/instance_set.rs
+++ b/executor/src/state/instance_set.rs
@@ -1,7 +1,7 @@
 //! [`InstanceSet`] — populated main + secondary state-machine instance maps.
 
 use std::collections::HashMap;
-use std::sync::{PoisonError, RwLock};
+use std::sync::{Arc, PoisonError, RwLock};
 
 use fields::PrimeField64;
 use sm_main::MainInstance;
@@ -14,7 +14,7 @@ pub struct InstanceSet<F: PrimeField64> {
     // drops the guard before computing, so the incremental main advancement
     // (which takes the write lock from the emulator's reader thread) is never
     // blocked behind a witness computation.
-    pub main_instances: RwLock<HashMap<usize, std::sync::Arc<MainInstance<F>>>>,
+    pub main_instances: RwLock<HashMap<usize, Arc<MainInstance<F>>>>,
 
     /// Secondary state machine instances, indexed by their global ID.
     pub secn_instances: RwLock<HashMap<usize, Box<dyn Instance<F>>>>,

--- a/executor/src/witness.rs
+++ b/executor/src/witness.rs
@@ -146,7 +146,10 @@ impl<F: PrimeField64> WitnessPhase<F> {
             state.instance_set.main_instances.write_or_poison("main_instances")?;
         for (global_id, plan) in assignments {
             main_instances.entry(global_id).or_insert_with(|| {
-                MainInstance::new(InstanceCtx::new(global_id, plan), self.sm_bundle.get_std())
+                std::sync::Arc::new(MainInstance::new(
+                    InstanceCtx::new(global_id, plan),
+                    self.sm_bundle.get_std(),
+                ))
             });
 
             let gid = GlobalId(global_id);

--- a/executor/src/witness/collector.rs
+++ b/executor/src/witness/collector.rs
@@ -49,7 +49,7 @@ struct WorkerCtx<'a, F: PrimeField64> {
 
     // ── Inputs ──
     zisk_rom: &'a ZiskRom,
-    min_traces: &'a [std::sync::Arc<EmuTrace>],
+    min_traces: &'a [Arc<EmuTrace>],
     pctx: &'a ProofCtx<F>,
 
     // ── Output sinks ──
@@ -110,7 +110,7 @@ impl<F: PrimeField64> ChunkDataCollector<F> {
     /// - `global_id_chunks[global_id]` = list of chunk_ids this instance needs
     pub fn compute_chunks_to_execute(
         &self,
-        min_traces: &[std::sync::Arc<EmuTrace>],
+        min_traces: &[Arc<EmuTrace>],
         secn_instances: &HashMap<usize, &dyn Instance<F>>,
     ) -> (Vec<Vec<usize>>, HashMap<usize, Vec<usize>>) {
         let mut chunks_to_execute = vec![Vec::new(); min_traces.len()];

--- a/executor/src/witness/collector.rs
+++ b/executor/src/witness/collector.rs
@@ -49,7 +49,7 @@ struct WorkerCtx<'a, F: PrimeField64> {
 
     // ── Inputs ──
     zisk_rom: &'a ZiskRom,
-    min_traces: &'a [EmuTrace],
+    min_traces: &'a [std::sync::Arc<EmuTrace>],
     pctx: &'a ProofCtx<F>,
 
     // ── Output sinks ──
@@ -110,7 +110,7 @@ impl<F: PrimeField64> ChunkDataCollector<F> {
     /// - `global_id_chunks[global_id]` = list of chunk_ids this instance needs
     pub fn compute_chunks_to_execute(
         &self,
-        min_traces: &[EmuTrace],
+        min_traces: &[std::sync::Arc<EmuTrace>],
         secn_instances: &HashMap<usize, &dyn Instance<F>>,
     ) -> (Vec<Vec<usize>>, HashMap<usize, Vec<usize>>) {
         let mut chunks_to_execute = vec![Vec::new(); min_traces.len()];
@@ -419,8 +419,7 @@ impl<F: PrimeField64> ChunkDataCollector<F> {
         // Run the emulator over this chunk's traces.
         ZiskEmulator::process_emu_traces::<F, _, _>(
             ctx.zisk_rom,
-            ctx.min_traces,
-            chunk_id,
+            &ctx.min_traces[chunk_id],
             &mut data_bus,
         );
 

--- a/executor/src/witness/generator.rs
+++ b/executor/src/witness/generator.rs
@@ -4,7 +4,7 @@
 
 use fields::PrimeField64;
 use proofman_common::{ProofCtx, SetupCtx};
-use sm_main::MainInstance;
+use sm_main::{MainInstance, MainPlanner, MainSmError};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 use zisk_common::{stats_begin, stats_end, BusDevice, Instance, InstanceType, Stats};
@@ -60,21 +60,38 @@ impl WitnessGenerator {
         stats_begin!(state.stats, _caller_stats_id, _stats_scope, "AIR_MAIN_WITNESS", air_id);
 
         let zisk_rom = state.get_rom()?;
-        let min_traces_guard = state.min_traces.read_or_poison("min_traces")?;
-        let min_traces = min_traces_guard.as_ref().ok_or(ExecutorError::MinTracesNotSet)?;
+        // Clone only this segment's chunk range (plus the preceding chunk's
+        // `last_c`) under a short read lock: with main-witness advancement the
+        // emulator's reader thread keeps pushing chunks into this store (write
+        // lock) while early segments are being computed.
+        let segment_id =
+            main_instance.ictx.plan.segment_id.ok_or(MainSmError::MissingSegmentId)?.as_usize();
+        let num_within = MainPlanner::traces_per_segment(self.chunk_size)?;
+        let (segment_min_traces, prev_chunk_last_c) = {
+            let min_traces_guard = state.min_traces.read_or_poison("min_traces")?;
+            let store = min_traces_guard.as_ref().ok_or(ExecutorError::MinTracesNotSet)?;
+            let start = segment_id * num_within;
+            let end = (start + num_within).min(store.len());
+            (
+                store.get(start..end).unwrap_or_default().to_vec(),
+                start.checked_sub(1).and_then(|i| store.get(i)).map(|t| t.last_c),
+            )
+        };
 
         // Packed ⇒ compact indexed Main row (+ instruction table); otherwise the unpacked row.
         let air_instance = if self.packed.load(Ordering::Relaxed) {
             main_instance.compute_witness::<MainTraceRowPackedIndexed<F>>(
                 &zisk_rom,
-                min_traces,
+                &segment_min_traces,
+                prev_chunk_last_c,
                 self.chunk_size,
                 trace_buffer,
             )?
         } else {
             main_instance.compute_witness::<MainTraceRow<F>>(
                 &zisk_rom,
-                min_traces,
+                &segment_min_traces,
+                prev_chunk_last_c,
                 self.chunk_size,
                 trace_buffer,
             )?

--- a/executor/src/witness/handlers/main.rs
+++ b/executor/src/witness/handlers/main.rs
@@ -19,14 +19,24 @@ impl MainWitnessHandler {
         buffer_pool: &dyn BufferPool<F>,
         stats_scope_id: u64,
     ) -> ExecutorResult<()> {
-        let main_instances = state.instance_set.main_instances.read_or_poison("main_instances")?;
-        let main_instance =
-            main_instances.get(&global_id).ok_or(ExecutorError::InstanceNotFound { global_id })?;
+        // Clone the Arc under a short guard and take the trace buffer OUTSIDE
+        // any lock: holding the read guard across the (long) witness
+        // computation — or across a potentially blocking take_buffer — would
+        // stall the incremental main advancement, which takes the write lock
+        // from the emulator's reader thread while chunks are still streaming.
+        let main_instance = {
+            let main_instances =
+                state.instance_set.main_instances.read_or_poison("main_instances")?;
+            main_instances
+                .get(&global_id)
+                .cloned()
+                .ok_or(ExecutorError::InstanceNotFound { global_id })?
+        };
 
         generator.compute_main_witness(
             pctx,
             state,
-            main_instance,
+            &main_instance,
             buffer_pool.take_buffer(),
             stats_scope_id,
         )

--- a/state-machines/main/src/error.rs
+++ b/state-machines/main/src/error.rs
@@ -39,6 +39,22 @@ pub enum MainSmError {
     #[error("fill_trace_outputs is empty; segment has no minimal traces")]
     EmptyFillTraceOutput,
 
+    /// A non-final segment was handed fewer minimal-trace chunks than it spans.
+    /// Only the last segment may be partial, so this means the caller's
+    /// minimal-trace store did not hold the whole segment — computing it anyway
+    /// would silently produce a truncated Main witness.
+    #[error(
+        "main segment {segment_id} is incomplete: got {got} minimal traces, expected {expected}"
+    )]
+    IncompleteSegment {
+        /// The segment whose chunk range was short.
+        segment_id: usize,
+        /// Minimal traces actually supplied.
+        got: usize,
+        /// Minimal traces the segment spans (`num_within`).
+        expected: usize,
+    },
+
     /// `MemHelpers::mem_step_to_slot` returned a value outside the expected `0..=2` range.
     #[error("mem_step_to_slot produced invalid slot {slot}")]
     InvalidSlot {

--- a/state-machines/main/src/main_planner.rs
+++ b/state-machines/main/src/main_planner.rs
@@ -31,6 +31,27 @@ impl MainPlanner {
     /// - The `chunk_size` exceeds the row capacity of `MainTrace` ([`MainSmError::ChunkSizeTooBig`]).
     /// - A `u64` quantity could not be converted to `usize` on this target ([`MainSmError::TryFromIntError`]).
     pub fn plan(min_traces: &[EmuTrace], chunk_size: u64) -> Result<Vec<Plan>> {
+        Self::plan_count(min_traces.len(), chunk_size)
+    }
+
+    /// Same as [`Self::plan`] but from the chunk count alone (plans depend only
+    /// on how many minimal-trace chunks exist).
+    pub fn plan_count(num_chunks: usize, chunk_size: u64) -> Result<Vec<Plan>> {
+        let num_within = Self::traces_per_segment(chunk_size)?;
+
+        // Number of `Main` segments needed to cover all the execution trace.
+        let num_instances = num_chunks.div_ceil(num_within);
+
+        Ok((0..num_instances)
+            .map(|segment_id| Self::plan_segment(segment_id, segment_id == num_instances - 1))
+            .collect())
+    }
+
+    /// Number of minimal-trace chunks wrapped in one main trace segment.
+    ///
+    /// # Errors
+    /// Same `chunk_size` validation as [`Self::plan`].
+    pub fn traces_per_segment(chunk_size: u64) -> Result<usize> {
         const NUM_ROWS: usize = MainTrace::<()>::NUM_ROWS;
 
         // Compile-time assertion to ensure `MainTrace::NUM_ROWS` is a power of two.
@@ -47,24 +68,23 @@ impl MainPlanner {
             return Err(MainSmError::ChunkSizeTooBig { chunk_size, num_rows: NUM_ROWS });
         }
 
-        // Number of minimal traces wrapped in a main trace.
-        let num_within = NUM_ROWS / chunk_size;
+        Ok(NUM_ROWS / chunk_size)
+    }
 
-        // Number of `Main` segments needed to cover all the execution trace.
-        let num_instances = min_traces.len().div_ceil(num_within);
-
-        Ok((0..num_instances)
-            .map(|segment_id| {
-                Plan::new(
-                    ZISK_AIRGROUP_ID,
-                    MAIN_AIR_IDS[0],
-                    Some(SegmentId(segment_id)),
-                    InstanceType::Instance,
-                    CheckPoint::Single(ChunkId(segment_id)),
-                    Some(Box::new(segment_id == num_instances - 1)),
-                )
-            })
-            .collect())
+    /// Builds the plan of a single Main segment. Used by the incremental
+    /// main-witness advancement: segments become plannable one by one while
+    /// the emulation streams chunks (`is_last_segment` for a full segment is
+    /// known as soon as one chunk beyond it exists; the final segment is
+    /// planned once the emulation ends and the total count is known).
+    pub fn plan_segment(segment_id: usize, is_last_segment: bool) -> Plan {
+        Plan::new(
+            ZISK_AIRGROUP_ID,
+            MAIN_AIR_IDS[0],
+            Some(SegmentId(segment_id)),
+            InstanceType::Instance,
+            CheckPoint::Single(ChunkId(segment_id)),
+            Some(Box::new(is_last_segment)),
+        )
     }
 }
 

--- a/state-machines/main/src/main_planner.rs
+++ b/state-machines/main/src/main_planner.rs
@@ -71,6 +71,22 @@ impl MainPlanner {
         Ok(NUM_ROWS / chunk_size)
     }
 
+    /// The Main segment that chunk `chunk_idx` completes, or `None` when that
+    /// chunk neither fills a segment nor ends the execution.
+    ///
+    /// `num_within` comes from [`Self::traces_per_segment`] (always `>= 1`).
+    /// Incremental main advancement calls this once per streamed minimal-trace
+    /// chunk: a segment is complete either at its own boundary (`chunk_idx + 1`
+    /// is a multiple of `num_within`) or on the chunk that ends the execution,
+    /// which closes the final — possibly partial — segment.
+    pub fn segment_completed_by(
+        chunk_idx: usize,
+        num_within: usize,
+        is_last_chunk: bool,
+    ) -> Option<usize> {
+        ((chunk_idx + 1) % num_within == 0 || is_last_chunk).then_some(chunk_idx / num_within)
+    }
+
     /// Builds the plan of a single Main segment. Used by the incremental
     /// main-witness advancement: segments become plannable one by one while
     /// the emulation streams chunks (`is_last_segment` for a full segment is
@@ -178,6 +194,69 @@ mod tests {
         assert!(matches!(plan.instance_type, InstanceType::Instance));
         // Checkpoint's ChunkId is the same usize as segment_id.
         assert!(matches!(plan.check_point, CheckPoint::Single(ChunkId(0))));
+    }
+
+    #[test]
+    fn segment_completed_by_releases_only_on_boundaries() {
+        // num_within = 4: only chunk 3 completes segment 0, only chunk 7 segment 1.
+        let released: Vec<Option<usize>> =
+            (0..8).map(|idx| MainPlanner::segment_completed_by(idx, 4, false)).collect();
+        assert_eq!(
+            released,
+            vec![None, None, None, Some(0), None, None, None, Some(1)],
+            "a segment is released by its last chunk only"
+        );
+    }
+
+    #[test]
+    fn segment_completed_by_closes_partial_segment_on_last_chunk() {
+        // Chunk 5 is mid-segment, but it ends the execution: segment 1 is released
+        // partial rather than waiting for a boundary that will never arrive.
+        assert_eq!(MainPlanner::segment_completed_by(5, 4, true), Some(1));
+        // A single chunk that is also the last one closes segment 0.
+        assert_eq!(MainPlanner::segment_completed_by(0, 4, true), Some(0));
+    }
+
+    #[test]
+    fn segment_completed_by_boundary_and_last_release_one_segment() {
+        // Chunk 7 both fills segment 1 and ends the execution — it must resolve to
+        // exactly one segment, not release segment 1 and then a phantom segment 2.
+        assert_eq!(MainPlanner::segment_completed_by(7, 4, true), Some(1));
+    }
+
+    #[test]
+    fn segment_completed_by_one_chunk_per_segment() {
+        // chunk_size == NUM_ROWS ⇒ num_within = 1: every chunk completes its own segment.
+        for idx in 0..4 {
+            assert_eq!(MainPlanner::segment_completed_by(idx, 1, false), Some(idx));
+        }
+    }
+
+    #[test]
+    fn incremental_release_matches_batch_plan() {
+        // Releasing chunk-by-chunk must yield exactly what the batch planner
+        // yields — same segment ids, same order, same `is_last_segment` flags —
+        // for every chunk count, partial tails included.
+        let chunk_size = (NUM_ROWS as u64) / 4;
+        let num_within = MainPlanner::traces_per_segment(chunk_size).unwrap();
+
+        for num_chunks in 1..=13usize {
+            let incremental: Vec<(usize, bool)> = (0..num_chunks)
+                .filter_map(|idx| {
+                    let is_last_chunk = idx == num_chunks - 1;
+                    MainPlanner::segment_completed_by(idx, num_within, is_last_chunk)
+                        .map(|segment| (segment, is_last_chunk))
+                })
+                .collect();
+
+            let batch: Vec<(usize, bool)> = MainPlanner::plan_count(num_chunks, chunk_size)
+                .unwrap()
+                .iter()
+                .map(|plan| (plan.segment_id.unwrap().as_usize(), is_last(plan)))
+                .collect();
+
+            assert_eq!(incremental, batch, "chunk count {num_chunks}");
+        }
     }
 
     #[test]

--- a/state-machines/main/src/main_sm.rs
+++ b/state-machines/main/src/main_sm.rs
@@ -53,8 +53,9 @@ impl<F: PrimeField64> MainInstance<F> {
     ///
     /// # Arguments
     /// * `zisk_rom` - Reference to the Zisk ROM used for execution.
-    /// * `min_traces` - A vector of the minimal traces, each segment has num_within minimal traces
-    ///   inside.
+    /// * `segment_min_traces` - This segment's minimal traces (at most `num_within`).
+    /// * `prev_chunk_last_c` - `last_c` of the chunk preceding the segment (`None` for the
+    ///   first segment).
     /// * `chunk_size` - The size of the minimal traces.
     ///
     /// The computed trace is added to the proof context's air instance repository.
@@ -72,7 +73,8 @@ impl<F: PrimeField64> MainInstance<F> {
     pub fn compute_witness<R: MainTraceRowOps<F> + IndexedFill>(
         &self,
         zisk_rom: &ZiskRom,
-        min_traces: &[EmuTrace],
+        segment_min_traces: &[std::sync::Arc<EmuTrace>],
+        prev_chunk_last_c: Option<u64>,
         chunk_size: u64,
         trace_buffer: Vec<F>,
     ) -> Result<AirInstance<F>, MainSmError> {
@@ -99,11 +101,6 @@ impl<F: PrimeField64> MainInstance<F> {
 
         // Determine the number of minimal traces per segment
         let num_within = NUM_ROWS / chunk_size;
-
-        // Determine trace slice for the current segment
-        let start_idx = segment_id.as_usize() * num_within;
-        let end_idx = (start_idx + num_within).min(min_traces.len());
-        let segment_min_traces = &min_traces[start_idx..end_idx];
 
         // Calculate total filled rows
         let filled_rows: usize =
@@ -147,7 +144,7 @@ impl<F: PrimeField64> MainInstance<F> {
                     &segment_min_traces[chunk_id],
                     &mut reg_trace,
                     &mut step_range_check,
-                    chunk_id == (end_idx - start_idx - 1),
+                    chunk_id == (segment_min_traces.len() - 1),
                 );
                 (pc, regs, reg_trace, step_range_check)
             })
@@ -180,10 +177,9 @@ impl<F: PrimeField64> MainInstance<F> {
         let last_row = Self::pad_trailing_rows(&mut main_trace.buffer, filled_rows, NUM_ROWS);
 
         // Determine the last row of the previous segment
-        let prev_segment_last_c = if start_idx > 0 {
-            Emu::intermediate_value(min_traces[start_idx - 1].last_c)
-        } else {
-            [F::ZERO, F::ZERO]
+        let prev_segment_last_c = match prev_chunk_last_c {
+            Some(last_c) => Emu::intermediate_value(last_c),
+            None => [F::ZERO, F::ZERO],
         };
 
         // Prepare main AIR values

--- a/state-machines/main/src/main_sm.rs
+++ b/state-machines/main/src/main_sm.rs
@@ -407,8 +407,10 @@ impl<F: PrimeField64> MainInstance<F> {
     /// chunk range, and padding the missing rows would quietly yield a truncated
     /// Main witness that only surfaces as a global-constraint failure.
     ///
-    /// An empty slice is left to [`MainSmError::EmptyFillTraceOutput`], which
-    /// already rejects it further down `compute_witness`.
+    /// An empty *non-final* segment is short like any other and is rejected here.
+    /// An empty *final* segment is the one case left to
+    /// [`MainSmError::EmptyFillTraceOutput`], which already rejects it further
+    /// down `compute_witness` and names the actual problem.
     ///
     /// # Errors
     /// - [`MainSmError::IncompleteSegment`] if a non-final segment is short.

--- a/state-machines/main/src/main_sm.rs
+++ b/state-machines/main/src/main_sm.rs
@@ -68,6 +68,8 @@ impl<F: PrimeField64> MainInstance<F> {
     ///   ([`MainSmError::InvalidSegmentMetadata`]).
     /// - The segment has no minimal traces to process
     ///   ([`MainSmError::EmptyFillTraceOutput`]).
+    /// - A non-final segment was given fewer than `num_within` minimal traces
+    ///   ([`MainSmError::IncompleteSegment`]).
     /// - `MemHelpers::mem_step_to_slot` returned a slot outside `0..=2`
     ///   ([`MainSmError::InvalidSlot`]).
     pub fn compute_witness<R: MainTraceRowOps<F> + IndexedFill>(
@@ -101,6 +103,13 @@ impl<F: PrimeField64> MainInstance<F> {
 
         // Determine the number of minimal traces per segment
         let num_within = NUM_ROWS / chunk_size;
+
+        Self::check_segment_complete(
+            segment_id,
+            segment_min_traces.len(),
+            num_within,
+            is_last_segment,
+        )?;
 
         // Calculate total filled rows
         let filled_rows: usize =
@@ -392,6 +401,33 @@ impl<F: PrimeField64> MainInstance<F> {
         (initial_step, final_step)
     }
 
+    /// Rejects a non-final segment that was handed fewer minimal traces than it
+    /// spans. Only the last segment may be partial; anywhere else a short slice
+    /// means the caller's minimal-trace store did not hold this segment's whole
+    /// chunk range, and padding the missing rows would quietly yield a truncated
+    /// Main witness that only surfaces as a global-constraint failure.
+    ///
+    /// An empty slice is left to [`MainSmError::EmptyFillTraceOutput`], which
+    /// already rejects it further down `compute_witness`.
+    ///
+    /// # Errors
+    /// - [`MainSmError::IncompleteSegment`] if a non-final segment is short.
+    fn check_segment_complete(
+        segment_id: SegmentId,
+        got: usize,
+        num_within: usize,
+        is_last_segment: bool,
+    ) -> Result<(), MainSmError> {
+        if !is_last_segment && got != num_within {
+            return Err(MainSmError::IncompleteSegment {
+                segment_id: segment_id.as_usize(),
+                got,
+                expected: num_within,
+            });
+        }
+        Ok(())
+    }
+
     /// Decodes `segment_id` and `is_last_segment` from the plan handed to this
     /// instance.
     ///
@@ -450,6 +486,48 @@ mod tests {
 
     fn make_plan(segment_id: Option<SegmentId>, meta: Option<Box<dyn Any + Send + Sync>>) -> Plan {
         Plan::new(0, 0, segment_id, InstanceType::Instance, CheckPoint::Single(ChunkId(0)), meta)
+    }
+
+    #[test]
+    fn full_non_final_segment_is_accepted() {
+        // The common case: a middle segment carrying exactly `num_within` chunks.
+        MI::check_segment_complete(SegmentId(1), 16, 16, false).expect("complete segment");
+    }
+
+    #[test]
+    fn short_non_final_segment_is_rejected() {
+        // Only the last segment may be partial. A short middle segment means the
+        // caller's store didn't hold the whole chunk range; computing it would pad
+        // the missing rows and silently produce a truncated Main witness.
+        let err = MI::check_segment_complete(SegmentId(2), 9, 16, false)
+            .expect_err("truncated middle segment");
+        assert!(matches!(
+            err,
+            MainSmError::IncompleteSegment { segment_id: 2, got: 9, expected: 16 }
+        ));
+    }
+
+    #[test]
+    fn empty_non_final_segment_is_rejected() {
+        let err = MI::check_segment_complete(SegmentId(0), 0, 16, false)
+            .expect_err("empty middle segment");
+        assert!(matches!(err, MainSmError::IncompleteSegment { got: 0, expected: 16, .. }));
+    }
+
+    #[test]
+    fn partial_final_segment_is_accepted() {
+        // The execution's tail is legitimately partial — this must not false-fire.
+        for got in 1..=16 {
+            MI::check_segment_complete(SegmentId(3), got, 16, true)
+                .unwrap_or_else(|e| panic!("final segment with {got} chunks rejected: {e}"));
+        }
+    }
+
+    #[test]
+    fn empty_final_segment_defers_to_empty_fill_trace_output() {
+        // Not this check's job: `compute_witness` rejects an empty segment later
+        // with `EmptyFillTraceOutput`, which names the actual problem.
+        MI::check_segment_complete(SegmentId(3), 0, 16, true).expect("deferred");
     }
 
     #[test]

--- a/state-machines/mem-cpp/cu/count_and_plan.cu
+++ b/state-machines/mem-cpp/cu/count_and_plan.cu
@@ -1267,10 +1267,15 @@ bool CountAndPlan::setup(void* d_buf, size_t bytes,
     d_ops_pool_cap_u32_  = (arena_bytes_ - cursor_) / 4;
     d_ops_pool_used_u32_ = 0;
 
+    // Highest device priority: the count/plan pipeline is the executor's critical
+    // path, and proofman's streaming-commit slots (priority 0) may run concurrently
+    // on this GPU 
+    int leastPrio = 0, greatestPrio = 0;
+    CUDA_CHECK(cudaDeviceGetStreamPriorityRange(&leastPrio, &greatestPrio));
     for (int s = 0; s < N_STREAMS; s++)
-        CUDA_CHECK(cudaStreamCreate(&streams_[s]));
-    CUDA_CHECK(cudaStreamCreate(&d2h_stream_));
-    CUDA_CHECK(cudaStreamCreate(&meta_stream_));
+        CUDA_CHECK(cudaStreamCreateWithPriority(&streams_[s], cudaStreamDefault, greatestPrio));
+    CUDA_CHECK(cudaStreamCreateWithPriority(&d2h_stream_, cudaStreamDefault, greatestPrio));
+    CUDA_CHECK(cudaStreamCreateWithPriority(&meta_stream_, cudaStreamDefault, greatestPrio));
     CUDA_CHECK(cudaEventCreate(&e_after_preproc_));
     CUDA_CHECK(cudaEventCreate(&e_after_prepare_));
     CUDA_CHECK(cudaEventCreate(&e_metas_ready_));
@@ -1801,7 +1806,12 @@ void CountAndPlan::process_worker_() {
         d_fml_, num_active_, n_chunks_, num_ops_);
     CUDA_CHECK_LAUNCH();
 
-    CUDA_CHECK(cudaDeviceSynchronize());
+    // Everything process_worker_ launched sits on the legacy default stream, and
+    // the sync memcpys below already order against it (and against the blocking
+    // count streams). A device-wide sync would additionally wait for FOREIGN
+    // non-blocking streams -- e.g. proofman's streaming-commit slots -- adopting
+    // their whole backlog into this critical path. Sync only our own stream.
+    CUDA_CHECK(cudaStreamSynchronize(nullptr));
     CUDA_CHECK(cudaMemcpy(h_active_first_.data(), d_active_first_, num_active_ * 4, cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaMemcpy(h_active_last_.data(),  d_active_last_,  num_active_ * 4, cudaMemcpyDeviceToHost));
 

--- a/state-machines/mem-cpp/cu/count_and_plan.cu
+++ b/state-machines/mem-cpp/cu/count_and_plan.cu
@@ -1269,7 +1269,7 @@ bool CountAndPlan::setup(void* d_buf, size_t bytes,
 
     // Highest device priority: the count/plan pipeline is the executor's critical
     // path, and proofman's streaming-commit slots (priority 0) may run concurrently
-    // on this GPU 
+    // on this GPU.
     int leastPrio = 0, greatestPrio = 0;
     CUDA_CHECK(cudaDeviceGetStreamPriorityRange(&leastPrio, &greatestPrio));
     for (int s = 0; s < N_STREAMS; s++)

--- a/test-artifacts/Cargo.lock
+++ b/test-artifacts/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "mem-common",
  "mem-planner-cpp",
  "named-sem",
+ "proofman-starks-lib-c",
  "proofman-util",
  "rayon",
  "thiserror 2.0.19",
@@ -700,9 +701,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -710,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -1830,6 +1831,7 @@ dependencies = [
  "precomp-big-int",
  "precomp-blake2",
  "precomp-dma",
+ "precomp-evm",
  "precomp-keccakf",
  "precomp-poseidon",
  "precomp-sha256f",
@@ -1924,6 +1926,7 @@ dependencies = [
  "cfg-if",
  "num-bigint",
  "paste",
+ "proofman-starks-lib-c",
  "serde",
 ]
 
@@ -3670,6 +3673,21 @@ dependencies = [
  "proofman-util",
  "rayon",
  "tracing",
+ "zisk-common",
+ "zisk-core",
+ "zisk-pil",
+]
+
+[[package]]
+name = "precomp-evm"
+version = "1.1.0-alpha"
+dependencies = [
+ "clap",
+ "fields",
+ "pil-std-lib",
+ "precompiles-common",
+ "precompiles-helpers",
+ "proofman-common",
  "zisk-common",
  "zisk-core",
  "zisk-pil",

--- a/test-artifacts/programs/Cargo.lock
+++ b/test-artifacts/programs/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "mem-common",
  "mem-planner-cpp",
  "named-sem",
+ "proofman-starks-lib-c",
  "proofman-util",
  "rayon",
  "thiserror 2.0.19",
@@ -735,9 +736,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -745,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
**Main AIR instances** are now planned, assigned and marked witness-ready **during** the ASM minimal-trace run instead of after it.
As soon as the emulator has streamed enough chunks to fill one Main segment, that instance is handed to proofman — so its witness computation, and the GPU streaming-slot commit that follows, overlap the remaining emulation and the gpu-mops window instead of queuing behind `await_mem_plans`.