### PR TITLE
Fix bugs in the DMA planner

### DIFF
--- a/precompiles/dma/src/dma_instances_builder.rs
+++ b/precompiles/dma/src/dma_instances_builder.rs
@@ -122,6 +122,10 @@ impl DmaInstancesBuilder {
                 .chunks
                 .insert(chunk_id, (self.inputs_counter as u64, collect_counters));
             self.instances.last_mut().unwrap().last_chunk = Some(chunk_id);
+            // The inputs counter belongs to the (instance, chunk) record just stored: the collector
+            // built from it uses the value as its own bound. Restart it so the next record does not
+            // inherit this one's inputs.
+            self.inputs_counter = 0;
         }
     }
     #[inline(always)]
@@ -147,6 +151,55 @@ impl DmaInstancesBuilder {
         self.add_op_rows(chunk_id, skip, rows, inputs, DMA_COUNTER_INPUTCPY);
     }
 
+    /// Registers `skip` rows of `op` that this builder must not collect for the current chunk,
+    /// because another air already took them. Applies once to the whole batch.
+    #[inline(always)]
+    fn add_skip_rows(&mut self, skip: usize, op: usize) {
+        match op {
+            DMA_COUNTER_MEMCPY => {
+                assert!(
+                    self.count_memcpy_rows == 0,
+                    "Cannot have both skip and count for memcpy in the same chunk",
+                );
+                self.skip_memcpy_rows += skip;
+            }
+            DMA_COUNTER_MEMSET => {
+                assert!(
+                    self.count_memset_rows == 0,
+                    "Cannot have both skip and count for memset in the same chunk",
+                );
+                self.skip_memset_rows += skip;
+            }
+            DMA_COUNTER_MEMCMP => {
+                assert!(
+                    self.count_memcmp_rows == 0,
+                    "Cannot have both skip and count for memcmp in the same chunk",
+                );
+                self.skip_memcmp_rows += skip;
+            }
+            DMA_COUNTER_INPUTCPY => {
+                assert!(
+                    self.count_inputcpy_rows == 0,
+                    "Cannot have both skip and count for inputcpy in the same chunk",
+                );
+                self.skip_inputcpy_rows += skip;
+            }
+            _ => panic!("Unsupported operation for DMA instance builder 0x{op:02X}"),
+        }
+    }
+
+    /// Adds `rows` rows of `op` to the instance currently being filled.
+    #[inline(always)]
+    fn add_count_rows(&mut self, rows: usize, op: usize) {
+        match op {
+            DMA_COUNTER_MEMCPY => self.count_memcpy_rows += rows,
+            DMA_COUNTER_MEMSET => self.count_memset_rows += rows,
+            DMA_COUNTER_MEMCMP => self.count_memcmp_rows += rows,
+            DMA_COUNTER_INPUTCPY => self.count_inputcpy_rows += rows,
+            _ => panic!("Unsupported operation for DMA instance builder 0x{op:02X}"),
+        }
+    }
+
     pub fn add_op_rows(
         &mut self,
         chunk_id: ChunkId,
@@ -161,6 +214,7 @@ impl DmaInstancesBuilder {
             self.current_chunk = Some(chunk_id);
         }
         let mut rows = rows;
+        let mut skip = skip;
         while rows > 0 {
             if self.rows_available == 0 {
                 self.flush_current_chunk();
@@ -170,51 +224,17 @@ impl DmaInstancesBuilder {
             let rows_applicable = std::cmp::min(self.rows_available, rows);
             rows -= rows_applicable;
             self.rows_available -= rows_applicable;
-            match op {
-                DMA_COUNTER_MEMCPY => {
-                    if skip > 0 {
-                        assert!(
-                            self.count_memcpy_rows == 0,
-                            "Cannot have both skip and count for memcpy in the same chunk",
-                        );
-                        self.skip_memcpy_rows += skip;
-                    }
-                    self.count_memcpy_rows += rows_applicable;
-                }
-                DMA_COUNTER_MEMSET => {
-                    if skip > 0 {
-                        assert!(
-                            self.count_memset_rows == 0,
-                            "Cannot have both skip and count for memset in the same chunk",
-                        );
-                        self.skip_memset_rows += skip;
-                    }
-                    self.count_memset_rows += rows_applicable;
-                }
-                DMA_COUNTER_MEMCMP => {
-                    if skip > 0 {
-                        assert!(
-                            self.count_memcmp_rows == 0,
-                            "Cannot have both skip and count for memcmp in the same chunk",
-                        );
-                        self.skip_memcmp_rows += skip;
-                    }
-                    self.count_memcmp_rows += rows_applicable;
-                }
-                DMA_COUNTER_INPUTCPY => {
-                    if skip > 0 {
-                        assert!(
-                            self.count_inputcpy_rows == 0,
-                            "Cannot have both skip and count for inputcpy in the same chunk",
-                        );
-                        self.skip_inputcpy_rows += skip;
-                    }
-                    self.count_inputcpy_rows += rows_applicable;
-                }
-                _ => {
-                    panic!("Unsupported operation for DMA instance builder 0x{op:02X}")
-                }
+            // `skip` counts rows of this op already collected by another air for this chunk, so it
+            // applies once to the whole batch, not once per instance: when the batch crosses an
+            // instance boundary, `count_to_skip` above already carries the rows consumed so far.
+            if skip > 0 {
+                self.add_skip_rows(skip, op);
+                skip = 0;
             }
+            self.add_count_rows(rows_applicable, op);
+            // Upper bound on the bus entries this instance collects for the chunk: an operation
+            // straddling an instance boundary is collected (partially) by both, so `inputs` is
+            // charged to every instance the batch reaches.
             self.inputs_counter += inputs;
         }
     }
@@ -242,3 +262,7 @@ impl DmaInstancesBuilder {
         checkpoints
     }
 }
+
+#[cfg(test)]
+#[path = "tests/dma_instances_builder_tests.rs"]
+mod tests;

--- a/precompiles/dma/src/dma_strategy.rs
+++ b/precompiles/dma/src/dma_strategy.rs
@@ -207,7 +207,11 @@ impl<F: PrimeField64> DmaStrategy<F> {
         info.inputcpy = rows_inputcpy.div_ceil(rows_x_inputcpy_instance);
 
         let remain_dma = rows_full % rows_x_full_instance;
-        let available_on_dma = if rows_full == 0 { 0 } else { rows_x_full_instance - remain_dma };
+        // Free rows left in the tail of the last full instance. When `rows_full` is an exact
+        // multiple of the capacity (0 included) that last instance is completely full, so there is
+        // nothing available: the outer `%` is what keeps `rows_x_full_instance - 0` from being read
+        // as a whole free instance, which would overflow `info.full` and panic the builder.
+        let available_on_dma = (rows_x_full_instance - remain_dma) % rows_x_full_instance;
         let remain_dma_memcpy = rows_memcpy % rows_x_memcpy_instance;
         let remain_dma_inputcpy = rows_inputcpy % rows_x_inputcpy_instance;
         let remain = remain_dma_memcpy + remain_dma_inputcpy;
@@ -780,3 +784,7 @@ impl<F: PrimeField64> DmaStrategy<F> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[path = "tests/dma_strategy_tests.rs"]
+mod tests;

--- a/precompiles/dma/src/tests/dma_instances_builder_tests.rs
+++ b/precompiles/dma/src/tests/dma_instances_builder_tests.rs
@@ -1,0 +1,76 @@
+//! Unit tests for `DmaInstancesBuilder`'s per-(instance, chunk) bookkeeping.
+//! Declared from `dma_instances_builder.rs` via `#[cfg(test)] #[path = …] mod tests;`.
+
+use super::*;
+
+/// Rows per instance used by every builder in these tests.
+const ROWS: usize = 10;
+
+#[test]
+fn skip_applies_once_when_a_batch_crosses_an_instance_boundary() {
+    let mut builder = DmaInstancesBuilder::new("test", 2, ROWS);
+    // 15 memcpy rows for one chunk, whose first 5 rows were already collected by another air.
+    builder.add_op_rows(ChunkId(0), 5, 15, 15, DMA_COUNTER_MEMCPY);
+    let plan = builder.get_plan();
+    assert_eq!(plan.len(), 2);
+
+    let first = plan[0].1.chunks[&ChunkId(0)].1.memcpy;
+    assert_eq!((first.initial_skip, first.collect_count), (5, 10));
+
+    // The second instance skips the 5 rows taken elsewhere plus the 10 the first instance already
+    // collected — the batch's skip is not charged a second time.
+    let second = plan[1].1.chunks[&ChunkId(0)].1.memcpy;
+    assert_eq!((second.initial_skip, second.collect_count), (15, 5));
+}
+
+#[test]
+fn skip_is_kept_when_the_batch_fits_in_one_instance() {
+    let mut builder = DmaInstancesBuilder::new("test", 1, ROWS);
+    builder.add_op_rows(ChunkId(0), 3, 4, 4, DMA_COUNTER_MEMCPY);
+    let plan = builder.get_plan();
+    assert_eq!(plan.len(), 1);
+
+    let counter = plan[0].1.chunks[&ChunkId(0)].1.memcpy;
+    assert_eq!((counter.initial_skip, counter.collect_count), (3, 4));
+}
+
+#[test]
+fn inputs_counter_is_scoped_to_its_chunk() {
+    let mut builder = DmaInstancesBuilder::new("test", 1, ROWS);
+    builder.add_op_rows(ChunkId(0), 0, 4, 2, DMA_COUNTER_MEMCPY);
+    builder.add_op_rows(ChunkId(1), 0, 3, 1, DMA_COUNTER_MEMCPY);
+    let plan = builder.get_plan();
+    assert_eq!(plan.len(), 1);
+
+    // Each record carries only its own inputs: chunk 1 must not inherit chunk 0's.
+    let chunks = &plan[0].1.chunks;
+    assert_eq!(chunks[&ChunkId(0)].0, 2);
+    assert_eq!(chunks[&ChunkId(1)].0, 1);
+}
+
+#[test]
+fn inputs_counter_restarts_on_a_new_instance() {
+    let mut builder = DmaInstancesBuilder::new("test", 2, ROWS);
+    // Chunk 0 fills the first instance exactly, so chunk 1 opens a second one.
+    builder.add_op_rows(ChunkId(0), 0, ROWS, 3, DMA_COUNTER_MEMCPY);
+    builder.add_op_rows(ChunkId(1), 0, 2, 1, DMA_COUNTER_MEMCPY);
+    let plan = builder.get_plan();
+    assert_eq!(plan.len(), 2);
+
+    assert_eq!(plan[0].1.chunks[&ChunkId(0)].0, 3);
+    assert_eq!(plan[1].1.chunks[&ChunkId(1)].0, 1);
+}
+
+#[test]
+fn inputs_counter_sums_the_ops_of_the_same_chunk() {
+    let mut builder = DmaInstancesBuilder::new("test", 1, ROWS);
+    builder.add_op_rows(ChunkId(0), 0, 2, 2, DMA_COUNTER_MEMCPY);
+    builder.add_op_rows(ChunkId(0), 0, 3, 1, DMA_COUNTER_MEMCMP);
+    let plan = builder.get_plan();
+    assert_eq!(plan.len(), 1);
+
+    let (inputs, counters) = plan[0].1.chunks[&ChunkId(0)];
+    assert_eq!(inputs, 3);
+    assert_eq!(counters.memcpy.collect_count, 2);
+    assert_eq!(counters.memcmp.collect_count, 3);
+}

--- a/precompiles/dma/src/tests/dma_strategy_tests.rs
+++ b/precompiles/dma/src/tests/dma_strategy_tests.rs
@@ -1,0 +1,140 @@
+//! Unit tests for the `Dma`/`DmaPrePost` instance-count strategy.
+//! Declared from `dma_strategy.rs` via `#[cfg(test)] #[path = …] mod tests;`, so it stays a child
+//! module of `dma_strategy` and keeps `super::` access to privates.
+
+use super::*;
+use fields::Goldilocks;
+
+type Strategy = DmaStrategy<Goldilocks>;
+
+/// Rows per instance used by every air in these tests, so the three capacities are comparable.
+const CAP: usize = 100;
+
+/// Builds the `rows` slice `calculate_dma_strategy` expects, indexed by `DMA_COUNTER_*`.
+fn rows_of(
+    memcpy: usize,
+    memset: usize,
+    memcmp: usize,
+    inputcpy: usize,
+) -> [usize; DMA_COUNTER_OPS] {
+    let mut rows = [0usize; DMA_COUNTER_OPS];
+    rows[DMA_COUNTER_MEMCPY] = memcpy;
+    rows[DMA_COUNTER_MEMSET] = memset;
+    rows[DMA_COUNTER_MEMCMP] = memcmp;
+    rows[DMA_COUNTER_INPUTCPY] = inputcpy;
+    rows
+}
+
+fn plan(rows: &[usize]) -> DmaInstances {
+    let mut info = DmaInstances::default();
+    Strategy::calculate_dma_strategy(rows, CAP, CAP, CAP, &mut info);
+    info
+}
+
+/// The rows routed to each air must fit in the instances the strategy asked for, and no row may be
+/// routed twice. This is exactly what `DmaInstancesBuilder::open_new_instance` panics on when the
+/// strategy over-promises free space.
+fn assert_fits(rows: &[usize], info: &DmaInstances) {
+    assert!(
+        info.rows_memcpy_to_full <= rows[DMA_COUNTER_MEMCPY],
+        "moved more memcpy rows to full than exist: {rows:?} → {info:?}"
+    );
+    assert!(
+        info.rows_inputcpy_to_full <= rows[DMA_COUNTER_INPUTCPY],
+        "moved more inputcpy rows to full than exist: {rows:?} → {info:?}"
+    );
+
+    let full_rows = rows[DMA_COUNTER_MEMSET]
+        + rows[DMA_COUNTER_MEMCMP]
+        + info.rows_memcpy_to_full
+        + info.rows_inputcpy_to_full;
+    assert!(
+        full_rows <= info.full * CAP,
+        "full air overflows: {full_rows} rows in {} instances: {rows:?} → {info:?}",
+        info.full
+    );
+
+    let memcpy_rows = rows[DMA_COUNTER_MEMCPY] - info.rows_memcpy_to_full;
+    assert!(
+        memcpy_rows <= info.memcpy * CAP,
+        "memcpy air overflows: {memcpy_rows} rows in {} instances: {rows:?} → {info:?}",
+        info.memcpy
+    );
+
+    let inputcpy_rows = rows[DMA_COUNTER_INPUTCPY] - info.rows_inputcpy_to_full;
+    assert!(
+        inputcpy_rows <= info.inputcpy * CAP,
+        "inputcpy air overflows: {inputcpy_rows} rows in {} instances: {rows:?} → {info:?}",
+        info.inputcpy
+    );
+}
+
+#[test]
+fn exact_multiple_of_capacity_leaves_no_room_to_spare() {
+    // memset+memcmp fill the last full instance exactly, so there is nowhere to put the memcpy
+    // remainder: it must keep its own instance.
+    let rows = rows_of(CAP + 50, CAP, 0, 0);
+    let info = plan(&rows);
+    assert_fits(&rows, &info);
+
+    assert_eq!(info.full, 1);
+    assert_eq!(info.memcpy, 2);
+    assert_eq!(info.rows_memcpy_to_full, 0);
+}
+
+#[test]
+fn partially_filled_full_instance_absorbs_the_memcpy_remainder() {
+    // 50 free rows in the single full instance, and a 30-row memcpy remainder: folding it in drops
+    // one whole DmaMemCpy instance.
+    let rows = rows_of(CAP + 30, 50, 0, 0);
+    let info = plan(&rows);
+    assert_fits(&rows, &info);
+
+    assert_eq!(info.full, 1);
+    assert_eq!(info.memcpy, 1);
+    assert_eq!(info.rows_memcpy_to_full, 30);
+}
+
+#[test]
+fn both_remainders_share_one_extra_full_instance() {
+    // No memset/memcmp at all, so there is no free space anywhere; pooling both remainders into a
+    // new full instance still trades two partial instances for one.
+    let rows = rows_of(CAP + 40, 0, 0, CAP + 50);
+    let info = plan(&rows);
+    assert_fits(&rows, &info);
+
+    assert_eq!(info.full, 1);
+    assert_eq!(info.memcpy, 1);
+    assert_eq!(info.inputcpy, 1);
+    assert_eq!(info.rows_memcpy_to_full, 40);
+    assert_eq!(info.rows_inputcpy_to_full, 50);
+}
+
+#[test]
+fn no_rows_plans_nothing() {
+    let rows = rows_of(0, 0, 0, 0);
+    let info = plan(&rows);
+    assert_fits(&rows, &info);
+
+    assert_eq!(info.full, 0);
+    assert_eq!(info.memcpy, 0);
+    assert_eq!(info.inputcpy, 0);
+}
+
+#[test]
+fn capacity_invariant_holds_around_instance_boundaries() {
+    // Sweep values just below, at and just above each multiple of the capacity — the exact-multiple
+    // rows are where an off-by-one instance of free space hides.
+    const VALUES: [usize; 9] = [0, 1, 99, 100, 101, 150, 199, 200, 201];
+    for memcpy in VALUES {
+        for memset in VALUES {
+            for memcmp in VALUES {
+                for inputcpy in VALUES {
+                    let rows = rows_of(memcpy, memset, memcmp, inputcpy);
+                    let info = plan(&rows);
+                    assert_fits(&rows, &info);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
 Three independent bugs in the counters → plan path of the DMA precompile, all found while
reviewing the instance-selection strategy. Two of them can invalidate a run; the third is a
memory/robustness problem. Plus the first unit tests for the crate.

No behavioural change is intended beyond the fixes: the strategy still routes the same
operations to the same airs, and the PIL is untouched.

## 1. Planner panics when the full air's rows are an exact multiple of the capacity

`calculate_dma_strategy` computes how many rows are still free in the tail of the last `Dma`
(resp. `DmaPrePost`) instance, so it can fold the `memcpy`/`inputcpy` remainders in there and
save whole instances:

```rust
let remain_dma = rows_full % rows_x_full_instance;
let available_on_dma = if rows_full == 0 { 0 } else { rows_x_full_instance - remain_dma };
```

When `rows_full` (= `memset` + `memcmp` rows) is a non-zero exact multiple of the capacity,
`remain_dma == 0` and this reports `rows_x_full_instance` free rows — a whole free instance —
when the last instance is in fact completely full.

The planner then decrements `info.memcpy` and routes the remainder into the full air, which now
receives more rows than the instances it asked for can hold, and
`DmaInstancesBuilder::open_new_instance` aborts:

```
[dma_full] Too many instances 1 max: 1, cannot create more
```

Deterministic crash at planning time, so no invalid proof — but it depends only on a total row
count landing exactly on a multiple of 2^21, i.e. it is input-dependent and would show up as a
sporadic failure on an otherwise valid program. Affects both `Dma` and `DmaPrePost`.

Fixed by taking the remainder modulo the capacity, which yields 0 both for an exact multiple and
for `rows_full == 0`, subsuming the previous special case:

```rust
let available_on_dma = (rows_x_full_instance - remain_dma) % rows_x_full_instance;
```

## 2. `skip` charged once per instance instead of once per batch

In `DmaInstancesBuilder::add_op_rows`, `skip` is the number of rows of this op in this chunk that
another air already collected, so the collector must ignore them. It was applied inside the
`while rows > 0` loop, i.e. once per instance the batch spans.

When a `(chunk, op)` batch crosses an instance boundary, the second iteration first calls
`count_to_skip()`, which already moves the rows consumed by the previous instance into
`skip_*_rows`, and then adds `skip` a second time. With `skip = 5` and a 15-row batch over
10-row instances, the second instance gets `initial_skip = 20` instead of `15`.

Those 5 rows are then collected by nobody: the first instance had already passed them and the
second skips over them. In debug builds the collector's `debug_assert!(is_final_skip())` fires;
in release the witness is silently short of inputs and the proof fails on the bus.

Reachable in the `Dma`/`DmaPrePost` paths, which are the only ones passing `skip > 0` — the
remainder-packing routes of bug 1 — for the single chunk where the remainder budget is partially
consumed, when that chunk's remaining rows still exceed the space left in the instance.

Fixed by applying the skip once per batch. The four near-identical match arms were extracted into
`add_skip_rows` / `add_count_rows`, which is what was hiding the bug: with the per-batch skip and
the per-instance count interleaved in one `match`, nothing signalled that the two have different
scope.

## 3. `inputs_counter` is cumulative but consumed as a per-chunk value

`DmaInstancesBuilder::inputs_counter` was never reset — not by `count_to_skip`, nor
`reset_count_and_skip`, nor `open_new_instance`, nor `flush`. It is stored per
`(instance, chunk)` record and read back by the collectors as the number of inputs *for that
chunk*: `Vec::with_capacity(num_inputs)` and the early-exit condition
`inputs.len() == num_inputs`.

So every record after the first carried the running total of the whole execution. Consequences:

- **Memory.** `Vec::with_capacity` over-allocates in proportion to the total run, not the chunk,
  at 32 B per `DmaInput`, once per collector and there is one per (instance, chunk). On a run
  with millions of DMA operations this is hundreds of MB of dead capacity.
- **Dead checks.** The collectors' early exit never triggers, so the
  `debug_assert!(is_final_skip())` guarding it never runs.

The witness itself stayed correct: the real filter is `collect_counters`, and `num_inputs` only
gates early termination.

Fixed by restarting the counter in `flush_current_chunk`, right after the record that owns it is
stored. Doing it there rather than in the callers means the invariant does not depend on all
three flush sites remembering to. The early-return path needs no reset: `inputs_counter` only
grows in the same loop iteration as one of the `count_*` counters, so if all of them are zero it
is zero too.

### Note on the per-instance value

`inputs_counter += inputs` is still charged once per loop iteration, i.e. a batch that straddles
an instance boundary charges its full `inputs` to both instances. That is deliberate and now
documented in the code.

`num_inputs` only controls the collectors' early exit, so **over-estimating is safe and
under-estimating would truncate collection**. An operation crossing an instance boundary is
collected — partially — by both instances, and the aggregate `(rows, inputs)` counters carry no
information about how the operations are distributed inside the batch, so an exact split is not
derivable here. Charging `inputs` to every instance the batch reaches is the correct upper bound;
it is tight whenever nothing straddles, which is the common case.

With the reset in place, every record now holds what only the first record held before this PR.

## Tests

10 unit tests, the first in this crate, following the `#[cfg(test)] #[path = …] mod tests;`
layout already used by `precomp-arith-eq`:

- `src/tests/dma_strategy_tests.rs` — instance counts for `Dma`/`DmaPrePost`, including an
  `assert_fits` helper that checks the invariant `DmaInstancesBuilder` panics on (the rows routed
  to each air fit in the instances requested, and no row is routed twice), and a sweep over values
  just below, at and just above each multiple of the capacity.
- `src/tests/dma_instances_builder_tests.rs` — per-(instance, chunk) bookkeeping: skip across an
  instance boundary, and the scope of the inputs counter across chunks, instances and ops.

Each fix was reverted individually to confirm its tests fail without it:

| reverted fix | failure |
|---|---|
| 1 | `full air overflows: 150 rows in 1 instances` — exactly the condition `open_new_instance` aborts on. The boundary sweep also caught a second case I had not anticipated (`memcmp = 100, inputcpy = 1`). |
| 2 | `initial_skip` 20, expected 15 |
| 3 | `num_inputs` 3, expected 1; and 4, expected 1 |

## Verification

- `cargo test -p precomp-dma` — 10/10 pass
- `cargo clippy -p precomp-dma --all-targets` — clean
- `cargo fmt -p precomp-dma -- --check` — clean
- `cargo check -p executor --all-targets` — clean (`executor` is the only crate depending on
  `precomp-dma`)
