### PR TITLE
fix bug on arith-eq planner

### DIFF
--- a/precompiles/arith_eq/src/arith_eq_family.rs
+++ b/precompiles/arith_eq/src/arith_eq_family.rs
@@ -9,7 +9,6 @@
 //! `ArithEqCollector`) match what `executor`'s `register_precompiles!` expects.
 
 use std::any::Any;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use fields::PrimeField64;
@@ -52,6 +51,51 @@ impl ArithEqCheckPoint {
 
     pub fn count(&self) -> u32 {
         self.ops.iter().map(|c| c.count()).sum()
+    }
+}
+
+/// Every per-chunk collection window of one `ArithEq` instance, sorted by `chunk_id`.
+///
+/// A sorted `Vec` rather than a `HashMap<ChunkId, _>` because of how the two sides use it. The
+/// planner writes one entry per (instance, chunk) while filling an instance, always appending in
+/// chunk order and only ever touching the last entry — hashing a ~240-byte value on every write
+/// measured as ~80% of the planner's total time, buying nothing. Reads happen once per
+/// (instance, chunk), when its collector is built, where a binary search over a few thousand
+/// entries is free.
+#[derive(Debug, Default)]
+pub struct ArithEqCheckPoints(Vec<ArithEqCheckPoint>);
+
+impl ArithEqCheckPoints {
+    /// Sorts `windows` by chunk and wraps them, establishing the invariant [`Self::get`] needs.
+    fn new(mut windows: Vec<ArithEqCheckPoint>) -> Self {
+        windows.sort_unstable_by_key(|cp| cp.chunk_id);
+        Self(windows)
+    }
+
+    /// The window for `chunk_id`. Panics when absent, like the map indexing it replaces: the
+    /// executor only ever asks for the chunks the plan's `CheckPoint` listed.
+    pub fn get(&self, chunk_id: ChunkId) -> &ArithEqCheckPoint {
+        let idx = self
+            .0
+            .binary_search_by_key(&chunk_id, |cp| cp.chunk_id)
+            .unwrap_or_else(|_| panic!("ArithEqCheckPoints: no window for {chunk_id:?}"));
+        &self.0[idx]
+    }
+
+    pub fn chunk_ids(&self) -> Vec<ChunkId> {
+        self.0.iter().map(|cp| cp.chunk_id).collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, ArithEqCheckPoint> {
+        self.0.iter()
     }
 }
 
@@ -243,7 +287,7 @@ impl BusDevice<PayloadType> for ArithEqCollector {
 // ============================================================================
 
 /// Turns per-chunk per-op counters into per-air instance plans (one `Plan` per instance, carrying a
-/// `HashMap<ChunkId, ArithEqCheckPoint>` as metadata).
+/// [`ArithEqCheckPoints`] as metadata).
 pub struct ArithEqPlanner<F: PrimeField64> {
     _phantom: std::marker::PhantomData<F>,
 }
@@ -301,13 +345,24 @@ impl<F: PrimeField64> Planner for ArithEqPlanner<F> {
             debug_assert!(cap > 0);
 
             let mut air_budget = air_plan.op_counts;
+            // Only the ops this air actually proves — typically 1 to 3 of the 11. The chunk loop
+            // below runs once per chunk for every air, so walking all 11 slots each time is what
+            // dominates the filler on a long run.
+            let active_ops: Vec<usize> =
+                (0..ARITH_EQ_OP_NUM).filter(|&idx| air_budget[idx] > 0).collect();
+            // Operations still owed to this air, so the chunk loop can stop as soon as they are all
+            // placed instead of walking the remaining chunks with nothing left to do.
+            let mut remaining: u64 = air_budget.iter().sum();
+
             let mut cur_fill = 0u64;
-            let mut cur_cps: HashMap<ChunkId, ArithEqCheckPoint> = HashMap::new();
-            let mut cur_chunks: Vec<ChunkId> = Vec::new();
+            let mut cur_cps: Vec<ArithEqCheckPoint> = Vec::new();
             let mut segment = 0usize;
 
             for (chunk_idx, (chunk_id, counts)) in per_chunk.iter().enumerate() {
-                for idx in 0..ARITH_EQ_OP_NUM {
+                if remaining == 0 {
+                    break;
+                }
+                for &idx in &active_ops {
                     if air_budget[idx] == 0 {
                         continue;
                     }
@@ -316,30 +371,42 @@ impl<F: PrimeField64> Planner for ArithEqPlanner<F> {
                     let mut take_total = air_budget[idx].min(available);
                     while take_total > 0 {
                         if cur_fill == cap {
-                            Self::close_instance(
-                                &mut plans,
-                                air_id,
-                                &mut segment,
-                                &mut cur_cps,
-                                &mut cur_chunks,
-                            );
+                            Self::close_instance(&mut plans, air_id, &mut segment, &mut cur_cps);
                             cur_fill = 0;
                         }
                         let take = take_total.min(cap - cur_fill);
-                        if !cur_cps.contains_key(chunk_id) {
-                            cur_chunks.push(*chunk_id);
-                            cur_cps.insert(*chunk_id, ArithEqCheckPoint::new(air_id, *chunk_id));
+                        // All the ops of one chunk are handled together, so the window being written
+                        // is always the last one appended — a fresh instance starts with none.
+                        if cur_cps.last().map(|cp| cp.chunk_id) != Some(*chunk_id) {
+                            cur_cps.push(ArithEqCheckPoint::new(air_id, *chunk_id));
                         }
-                        cur_cps.get_mut(chunk_id).unwrap().ops[idx] =
+                        let cp = cur_cps.last_mut().unwrap();
+                        cp.ops[idx] =
                             CollectCounter::new(offset[chunk_idx][idx] as u32, take as u32);
                         offset[chunk_idx][idx] += take;
                         cur_fill += take;
                         air_budget[idx] -= take;
                         take_total -= take;
+                        remaining -= take;
                     }
                 }
             }
-            Self::close_instance(&mut plans, air_id, &mut segment, &mut cur_cps, &mut cur_chunks);
+            Self::close_instance(&mut plans, air_id, &mut segment, &mut cur_cps);
+
+            // The strategy promised these operations to this air and the chunks do contain them, so
+            // the budget must be spent. A leftover means the plan and the counters disagree, and
+            // those operations would end up collected by nobody.
+            debug_assert!(
+                air_budget.iter().all(|&b| b == 0),
+                "air {air_id}: {air_budget:?} operations left unplanned"
+            );
+            // Ties the two places that size this air: the strategy's `ceil(total / cap)` and the
+            // instances the filler actually cut.
+            debug_assert_eq!(
+                segment as u64, air_plan.instances,
+                "air {air_id}: filled {segment} instances, strategy sized {}",
+                air_plan.instances
+            );
         }
         plans
     }
@@ -350,20 +417,19 @@ impl<F: PrimeField64> ArithEqPlanner<F> {
         plans: &mut Vec<Plan>,
         air_id: usize,
         segment: &mut usize,
-        cur_cps: &mut HashMap<ChunkId, ArithEqCheckPoint>,
-        cur_chunks: &mut Vec<ChunkId>,
+        cur_cps: &mut Vec<ArithEqCheckPoint>,
     ) {
         if cur_cps.is_empty() {
             return;
         }
-        let checkpoints = std::mem::take(cur_cps);
-        let chunks = std::mem::take(cur_chunks);
+        // `new` sorts by chunk, which is also the order the `CheckPoint` list must agree with.
+        let checkpoints = ArithEqCheckPoints::new(std::mem::take(cur_cps));
         let plan = Plan::new(
             ZISK_AIRGROUP_ID,
             air_id,
             Some(SegmentId(*segment)),
             InstanceType::Instance,
-            CheckPoint::Multiple(chunks),
+            CheckPoint::Multiple(checkpoints.chunk_ids()),
             Some(Box::new(checkpoints)),
         );
         *segment += 1;
@@ -377,7 +443,7 @@ impl<F: PrimeField64> ArithEqPlanner<F> {
 
 pub struct ArithEqInstance<F: PrimeField64> {
     ictx: InstanceCtx,
-    checkpoint: HashMap<ChunkId, ArithEqCheckPoint>,
+    checkpoint: ArithEqCheckPoints,
     arith_eq_sm: Arc<ArithEqSM<F>>,
 }
 
@@ -385,13 +451,13 @@ impl<F: PrimeField64> ArithEqInstance<F> {
     pub fn new(arith_eq_sm: Arc<ArithEqSM<F>>, mut ictx: InstanceCtx) -> Self {
         let meta = ictx.plan.meta.take().expect("ArithEqInstance: expected metadata in plan.meta");
         let checkpoint = *meta
-            .downcast::<HashMap<ChunkId, ArithEqCheckPoint>>()
+            .downcast::<ArithEqCheckPoints>()
             .expect("ArithEqInstance: failed to downcast plan.meta");
         Self { ictx, checkpoint, arith_eq_sm }
     }
 
     pub fn build_arith_eq_collector(&self, chunk_id: ChunkId) -> ArithEqCollector {
-        ArithEqCollector::new(&self.checkpoint[&chunk_id])
+        ArithEqCollector::new(self.checkpoint.get(chunk_id))
     }
 }
 
@@ -431,7 +497,7 @@ impl<F: PrimeField64> Instance<F> for ArithEqInstance<F> {
     }
 
     fn build_inputs_collector(&self, chunk_id: ChunkId) -> Option<Box<dyn BusDevice<PayloadType>>> {
-        Some(Box::new(ArithEqCollector::new(&self.checkpoint[&chunk_id])))
+        Some(Box::new(ArithEqCollector::new(self.checkpoint.get(chunk_id))))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -471,3 +537,7 @@ impl<F: PrimeField64> ComponentBuilder<F> for ArithEqManager<F> {
         Box::new(ArithEqInstance::new(self.arith_eq_sm.clone(), ictx))
     }
 }
+
+#[cfg(test)]
+#[path = "tests/arith_eq_filler_tests.rs"]
+mod tests;

--- a/precompiles/arith_eq/src/arith_eq_family.rs
+++ b/precompiles/arith_eq/src/arith_eq_family.rs
@@ -58,10 +58,11 @@ impl ArithEqCheckPoint {
 ///
 /// A sorted `Vec` rather than a `HashMap<ChunkId, _>` because of how the two sides use it. The
 /// planner writes one entry per (instance, chunk) while filling an instance, always appending in
-/// chunk order and only ever touching the last entry — hashing a ~240-byte value on every write
-/// measured as ~80% of the planner's total time, buying nothing. Reads happen once per
-/// (instance, chunk), when its collector is built, where a binary search over a few thousand
-/// entries is free.
+/// chunk order and only ever touching the last one, so it paid a hash-table probe per write to find
+/// an entry it already knew, plus relocating the ~240-byte `ArithEqCheckPoint` on insert and again
+/// whenever the table grew. That measured as ~80% of the planner's total time. Reads happen once per
+/// (instance, chunk), when its collector is built, where the binary search that replaces the probe
+/// is free.
 #[derive(Debug, Default)]
 pub struct ArithEqCheckPoints(Vec<ArithEqCheckPoint>);
 

--- a/precompiles/arith_eq/src/arith_eq_planner.rs
+++ b/precompiles/arith_eq/src/arith_eq_planner.rs
@@ -2,7 +2,7 @@
 //!
 //! The counter tallies each sub-operation separately (`[u64; ARITH_EQ_OP_NUM]`). This module turns
 //! those totals — together with the airs actually present in the pilout — into a per-air, per-op
-//! assignment that covers every observed operation at (heuristically) minimal total area.
+//! assignment that covers every observed operation at minimal total area.
 //!
 //! Area model: every instance is a full `num_rows` trace regardless of how full it is, so its area is
 //! `instances · num_rows · row_size`. A specialized air (fewer columns → smaller `row_size`) is the
@@ -10,27 +10,28 @@
 //! instance can cost more area than folding its leftover into a broader air shared with other
 //! leftovers.
 //!
-//! Strategy (per family = PIL equation group):
-//!   * Its `full = count / cap` **full instances always go to its specialized air** (cheapest per-op).
-//!   * Its `remainder = count % cap` is either kept in one extra partial specialized instance, or
-//!     **pooled into the universal (full `ArithEq`) air** together with other families' leftovers.
+//! Strategy, per operation (not per PIL equation group: an air may cover only part of a group, and
+//! `Arith256` is proved by both the 11-column `Arith256` air and the 19-column `Arith256X` one):
+//!   * Its `bulk = ⌊count/cap⌋·cap` — the part that fills whole instances — **always goes to the
+//!     covering air with the smallest row**. Since `cap = num_rows / ARITH_EQ_ROWS_BY_OP`, a filled
+//!     instance costs `ARITH_EQ_ROWS_BY_OP · row_size` per operation whatever `num_rows` is, so no
+//!     other air can prove those instances for less. And a bulk is a whole number of instances, so
+//!     it can never absorb anyone's leftover: the choice is independent of everything below.
+//!   * Its `tail = count % cap` may go to **any** air that covers it — its own cheapest air (i.e.
+//!     one extra partial instance), another specialized air whose partial instance it can share, or
+//!     the universal air pooling every leftover.
 //!
-//! We enumerate which remainders to pool and pick the least total area. Because a remainder can be
-//! pooled, a single operation type may be **split** across its specialized air (its full instances)
-//! and the universal air (its remainder) — the per-air `op_counts` capture that split, and the
-//! planner's filler assigns non-overlapping per-op collect windows (specialized ranks first).
+//! Only the tails are searched, exhaustively, so the result is optimal within that model. Because a
+//! tail can land elsewhere, a single operation may be **split** across two airs — the per-air
+//! `op_counts` capture that split, and the planner's filler assigns non-overlapping per-op collect
+//! windows in the order the plans are returned.
 
 use crate::{air_metas, ArithEqAirMeta, ArithEqOp, ARITH_EQ_OP_NUM, ARITH_EQ_ROWS_BY_OP};
 
-/// Intrinsic `ArithEq` operation families (PIL equation groups): ops within a family are proved by
-/// the same specialized air.
-const FAMILIES: &[&[ArithEqOp]] = &[
-    &[ArithEqOp::Arith256, ArithEqOp::Arith256Mod],
-    &[ArithEqOp::Secp256k1Add, ArithEqOp::Secp256k1Dbl],
-    &[ArithEqOp::Bn254CurveAdd, ArithEqOp::Bn254CurveDbl],
-    &[ArithEqOp::Bn254ComplexAdd, ArithEqOp::Bn254ComplexSub, ArithEqOp::Bn254ComplexMul],
-    &[ArithEqOp::Secp256r1Add, ArithEqOp::Secp256r1Dbl],
-];
+/// Upper bound on the tail placements this exhaustive search will enumerate. The current air table
+/// yields `3 · 2^8 = 768`; the bound is here so that adding heavily overlapping airs fails loudly
+/// instead of silently hanging, since optimal tail placement is a bin-packing problem.
+const MAX_TAIL_COMBINATIONS: u64 = 1 << 20;
 
 /// One planned air: how many of each operation it proves. Ops with a non-zero count feed this air;
 /// the same op may also appear (with the complementary count) in another air when split.
@@ -48,172 +49,155 @@ impl ArithEqAirPlan {
     }
 }
 
+/// Operations one instance of `m` can prove.
 #[inline]
 fn cap(m: &ArithEqAirMeta) -> u64 {
     m.num_rows as u64 / ARITH_EQ_ROWS_BY_OP as u64
 }
 
+/// Area of one instance of `m`, full or not.
+#[inline]
+fn instance_area(m: &ArithEqAirMeta) -> u64 {
+    m.num_rows as u64 * m.row_size as u64
+}
+
 /// Total area to prove `ops` operations in air `m`: `ceil(ops/cap) · num_rows · row_size`.
+///
+/// The definition of the cost model, kept for the tests to state expected areas with. The sweep in
+/// `plan_air_strategy` inlines it against hoisted `caps`/`instance_areas` instead of calling it, so
+/// it does not redo both divisions once per air per combination.
+#[cfg(test)]
 #[inline]
 fn area(m: &ArithEqAirMeta, ops: u64) -> u64 {
-    ops.div_ceil(cap(m)) * m.num_rows as u64 * m.row_size as u64
+    ops.div_ceil(cap(m)) * instance_area(m)
+}
+
+/// A leftover to place: fewer than `cap` operations of one op, and the airs that could take them.
+struct Tail {
+    op_idx: usize,
+    rows: u64,
+    /// Indices into the `metas` slice.
+    candidates: Vec<usize>,
 }
 
 /// Compute the per-air, per-op assignment for the given per-op totals, considering only
-/// `present_air_ids` (the airs in the pilout), minimizing total instance area. The returned plans put
-/// the universal (full) air last, so the filler assigns specialized ranks of each op first. Panics if
-/// an observed operation is covered by no present air.
+/// `present_air_ids` (the airs in the pilout), minimizing total instance area. Plans come back in
+/// `air_metas()` order — cheapest/most-specific first, universal last — so a split op's specialized
+/// collect windows are assigned before its universal ones. Panics if an observed operation is
+/// covered by no present air.
 pub fn plan_air_strategy(
     present_air_ids: &[usize],
     op_counts: &[u64; ARITH_EQ_OP_NUM],
 ) -> Vec<ArithEqAirPlan> {
     let metas: Vec<ArithEqAirMeta> =
         air_metas().into_iter().filter(|m| present_air_ids.contains(&m.air_id)).collect();
-    if metas.is_empty() {
-        return Vec::new();
-    }
 
-    // Universal air = one that covers every operation (the full `ArithEq`); pools leftovers.
-    let universal = metas.iter().find(|m| ArithEqOp::ALL.iter().all(|&op| m.covers(op))).copied();
-    let universal_id = universal.as_ref().map(|u| u.air_id);
+    // Rows every air receives no matter how the tails are placed, and which ops they came from.
+    let mut bulk_rows = vec![0u64; metas.len()];
+    let mut air_counts = vec![[0u64; ARITH_EQ_OP_NUM]; metas.len()];
+    let mut tails: Vec<Tail> = Vec::new();
 
-    // Present families: total count, full/remainder split, cheapest covering specialized air.
-    struct Family {
-        ops: Vec<usize>,
-        count: u64,
-        spec: Option<ArithEqAirMeta>,
-        full: u64,
-        rem: u64,
-    }
-    let mut families: Vec<Family> = Vec::new();
-    for fam in FAMILIES {
-        let ops: Vec<usize> =
-            fam.iter().map(|op| op.index()).filter(|&i| op_counts[i] > 0).collect();
-        if ops.is_empty() {
+    for (op_idx, &count) in op_counts.iter().enumerate() {
+        if count == 0 {
             continue;
         }
-        let count: u64 = ops.iter().map(|&i| op_counts[i]).sum();
-        let spec = metas
-            .iter()
-            .filter(|m| Some(m.air_id) != universal_id)
-            .filter(|m| ops.iter().all(|&i| m.covers(ArithEqOp::ALL[i])))
-            .min_by_key(|m| m.row_size)
-            .copied();
-        let (full, rem) = match &spec {
-            Some(s) => (count / cap(s), count % cap(s)),
-            None => (0, count), // no specialized air → everything pools into the universal air
-        };
-        families.push(Family { ops, count, spec, full, rem });
-    }
-    if families.is_empty() {
-        return Vec::new();
+        let op = ArithEqOp::ALL[op_idx];
+        let candidates: Vec<usize> = (0..metas.len()).filter(|&j| metas[j].covers(op)).collect();
+        assert!(!candidates.is_empty(), "plan_air_strategy: {op:?} is covered by no present air");
+
+        let bulk_air = *candidates.iter().min_by_key(|&&j| metas[j].row_size).unwrap();
+        let bulk = count / cap(&metas[bulk_air]) * cap(&metas[bulk_air]);
+        if bulk > 0 {
+            bulk_rows[bulk_air] += bulk;
+            air_counts[bulk_air][op_idx] += bulk;
+        }
+        if count > bulk {
+            tails.push(Tail { op_idx, rows: count - bulk, candidates });
+        }
     }
 
-    // Full instances always go specialized (fixed area). Only remainders are decided.
-    let full_area: u64 = families
+    let combinations = tails
         .iter()
-        .filter_map(|f| f.spec.as_ref().map(|s| f.full * s.num_rows as u64 * s.row_size as u64))
-        .sum();
-    let forced_pool: u64 = families.iter().filter(|f| f.spec.is_none()).map(|f| f.count).sum();
-
-    // Candidates for the pool-vs-keep decision: families with a specialized air and a remainder.
-    let candidates: Vec<usize> = (0..families.len())
-        .filter(|&i| families[i].spec.is_some() && families[i].rem > 0)
-        .collect();
-
-    let mut best_mask = 0u64;
-    let mut best_area = u64::MAX;
-    for mask in 0..(1u64 << candidates.len()) {
-        let mut spec_partial = 0u64;
-        let mut pool = forced_pool;
-        for (bit, &fi) in candidates.iter().enumerate() {
-            let s = families[fi].spec.as_ref().unwrap();
-            if mask & (1 << bit) != 0 {
-                pool += families[fi].rem; // pool this remainder
-            } else {
-                spec_partial += s.num_rows as u64 * s.row_size as u64; // one extra partial instance
-            }
-        }
-        let pool_area = if pool > 0 {
-            match &universal {
-                Some(u) => area(u, pool),
-                None => continue, // cannot pool without a universal air
-            }
-        } else {
-            0
-        };
-        let total = full_area + spec_partial + pool_area;
-        if total < best_area {
-            best_area = total;
-            best_mask = mask;
-        }
-    }
+        .try_fold(1u64, |acc, t| acc.checked_mul(t.candidates.len() as u64))
+        .unwrap_or(u64::MAX);
     assert!(
-        best_area != u64::MAX,
-        "plan_air_strategy: some operation is covered by no present air"
+        combinations <= MAX_TAIL_COMBINATIONS,
+        "plan_air_strategy: {combinations} tail placements exceed the {MAX_TAIL_COMBINATIONS} this \
+         exhaustive search is sized for; the air table needs a smarter search"
     );
 
-    // Materialize per-air, per-op counts. `pool_promoted[i]` = remainder of candidate i goes to univ.
-    let promoted: std::collections::HashSet<usize> = candidates
+    // Hoisted out of the sweep below: `area` would otherwise recompute both divisions once per air
+    // per combination.
+    let caps: Vec<u64> = metas.iter().map(cap).collect();
+    let instance_areas: Vec<u64> = metas.iter().map(instance_area).collect();
+
+    // Mixed-radix sweep over the tail placements: choice[i] indexes tails[i].candidates.
+    let mut choice = vec![0usize; tails.len()];
+    let mut best_choice = choice.clone();
+    let mut best_area = u64::MAX;
+    let mut rows = vec![0u64; metas.len()];
+    loop {
+        rows.copy_from_slice(&bulk_rows);
+        for (t, &c) in tails.iter().zip(choice.iter()) {
+            rows[t.candidates[c]] += t.rows;
+        }
+        let total: u64 = rows
+            .iter()
+            .enumerate()
+            .map(|(j, &r)| if r == 0 { 0 } else { r.div_ceil(caps[j]) * instance_areas[j] })
+            .sum();
+        if total < best_area {
+            best_area = total;
+            best_choice.copy_from_slice(&choice);
+        }
+
+        // Advance from the rightmost digit; a carry out of the leftmost means we are back to the
+        // all-zeros placement and every combination has been seen. With no tails at all this exits
+        // after the single evaluation above.
+        let mut carry = true;
+        for (pos, digit) in choice.iter_mut().enumerate().rev() {
+            *digit += 1;
+            if *digit < tails[pos].candidates.len() {
+                carry = false;
+                break;
+            }
+            *digit = 0;
+        }
+        if carry {
+            break;
+        }
+    }
+
+    for (t, &c) in tails.iter().zip(best_choice.iter()) {
+        air_counts[t.candidates[c]][t.op_idx] += t.rows;
+    }
+
+    let plans: Vec<ArithEqAirPlan> = metas
         .iter()
-        .enumerate()
-        .filter(|(bit, _)| best_mask & (1 << bit) != 0)
-        .map(|(_, &fi)| fi)
+        .zip(air_counts)
+        .filter_map(|(m, counts)| {
+            let total: u64 = counts.iter().sum();
+            (total > 0).then(|| ArithEqAirPlan {
+                air_id: m.air_id,
+                op_counts: counts,
+                instances: total.div_ceil(cap(m)),
+            })
+        })
         .collect();
 
-    let mut spec_counts: Vec<(usize, [u64; ARITH_EQ_OP_NUM])> = Vec::new(); // (air_id, counts)
-    let mut univ_counts = [0u64; ARITH_EQ_OP_NUM];
-
-    for (i, f) in families.iter().enumerate() {
-        match &f.spec {
-            Some(s) => {
-                // Ops kept in the specialized air: all of them unless this family's remainder is
-                // pooled, in which case only the `full · cap` that fill whole instances stay.
-                let spec_total = if promoted.contains(&i) { f.full * cap(s) } else { f.count };
-                let mut remaining = spec_total;
-                let entry = spec_counts.iter_mut().find(|(id, _)| *id == s.air_id);
-                let counts = match entry {
-                    Some((_, c)) => c,
-                    None => {
-                        spec_counts.push((s.air_id, [0u64; ARITH_EQ_OP_NUM]));
-                        &mut spec_counts.last_mut().unwrap().1
-                    }
-                };
-                for &op_idx in &f.ops {
-                    let to_spec = op_counts[op_idx].min(remaining);
-                    counts[op_idx] += to_spec;
-                    remaining -= to_spec;
-                    univ_counts[op_idx] += op_counts[op_idx] - to_spec;
-                }
-            }
-            None => {
-                for &op_idx in &f.ops {
-                    univ_counts[op_idx] += op_counts[op_idx];
-                }
+    // Every counted operation must be planned exactly once: an op silently missing from every plan
+    // would never be collected, and would only surface much later as an unbalanced bus.
+    #[cfg(debug_assertions)]
+    {
+        let mut summed = [0u64; ARITH_EQ_OP_NUM];
+        for plan in &plans {
+            for (s, c) in summed.iter_mut().zip(plan.op_counts.iter()) {
+                *s += *c;
             }
         }
+        assert_eq!(&summed, op_counts, "plan_air_strategy dropped or duplicated operations");
     }
 
-    // Emit specialized plans first, then the universal pool (so the filler assigns specialized ranks
-    // of each split op before the universal ranks).
-    let mut plans: Vec<ArithEqAirPlan> = Vec::new();
-    for (air_id, counts) in spec_counts {
-        let m = metas.iter().find(|m| m.air_id == air_id).unwrap();
-        let total: u64 = counts.iter().sum();
-        if total == 0 {
-            continue;
-        }
-        plans.push(ArithEqAirPlan { air_id, op_counts: counts, instances: total.div_ceil(cap(m)) });
-    }
-    let univ_total: u64 = univ_counts.iter().sum();
-    if univ_total > 0 {
-        let u = universal.as_ref().expect("universal air required to pool leftovers");
-        plans.push(ArithEqAirPlan {
-            air_id: u.air_id,
-            op_counts: univ_counts,
-            instances: univ_total.div_ceil(cap(u)),
-        });
-    }
     plans
 }
 

--- a/precompiles/arith_eq/src/arith_eq_planner.rs
+++ b/precompiles/arith_eq/src/arith_eq_planner.rs
@@ -2,7 +2,7 @@
 //!
 //! The counter tallies each sub-operation separately (`[u64; ARITH_EQ_OP_NUM]`). This module turns
 //! those totals — together with the airs actually present in the pilout — into a per-air, per-op
-//! assignment that covers every observed operation at minimal total area.
+//! assignment that covers every observed operation, cheaply in total area.
 //!
 //! Area model: every instance is a full `num_rows` trace regardless of how full it is, so its area is
 //! `instances · num_rows · row_size`. A specialized air (fewer columns → smaller `row_size`) is the
@@ -21,10 +21,21 @@
 //!     one extra partial instance), another specialized air whose partial instance it can share, or
 //!     the universal air pooling every leftover.
 //!
-//! Only the tails are searched, exhaustively, so the result is optimal within that model. Because a
-//! tail can land elsewhere, a single operation may be **split** across two airs — the per-air
+//! Only the tails are searched, and each one is placed **whole**: the sweep is exhaustive over which
+//! air takes a tail, not over how a tail might be divided between several. Because a tail can land
+//! away from its bulk, a single operation may still be **split** across two airs — the per-air
 //! `op_counts` capture that split, and the planner's filler assigns non-overlapping per-op collect
 //! windows in the order the plans are returned.
+//!
+//! # Known gap
+//!
+//! Placing tails whole is *not* globally area-minimal. Dividing one tail to top up the spare
+//! capacity of two other airs can empty an air completely, which the sweep cannot see: with equal
+//! capacities `c` and counts `Arith256 = c/2`, `Arith256Mod = 3c/4`, `Secp256r1Add = 3c/4` it picks
+//! one instance each of `Arith256`, `Arith256X` and `ArithEq`, where splitting the `Arith256` tail
+//! into `c/4 + c/4` fills `Arith256X` and `ArithEq` exactly and drops the `Arith256` instance — 14.7%
+//! less area. `indivisible_tails_are_a_known_gap` pins this down. Searching divisible placements is
+//! bin packing with splitting, so it needs a different algorithm, not a wider sweep.
 
 use crate::{air_metas, ArithEqAirMeta, ArithEqOp, ARITH_EQ_OP_NUM, ARITH_EQ_ROWS_BY_OP};
 
@@ -81,7 +92,8 @@ struct Tail {
 }
 
 /// Compute the per-air, per-op assignment for the given per-op totals, considering only
-/// `present_air_ids` (the airs in the pilout), minimizing total instance area. Plans come back in
+/// `present_air_ids` (the airs in the pilout), at the least total instance area among the placements
+/// it searches — every tail placed whole, see the module's *Known gap*. Plans come back in
 /// `air_metas()` order — cheapest/most-specific first, universal last — so a split op's specialized
 /// collect windows are assigned before its universal ones. Panics if an observed operation is
 /// covered by no present air.

--- a/precompiles/arith_eq/src/tests/arith_eq_filler_tests.rs
+++ b/precompiles/arith_eq/src/tests/arith_eq_filler_tests.rs
@@ -11,7 +11,7 @@
 use super::*;
 use fields::Goldilocks;
 use std::collections::BTreeMap;
-use zisk_pil::{Arith256Trace, ArithSecp256K1Trace};
+use zisk_pil::{Arith256Trace, ArithEqTrace, ArithSecp256K1Trace};
 
 // NOTE: not named `Planner`, which would shadow the `zisk_common::Planner` trait `plan` comes from.
 type TestPlanner = ArithEqPlanner<Goldilocks>;
@@ -209,8 +209,26 @@ fn a_split_op_tiles_across_two_airs() {
     let plans = plan_of(per_chunk);
     let per_air = assert_tiles(&plans, per_chunk);
 
-    // Whichever way the strategy pools, secp256k1 keeps at least its two full instances.
-    assert!(per_air.get(&ArithSecp256K1Trace::<()>::AIR_ID).is_some_and(|&n| n >= 2));
+    // secp256k1 keeps its two full instances specialized.
+    assert_eq!(per_air.get(&ArithSecp256K1Trace::<()>::AIR_ID), Some(&2));
+
+    // And the split the test is named for: the 10-op tail is proved by the universal air, whose
+    // window must start exactly where the specialized ones stopped. Without this the test would
+    // still pass if the tail went back to ArithSecp256K1 — tiling holds either way.
+    let op = ArithEqOp::Secp256k1Add.index();
+    let specialized: u64 = plans
+        .iter()
+        .filter(|p| p.air_id == ArithSecp256K1Trace::<()>::AIR_ID)
+        .map(|p| checkpoint_of(p).get(ChunkId(0)).ops[op].collect_count as u64)
+        .sum();
+    assert_eq!(specialized, 2 * cap);
+
+    let pooled = plans
+        .iter()
+        .find(|p| p.air_id == ArithEqTrace::<()>::AIR_ID)
+        .expect("the tail must be pooled into the universal air");
+    let window = checkpoint_of(pooled).get(ChunkId(0)).ops[op];
+    assert_eq!((window.initial_skip as u64, window.collect_count as u64), (2 * cap, 10));
 }
 
 #[test]

--- a/precompiles/arith_eq/src/tests/arith_eq_filler_tests.rs
+++ b/precompiles/arith_eq/src/tests/arith_eq_filler_tests.rs
@@ -1,0 +1,233 @@
+//! Unit tests for `ArithEqPlanner::plan` — the filler that turns the per-air strategy into one
+//! `Plan` per instance, with a per-(chunk, op) collect window.
+//!
+//! Declared from `arith_eq_family.rs` via `#[cfg(test)] #[path = …] mod tests;`.
+//!
+//! The property that matters is **tiling**: for every (chunk, op), the collect windows emitted
+//! across all plans must partition that chunk's occurrences of that op — no overlap (an operation
+//! proved twice) and no gap (an operation never proved). The strategy decides *where* rows go; this
+//! is what guarantees the plans actually collect them exactly once.
+
+use super::*;
+use fields::Goldilocks;
+use std::collections::BTreeMap;
+use zisk_pil::{Arith256Trace, ArithSecp256K1Trace};
+
+// NOTE: not named `Planner`, which would shadow the `zisk_common::Planner` trait `plan` comes from.
+type TestPlanner = ArithEqPlanner<Goldilocks>;
+
+fn cap_of(air_id: usize) -> u64 {
+    let meta = air_metas().into_iter().find(|m| m.air_id == air_id).unwrap();
+    meta.num_rows as u64 / ARITH_EQ_ROWS_BY_OP as u64
+}
+
+/// Builds the planner input from per-chunk `(op, count)` lists, in chunk order.
+fn counters(per_chunk: &[&[(ArithEqOp, u64)]]) -> Vec<(ChunkId, Box<dyn BusDeviceMetrics>)> {
+    per_chunk
+        .iter()
+        .enumerate()
+        .map(|(idx, ops)| {
+            let mut counter = ArithEqCounterInputGen::<Goldilocks>::new(BusDeviceMode::Counter);
+            for &(op, n) in *ops {
+                counter.counts[op.index()] = n;
+            }
+            (ChunkId(idx), Box::new(counter) as Box<dyn BusDeviceMetrics>)
+        })
+        .collect()
+}
+
+fn checkpoint_of(plan: &Plan) -> &ArithEqCheckPoints {
+    plan.meta.as_ref().unwrap().downcast_ref::<ArithEqCheckPoints>().unwrap()
+}
+
+/// Asserts the collect windows of every (chunk, op) tile `[0, count)` exactly once, and that no
+/// instance is over-filled. Returns the number of plans per air id.
+fn assert_tiles(plans: &[Plan], per_chunk: &[&[(ArithEqOp, u64)]]) -> BTreeMap<usize, usize> {
+    // (chunk, op) -> the windows every plan asks to collect, as (skip, count).
+    let mut windows: BTreeMap<(usize, usize), Vec<(u64, u64)>> = BTreeMap::new();
+    let mut plans_per_air: BTreeMap<usize, usize> = BTreeMap::new();
+
+    for plan in plans {
+        *plans_per_air.entry(plan.air_id).or_default() += 1;
+        let checkpoint = checkpoint_of(plan);
+        assert!(!checkpoint.is_empty(), "air {} emitted an empty instance", plan.air_id);
+
+        // The plan's CheckPoint must list exactly the chunks its metadata covers, or the executor
+        // would build a collector for a chunk with no window (or miss one entirely).
+        let listed = match &plan.check_point {
+            CheckPoint::Multiple(chunks) => chunks.to_vec(),
+            other => panic!("expected CheckPoint::Multiple, got {other:?}"),
+        };
+        assert_eq!(listed, checkpoint.chunk_ids(), "chunk list and metadata windows disagree");
+        // `get` is the binary search the executor uses to find a chunk's window; it must resolve
+        // every chunk the plan listed, which also asserts the sorted invariant holds.
+        for &chunk_id in &listed {
+            assert_eq!(checkpoint.get(chunk_id).chunk_id, chunk_id);
+        }
+
+        let mut filled = 0u64;
+        for cp in checkpoint.iter() {
+            let chunk_id = &cp.chunk_id;
+            assert_eq!(cp.air_id, plan.air_id);
+            for (op_idx, counter) in cp.ops.iter().enumerate() {
+                if counter.collect_count == 0 {
+                    continue;
+                }
+                filled += counter.collect_count as u64;
+                windows
+                    .entry((chunk_id.0, op_idx))
+                    .or_default()
+                    .push((counter.initial_skip as u64, counter.collect_count as u64));
+            }
+        }
+        assert!(
+            filled <= cap_of(plan.air_id),
+            "air {} instance holds {filled} ops, capacity is {}",
+            plan.air_id,
+            cap_of(plan.air_id)
+        );
+    }
+
+    // Every op occurrence of every chunk must be covered exactly once.
+    for (chunk_idx, ops) in per_chunk.iter().enumerate() {
+        for &(op, count) in *ops {
+            if count == 0 {
+                continue;
+            }
+            let key = (chunk_idx, op.index());
+            let mut got = windows.remove(&key).unwrap_or_default();
+            got.sort_unstable();
+
+            let mut covered = 0u64;
+            for (skip, len) in &got {
+                assert_eq!(
+                    *skip, covered,
+                    "chunk {chunk_idx} op {op:?}: window starts at {skip}, expected {covered} \
+                     (windows: {got:?})"
+                );
+                covered += len;
+            }
+            assert_eq!(
+                covered, count,
+                "chunk {chunk_idx} op {op:?}: windows cover {covered} of {count} occurrences \
+                 (windows: {got:?})"
+            );
+        }
+    }
+    // Anything left refers to an op/chunk that was never counted.
+    assert!(windows.is_empty(), "windows for uncounted (chunk, op) pairs: {windows:?}");
+
+    plans_per_air
+}
+
+fn plan_of(per_chunk: &[&[(ArithEqOp, u64)]]) -> Vec<Plan> {
+    TestPlanner::new().plan(counters(per_chunk))
+}
+
+#[test]
+fn no_operations_plans_nothing() {
+    assert!(plan_of(&[&[], &[]]).is_empty());
+}
+
+#[test]
+fn single_chunk_single_op() {
+    let per_chunk: &[&[(ArithEqOp, u64)]] = &[&[(ArithEqOp::Arith256, 3)]];
+    let plans = plan_of(per_chunk);
+    let per_air = assert_tiles(&plans, per_chunk);
+    assert_eq!(per_air.values().sum::<usize>(), 1);
+}
+
+#[test]
+fn windows_tile_across_several_chunks() {
+    let per_chunk: &[&[(ArithEqOp, u64)]] = &[
+        &[(ArithEqOp::Arith256, 5), (ArithEqOp::Secp256k1Add, 2)],
+        &[(ArithEqOp::Arith256, 7)],
+        &[(ArithEqOp::Secp256k1Add, 4), (ArithEqOp::Bn254ComplexMul, 1)],
+    ];
+    let plans = plan_of(per_chunk);
+    assert_tiles(&plans, per_chunk);
+}
+
+#[test]
+fn an_op_spanning_several_instances_is_split_without_gaps() {
+    // One chunk holding more of a single op than an instance can take: the filler must cut it into
+    // consecutive windows, one per instance.
+    let air = Arith256Trace::<()>::AIR_ID;
+    let cap = cap_of(air);
+    let per_chunk: &[&[(ArithEqOp, u64)]] = &[&[(ArithEqOp::Arith256, 2 * cap + 10)]];
+    let plans = plan_of(per_chunk);
+    let per_air = assert_tiles(&plans, per_chunk);
+
+    assert_eq!(per_air.get(&air), Some(&3), "expected ceil((2·cap + 10)/cap) = 3 instances");
+}
+
+#[test]
+fn an_instance_boundary_inside_a_chunk_keeps_both_windows() {
+    // The first instance fills up midway through the chunk, so the chunk appears in two instances
+    // with disjoint windows for the same op.
+    let air = Arith256Trace::<()>::AIR_ID;
+    let cap = cap_of(air);
+    let per_chunk: &[&[(ArithEqOp, u64)]] =
+        &[&[(ArithEqOp::Arith256, cap - 1)], &[(ArithEqOp::Arith256, 5)]];
+    let plans = plan_of(per_chunk);
+    assert_tiles(&plans, per_chunk);
+
+    // Chunk 1's 5 occurrences straddle the boundary: 1 in the first instance, 4 in the second.
+    let first = checkpoint_of(&plans[0]).get(ChunkId(1)).ops[ArithEqOp::Arith256.index()];
+    assert_eq!((first.initial_skip, first.collect_count), (0, 1));
+    let second = checkpoint_of(&plans[1]).get(ChunkId(1)).ops[ArithEqOp::Arith256.index()];
+    assert_eq!((second.initial_skip, second.collect_count), (1, 4));
+}
+
+#[test]
+fn segment_ids_are_contiguous_per_air() {
+    let air = Arith256Trace::<()>::AIR_ID;
+    let cap = cap_of(air);
+    let per_chunk: &[&[(ArithEqOp, u64)]] =
+        &[&[(ArithEqOp::Arith256, 2 * cap + 1), (ArithEqOp::Secp256k1Add, 1)]];
+    let plans = plan_of(per_chunk);
+    assert_tiles(&plans, per_chunk);
+
+    let mut seen: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for plan in &plans {
+        seen.entry(plan.air_id).or_default().push(plan.segment_id.unwrap().0);
+    }
+    for (air_id, mut segments) in seen {
+        segments.sort_unstable();
+        let expected: Vec<usize> = (0..segments.len()).collect();
+        assert_eq!(segments, expected, "air {air_id} segment ids must be 0..n");
+    }
+}
+
+#[test]
+fn a_split_op_tiles_across_two_airs() {
+    // A family big enough that its remainder is worth pooling elsewhere: the same op is then proved
+    // partly by its specialized air and partly by the pool, and the windows must still tile.
+    let cap = cap_of(ArithSecp256K1Trace::<()>::AIR_ID);
+    let per_chunk: &[&[(ArithEqOp, u64)]] =
+        &[&[(ArithEqOp::Secp256k1Add, 2 * cap + 10), (ArithEqOp::Arith256Mod, 7)]];
+    let plans = plan_of(per_chunk);
+    let per_air = assert_tiles(&plans, per_chunk);
+
+    // Whichever way the strategy pools, secp256k1 keeps at least its two full instances.
+    assert!(per_air.get(&ArithSecp256K1Trace::<()>::AIR_ID).is_some_and(|&n| n >= 2));
+}
+
+#[test]
+fn every_op_is_planned_even_without_a_specialized_air() {
+    // secp256r1 has no specialized air, so it can only be proved by the universal one; it must
+    // still be covered.
+    let per_chunk: &[&[(ArithEqOp, u64)]] =
+        &[&[(ArithEqOp::Secp256r1Add, 3), (ArithEqOp::Secp256r1Dbl, 2), (ArithEqOp::Arith256, 4)]];
+    let plans = plan_of(per_chunk);
+    assert_tiles(&plans, per_chunk);
+}
+
+#[test]
+fn all_eleven_ops_at_once_tile() {
+    let all: Vec<(ArithEqOp, u64)> =
+        ArithEqOp::ALL.iter().enumerate().map(|(i, &op)| (op, i as u64 + 1)).collect();
+    let per_chunk: &[&[(ArithEqOp, u64)]] = &[&all];
+    let plans = plan_of(per_chunk);
+    assert_tiles(&plans, per_chunk);
+}

--- a/precompiles/arith_eq/src/tests/arith_eq_planner_tests.rs
+++ b/precompiles/arith_eq/src/tests/arith_eq_planner_tests.rs
@@ -121,3 +121,59 @@ fn full_instances_specialized_remainder_pooled() {
         assert!(ae.op_counts[ArithEqOp::Arith256Mod.index()] > 0);
     }
 }
+
+#[test]
+fn a_bulk_keeps_the_narrow_air_and_its_tail_shares_the_wider_one() {
+    // The mix that per-family assignment could not handle: plenty of arith256 plus a handful of
+    // arith256_mod. Only `Arith256X` covers both, but `Arith256` (11 columns vs 19) covers the bulk
+    // — and the bulk's tail can then ride along in the `Arith256X` instance the mod ops need anyway.
+    let cap_arith = cap(&meta_of(Arith256Trace::<()>::AIR_ID));
+    let totals = counts(&[(ArithEqOp::Arith256, 3 * cap_arith + 10), (ArithEqOp::Arith256Mod, 1)]);
+    let plan = plan_air_strategy(&all_air_ids(), &totals);
+    assert_conserves(&plan, &totals);
+
+    let narrow = plan.iter().find(|p| p.air_id == Arith256Trace::<()>::AIR_ID).unwrap();
+    assert_eq!(narrow.op_counts[ArithEqOp::Arith256.index()], 3 * cap_arith);
+    assert_eq!(narrow.instances, 3);
+
+    let wide = plan.iter().find(|p| p.air_id == Arith256XTrace::<()>::AIR_ID).unwrap();
+    assert_eq!(wide.op_counts[ArithEqOp::Arith256.index()], 10);
+    assert_eq!(wide.op_counts[ArithEqOp::Arith256Mod.index()], 1);
+    assert_eq!(wide.instances, 1);
+
+    // Strictly better than proving the whole equation group in Arith256X, which is all a
+    // per-family assignment could do.
+    let all_in_wide = area(&meta_of(Arith256XTrace::<()>::AIR_ID), 3 * cap_arith + 11);
+    assert!(plan_area(&plan) < all_in_wide, "{} !< {all_in_wide}", plan_area(&plan));
+}
+
+#[test]
+fn ops_without_a_specialized_air_go_to_the_universal_one() {
+    let totals = counts(&[(ArithEqOp::Secp256r1Add, 3), (ArithEqOp::Secp256r1Dbl, 2)]);
+    let plan = plan_air_strategy(&all_air_ids(), &totals);
+    assert_conserves(&plan, &totals);
+
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].air_id, ArithEqTrace::<()>::AIR_ID);
+}
+
+#[test]
+fn absent_airs_are_never_planned() {
+    // Without Arith256X in the pilout, arith256_mod has only the universal air left, and pooling
+    // the arith256 ops there with it beats keeping a separate Arith256 instance.
+    let totals = counts(&[(ArithEqOp::Arith256, 2), (ArithEqOp::Arith256Mod, 1)]);
+    let present = vec![ArithEqTrace::<()>::AIR_ID, Arith256Trace::<()>::AIR_ID];
+    let plan = plan_air_strategy(&present, &totals);
+    assert_conserves(&plan, &totals);
+
+    assert!(plan.iter().all(|p| present.contains(&p.air_id)));
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].air_id, ArithEqTrace::<()>::AIR_ID);
+}
+
+#[test]
+#[should_panic(expected = "covered by no present air")]
+fn an_op_no_present_air_covers_panics() {
+    let totals = counts(&[(ArithEqOp::Secp256r1Add, 1)]);
+    plan_air_strategy(&[Arith256Trace::<()>::AIR_ID], &totals);
+}

--- a/precompiles/arith_eq/src/tests/arith_eq_planner_tests.rs
+++ b/precompiles/arith_eq/src/tests/arith_eq_planner_tests.rs
@@ -172,6 +172,37 @@ fn absent_airs_are_never_planned() {
 }
 
 #[test]
+fn indivisible_tails_are_a_known_gap() {
+    // Documents the module's *Known gap*: tails are placed whole, so the sweep cannot divide one to
+    // top up two other airs at once, even when that empties an air. Update this test if divisible
+    // placements ever get searched — the assertion below should then become the split plan's area.
+    let c = cap(&meta_of(Arith256Trace::<()>::AIR_ID));
+    let totals = counts(&[
+        (ArithEqOp::Arith256, c / 2),
+        (ArithEqOp::Arith256Mod, 3 * c / 4),
+        (ArithEqOp::Secp256r1Add, 3 * c / 4),
+    ]);
+    let plan = plan_air_strategy(&all_air_ids(), &totals);
+    assert_conserves(&plan, &totals);
+
+    // What it picks: one instance each, the Arith256 one only half used.
+    assert_eq!(plan.len(), 3);
+    for p in &plan {
+        assert_eq!(p.instances, 1, "air {} ", p.air_id);
+    }
+
+    // What a divisible search would find: split the c/2 Arith256 tail into c/4 + c/4, filling
+    // Arith256X (3c/4 of mod) and ArithEq (3c/4 of secp256r1) to exactly one instance each, so no
+    // Arith256 instance is needed at all.
+    let split = area(&meta_of(Arith256XTrace::<()>::AIR_ID), c)
+        + area(&meta_of(ArithEqTrace::<()>::AIR_ID), c);
+    let chosen = plan_area(&plan);
+    assert!(split < chosen, "expected the split plan to be cheaper: {split} vs {chosen}");
+    // The whole gap is exactly the wasted Arith256 instance.
+    assert_eq!(chosen - split, area(&meta_of(Arith256Trace::<()>::AIR_ID), 1));
+}
+
+#[test]
 #[should_panic(expected = "covered by no present air")]
 fn an_op_no_present_air_covers_panics() {
     let totals = counts(&[(ArithEqOp::Secp256r1Add, 1)]);


### PR DESCRIPTION
# ArithEq planner: per-operation air assignment

Three changes, all confined to `precompiles/arith_eq`:

1. The air-selection strategy assigns **operations** rather than PIL equation groups, and a leftover
   can be pooled into **any** air that covers it. Up to 42% less area on the `arith256` mix.
2. The filler is **~39% faster** at 100k chunks (~32.6 ms → ~19.8 ms), 3.4× on a small run.
3. Invariants that were only checked in tests are now asserted in the planner itself.

Plus the first tests for the filler, which had none.

No PIL change. `CollectCounter` and `ChunkId` live in `zisk_common` and are shared with the other
state machines — neither is touched, so nothing outside this crate changes behaviour.

## 1. Per-operation assignment

`plan_air_strategy` grouped operations by PIL equation group and required the specialized air to cover
*every* operation of the group with a non-zero count. Only one group has two airs of different
coverage — `Arith256` is proved by both the 11-column `Arith256` air and the 19-column `Arith256X` —
but it is the common one, and the effect is large: **a single `Arith256Mod` operation forced all the
`Arith256` ones onto the 19-column air**, a 73% higher cost per operation.

The bulk is no longer searched, because its placement is provably fixed. With
`cap = num_rows / ARITH_EQ_ROWS_BY_OP`, a filled instance costs `ARITH_EQ_ROWS_BY_OP · row_size` per
operation *whatever* `num_rows` is, so whole instances always belong in the narrowest covering air; and
a bulk is a whole number of instances, so it can never absorb anyone's leftover. That leaves only the
tails:

* `bulk = ⌊count/cap⌋·cap` → narrowest covering air. No search.
* `tail = count % cap` → **any** covering air: its own cheapest air, another specialized air whose
  partial instance it can share, or the universal air.

The old code could only choose between "keep it in the spec air" and "pool it into the universal air".
Allowing another *specialized* air to act as the pool is where most of the win comes from.

With `3·cap + 10` `Arith256` and 1 `Arith256Mod` (`cap = 65536`):

| | plan | area |
|---|---|---|
| before | 4 × `Arith256X` | 79,691,776 |
| after | 3 × `Arith256` + 1 × `Arith256X` holding the 10-op tail **and** the mod op | 54,525,952 |

**31.6% less area**, tending to 42% as the bulk dominates. The second air is not extra overhead: the
mod operation needed an `Arith256X` instance anyway, and the tail rides along in it for free.

Each tail is placed **whole**, which is not globally area-minimal: dividing one tail to top up two
other airs at once can empty an air, which the sweep cannot see. The module documents that gap with a
worked counterexample (14.7% on it), pinned by `indivisible_tails_are_a_known_gap`. Closing it is bin
packing with splitting — a different algorithm, not a wider sweep.

The sweep is `Π |covering airs|` over the operations with a non-zero tail, `3 · 2⁸ = 768` at worst
today; `MAX_TAIL_COMBINATIONS` guards it so that adding heavily overlapping airs fails loudly instead
of quietly stalling.

Two side effects worth noting: the `FAMILIES` table is gone, so an operation added to `ArithEqOp` but
forgotten there can no longer be dropped from every plan and surface later as an unbalanced bus; and
all five pre-existing strategy tests pass **unchanged**, since this is a strict generalization.

## 2. Planner speed

The tail search is noise — 11 µs worst case, 150 ns typical, 0.03% of the planner. The filler is
everything. Same bench and workload, this branch against its merge base, three runs each:

| chunks | before | after | airs used |
|---|---|---|---|
| 1,000 | 478 / 523 / 530 µs | **182 / 152 / 113 µs** | 1 → 1 |
| 10,000 | 2.88 / 3.13 / 3.25 ms | **1.97 / 2.28 / 2.14 ms** | 2 → 3 |
| 100,000 | 28.5 / 32.6 / 36.6 ms | **20.2 / 19.0 / 19.4 ms** | 3 → 4 |

**39% faster at 100k chunks**, 31% at 10k; the baseline's best run against this branch's worst still
gives 29%, so it is not an artefact of the noise. The 1,000-chunk row is the cleanest read on the
filler alone — both sides produce the same single-air plan there — and it is **3.4× faster**. Variance
also drops from ±25% to ±3%, as expected from removing a `HashMap` that was growing and rehashing.

Two changes got that: walk only the operations the air proves (1–3 of the 11) and stop when its budget
is spent; and move the checkpoint metadata from `HashMap<ChunkId, _>` to a `Vec` sorted by chunk. The
map was found by measurement, not guesswork — removing just the map write from the loop took 100k
chunks from ~30 ms to 6.2 ms, i.e. **80% of the filler was the map**. It was never a good fit: the
planner appends one entry per (instance, chunk) in chunk order and only ever touches the last one, so
it paid a hash probe per write to find an entry it already knew, plus relocating a ~240-byte value on
insert and on growth. `ArithEqCheckPoints` owns the sorted invariant; `cur_chunks` disappeared, so the
plan's `CheckPoint` list and the windows can no longer disagree.

Note the per-operation strategy makes this workload use **4 airs where the old one used 3**, and the
filler walks every chunk once per air — the filler is measurably faster *despite* that extra pass, not
because the air count stayed put.

## 3. Invariants asserted in the planner

Previously only the tests checked these:

* **Conservation** in `plan_air_strategy` (`#[cfg(debug_assertions)]`): every counted operation is
  planned exactly once.
* **Budget drained** in the filler: a leftover means the plan and the counters disagree, and those
  operations would be collected by nobody.
* **Instances match**: ties the strategy's `ceil(total / cap)` to the instances the filler actually
  cut — two independent computations that never compared themselves.

## Tests

19 tests, run in debug where the new `debug_assert`s are live.

`arith_eq_filler_tests.rs` (new, 9 tests) covers `ArithEqPlanner::plan`, which had no coverage at all
despite holding the delicate part — the global per-(chunk, op) offset, operations split across airs,
per-air segment ids. The core is `assert_tiles`, which reconstructs the collect windows of every plan
and asserts the property that matters: for each (chunk, op) the windows **partition** `[0, count)` — no
overlap (an operation proved twice) and no gap (an operation never proved). It also checks no instance
exceeds `cap` and that the `CheckPoint` list agrees with the metadata.

`arith_eq_planner_tests.rs` gains 5: the `arith256` bulk/tail split above, the known gap, operations
with no specialized air, absent airs never being planned, and the no-covering-air panic.

Each guard was verified to actually fire:

| mutation | result |
|---|---|
| `CollectCounter::new(offset, take)` → `new(0, take)` | 4 filler tests fail, naming the window: `window starts at 0, expected 10` |
| strategy `instances` inflated by 1 | `air 17: filled 1 instances, strategy sized 2` |
| drop one tail placement | `plan_air_strategy dropped or duplicated operations` |
| tails forced to stay in their bulk air | `a_split_op_tiles_across_two_airs` fails |

## Verification

```
SKIP_GUEST_BUILD=1 cargo test  -p precomp-arith-eq --lib -- arith_eq_family::tests arith_eq_planner::tests   # 19/19
SKIP_GUEST_BUILD=1 cargo clippy -p precomp-arith-eq --all-targets                                            # clean
                   cargo fmt    -p precomp-arith-eq -- --check                                               # clean
SKIP_GUEST_BUILD=1 cargo check  -p executor --all-targets                                                    # clean
```

`SKIP_GUEST_BUILD=1` is required on a host without the ZisK guest toolchain: `precomp-arith-eq`
dev-depends on `test-artifacts`, whose build script cross-compiles the guest programs and fails in
`clap_builder`. Pre-existing and unrelated to this PR.
