### PR TITLE
ziskemu: new options (csv, reference, diff, html report, duplicates, reg distances)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,9 +758,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",

--- a/book/developer/profiling.md
+++ b/book/developer/profiling.md
@@ -10,27 +10,43 @@ This guide walks you through ZiskEmu's profiling capabilities, progressing from 
 
 2. **Basic Profiling**: Global statistics showing cost distribution across major categories (base, main, opcodes, precompiles, memory)
 
-3. **SDK Report Mode**: Streamlined, compact output format ideal for CI/CD and quick checks, with selective section display options
+3. **Opcode Variant Breakdown**: Splitting an opcode into the cheaper-to-prove shapes its operands actually take
 
-4. **Function Name Display Options**: Configure how long function names are displayed with compact and no-compact modes
+4. **Operand Pattern Analysis**: Finding operand shapes common enough to justify a cheaper state machine
 
-5. **Profile Tags**: Instrument your code to measure specific sections, with immediate or deferred reporting of steps and costs
+5. **Precompile Duplicate Analysis**: Detecting precompile calls that repeat a computation already done, and where they come from
 
-6. **Firefox Profiler Integration**: Export profiling data for advanced visualization and interactive analysis
+6. **Memory Statistics**: Breaking the memory cost down by region, alignment and access shape, and ranking functions by memory traffic
 
-7. **Function-Level Profiling**: Identifying which functions consume the most resources with cumulative analysis
+7. **Register Step Distance**: Measuring how long registers keep a value between accesses, against the proof's distance limit
 
-8. **Customizing ROI Display**: Controlling how many functions to show and filtering by patterns
+8. **Opcode Coverage**: Which opcodes, precompiles and RISC-V instructions the run exercised
 
-9. **Detailed Caller Analysis**: In-depth breakdown showing which operations are expensive within each function and who calls them
+9. **Comparing Runs**: Saving a statistics snapshot and diffing a later run against it to validate an optimization
 
-10. **Tracking Function Calls**: Logging individual call parameters to analyze usage patterns and optimize for common cases
+10. **SDK Report Mode**: Streamlined, compact output format ideal for CI/CD and quick checks, with selective section display options
 
-11. **PC Histogram Analysis**: Low-level view of the most frequently executed RISC-V instruction sequences
+11. **Function Name Display Options**: Configure how long function names are displayed with compact and no-compact modes
 
-12. **Additional Options**: Quick reference for other useful flags (steps, progress indicators, formatting)
+12. **Profile Tags**: Instrument your code to measure specific sections, with immediate or deferred reporting of steps and costs
 
-13. **Practical Example**: Real-world case study analyzing Ethereum opcode costs in a block validator
+13. **Firefox Profiler Integration**: Export profiling data for advanced visualization and interactive analysis
+
+14. **Function-Level Profiling**: Identifying which functions consume the most resources with cumulative analysis
+
+15. **Customizing ROI Display**: Controlling how many functions to show and filtering by patterns
+
+16. **Detailed Caller Analysis**: In-depth breakdown showing which operations are expensive within each function and who calls them
+
+17. **Tracking Function Calls**: Logging individual call parameters to analyze usage patterns and optimize for common cases
+
+18. **PC Histogram Analysis**: Low-level view of the most frequently executed RISC-V instruction sequences
+
+19. **Instruction Tracing and Disassembly**: Step-by-step traces, change traces and an annotated disassembly with execution counts
+
+20. **Additional Options**: Quick reference for other useful flags (steps, progress indicators, formatting)
+
+21. **Practical Example**: Real-world case study analyzing Ethereum opcode costs in a block validator
 
 ## Introduction
 
@@ -174,21 +190,23 @@ ziskemu -e \<elf\> -i \<input\> -X
 ```
 REPORT                                  
 ----------------------------------------
-STEPS                         92,875,129
+STEPS                          3,159,193
 
 COST DISTRIBUTION                   COST       %
 ------------------------------------------------
-BASE                         293,601,280   2.57%
-MAIN                       6,315,508,772  55.22%
-OPCODES                    1,334,639,984  11.67%
-PRECOMPILES                2,565,960,716  22.43%
-MEMORY                       927,932,629   8.11%
+MAIN                         214,825,124  33.99%
+OPCODES                      110,764,355  17.52%
+PRECOMPILES                      836,980   0.13%
+MEMORY                        18,327,393   2.90%
+                        ------------------------
+VARIABLE                     344,753,852  54.54%
+BASE                         287,309,824  45.46%
+                        ------------------------
+TOTAL                        632,063,676 100.00%
 
-TOTAL                     11,437,643,381 100.00%
-
-FROPS                        963,440,253   8.42%
-RAM USAGE                     18,465,008   3.47%
-ROM USAGE                      1,253,331  29.88%
+FROPS                          7,289,417   2.11%
+RAM USAGE                          1,120   0.00%
+ROM USAGE                         14,114   0.34%
 
 ```
 
@@ -199,8 +217,6 @@ ROM USAGE                      1,253,331  29.88%
 **COST DISTRIBUTION**: This shows the **profiling cost** (see the [Understanding Profiling Costs](#understanding-profiling-costs-vs-final-costs) section for detailed explanation). Each operation is costed individually using the proof area as the metric, which is the best indicator of proof generation time—higher cost means longer proof generation.
 
 The cost is broken down into these categories:
-
-- **BASE**: Cost of fixed components such as tables, range checks, and other constant overhead that exists regardless of program logic.
 
 - **MAIN**: Cost of the processor itself without operation costs. This is **directly proportional to the steps** count and represents the base cost of executing instructions.
 
@@ -216,14 +232,20 @@ The cost is broken down into these categories:
   - The address is not aligned to 8 bytes
   - Operations don't work with 8-byte chunks (e.g., reading a single byte)
 
-- **TOTAL**: Sum of all costs. Each category shows the percentage (%) it represents of the total cost.
+- **VARIABLE**: Sum of MAIN + OPCODES + PRECOMPILES + MEMORY, i.e. **everything the program controls**. This is the number to watch when optimizing: it is the only part that moves when you change your code.
+
+- **BASE**: Cost of fixed components such as tables, range checks, and other constant overhead that exists regardless of program logic. It is the same for every program, so it dilutes percentages: in the example above, a small program pays 287M of BASE against only 344M of VARIABLE, which is why BASE is 45% of the total. On a large program the same 287M becomes a rounding error.
+
+- **TOTAL**: VARIABLE + BASE. Each category shows the percentage (%) it represents of this total.
+
+**Why VARIABLE matters**: because BASE is a constant, comparing two runs by TOTAL understates your improvement. If an optimization removes 60M of cost, VARIABLE drops by a visible fraction while TOTAL barely moves. All the percentages *below* the cost distribution (FROPS, the per-opcode tables, TOP COST FUNCTIONS) are therefore expressed as a share of **VARIABLE**, not of TOTAL.
 
 **FROPS** (FRequent OPerationS): These are operations that are very frequently used by the processor, such as:
 - Adding 1 to a relatively small number (common in loop counters)
 - Adding 8 to an address (typical for pointer arithmetic)
 - Working with values < 256
 
-These frequent operations are analyzed, detected, and **pre-calculated**, becoming part of the BASE cost but representing significant savings. In this example, FROPS show 8.42% - this is the cost the program would have if these optimizations were not applied. The actual savings are already reflected in the lower costs of the affected operations.
+These frequent operations are analyzed, detected, and **pre-calculated**, becoming part of the BASE cost but representing significant savings. In this example, FROPS show 2.11% of the variable cost - this is the cost the program would have if these optimizations were not applied. The actual savings are already reflected in the lower costs of the affected operations.
 
 **RAM USAGE**: The amount of memory used out of the total available. This information is **only available with the default allocator (bump allocator)**, which:
 - Never frees memory - always allocates new memory
@@ -239,85 +261,72 @@ holds two things that consume rows:
 
 A high ROM usage means the program (plus its initialization data) is close to filling the ROM instance.
 
-**Detailed Opcode Breakdown:**
+### Detailed Opcode Breakdown
 
-Below the summary, you'll see a detailed breakdown of each operation:
+Below the summary you get three tables: the base (ALU) opcodes, the precompiled opcodes, and the
+FROPS coverage. They are **sorted by cost, most expensive first** — the first rows are always the
+ones worth looking at. Pass `--sort-by-units` to sort them by operation count instead, which is
+what you want when you care about *how often* something runs rather than what it costs.
+
 ```
-COST BY OPCODE                     COUNT       %            COST       % RANK
------------------------------------------------------------------------------
-OP ltu                         1,767,360   1.90%     106,041,600   0.93%
-OP lt                            389,360   0.42%      23,361,600   0.20%
-OP eq                            543,251   0.58%      32,595,060   0.28%
-OP add                         7,086,411   7.63%     177,160,275   1.55% #4
-OP sub                           693,157   0.75%      41,589,420   0.36%
-OP and                         3,740,044   4.03%     224,402,640   1.96% #3
-OP or                          7,482,273   8.06%     448,936,380   3.93% #2
-OP xor                         1,027,290   1.11%      61,637,400   0.54%
-OP add_w                          15,804   0.02%         948,240   0.01%
-OP sub_w                           4,085   0.00%         245,100   0.00%
-OP sll                         1,551,879   1.67%      82,249,587   0.72%
-OP srl                           611,361   0.66%      32,402,133   0.28%
-OP sra                           807,976   0.87%      42,822,728   0.37%
-OP srl_w                          84,289   0.09%       4,467,317   0.04%
-OP sra_w                              62   0.00%           3,286   0.00%
-OP signextend_b                  121,977   0.13%       6,464,781   0.06%
-OP signextend_h                    1,684   0.00%          89,252   0.00%
-OP signextend_w                   27,460   0.03%       1,455,380   0.01%
+COST BY BASE OPCODE                COUNT       %            COST       %
+------------------------------------------------------------------------
+OP xor                           561,981  17.79%      33,718,860   9.78%
+OP ror_w                         561,974  17.79%      31,470,544   9.13%
+OP add                           674,936  21.36%      15,889,840   4.61%
+OP and                           194,544   6.16%      11,672,640   3.39%
+OP or                             82,038   2.60%       4,922,280   1.43%
+OP srl_w                          78,992   2.50%       4,423,552   1.28%
+OP andn                           64,000   2.03%       3,840,000   1.11%
+OP srl                            28,088   0.89%       1,572,928   0.46%
+OP rev8                           16,993   0.54%         951,608   0.28%
+OP signextend_w                   16,007   0.51%         896,392   0.26%
+OP signextend_b                   16,000   0.51%         896,000   0.26%
+OP sll                             4,205   0.13%         235,480   0.07%
+OP eq                              2,132   0.07%         127,920   0.04%
+OP mul                               202   0.01%          19,594   0.01%
 OP pubout                             32   0.00%               0   0.00%
-OP muluh                          86,682   0.09%       8,234,790   0.07%
-OP mul                           409,765   0.44%      38,927,675   0.34%
-OP divu                            6,368   0.01%         604,960   0.01%
-OP remu                                4   0.00%             380   0.00%
-OP dma_memcpy                    302,551   0.33%      12,707,142   0.11%
-OP dma_memcmp                     91,454   0.10%       3,841,068   0.03%
-OP dma_inputcpy                       90   0.00%           3,780   0.00%
-OP dma_xmemset                    32,381   0.03%       1,360,002   0.01%
-OP _dma_pre                      140,043   0.15%      12,323,784   0.11%
-OP _dma_post                     164,752   0.18%      14,498,176   0.13%
-OP keccak                         32,650   0.04%   2,466,707,500  21.57% #1
-OP arith256_mod                      714   0.00%       1,016,736   0.01%
-OP secp256k1_add                  17,688   0.02%      25,187,712   0.22%
-OP secp256k1_dbl                  19,884   0.02%      28,314,816   0.25%
-OP fcall_param                       652   0.00%               0   0.00%
-OP fcall                             172   0.00%               0   0.00%
-OP fcall_get                         156   0.00%               0   0.00%
 
-FROPS BY OPCODE                    COUNT    HIT            COST       % RANK
-----------------------------------------------------------------------------
-FROP ltu                         942,288  34.78%      56,537,280   0.49% #4
-FROP lt                          641,963  62.25%      38,517,780   0.34%
-FROP eq                        3,273,419  85.77%     196,405,140   1.72% #2
-FROP add                       1,597,142  18.39%      39,928,550   0.35%
-FROP sub                         357,871  34.05%      21,472,260   0.19%
-FROP and                         471,898  11.20%      28,313,880   0.25%
-FROP or                        1,303,629  14.84%      78,217,740   0.68% #3
-FROP xor                         105,118   9.28%       6,307,080   0.06%
-FROP add_w                        75,366  82.67%       4,521,960   0.04%
-FROP sub_w                         2,177  34.77%         130,620   0.00%
-FROP sll                       8,729,869  84.91%     462,683,057   4.05% #1
-FROP srl                         376,620  38.12%      19,960,860   0.17%
-FROP sra                           5,962   0.73%         315,986   0.00%
-FROP srl_w                        66,935  44.26%       3,547,555   0.03%
-FROP sra_w                            60  49.18%           3,180   0.00%
-FROP muluh                        25,590  22.79%       2,431,050   0.02%
-FROP mul                          43,603   9.62%       4,142,285   0.04%
-FROP divu                             42   0.66%           3,990   0.00%
+COST BY PRECOMPILED OPCODE           COUNT       %            COST       %
+--------------------------------------------------------------------------
+OP dma_xmemcpy                     3,002   0.10%         406,226   0.12%
+OP dma_xmemset                     2,003   0.06%         400,496   0.12%
+OP dma_memcpy                        204   0.01%          30,258   0.01%
+
+FROPS BY OPCODE                    COUNT    HIT            COST       %
+-----------------------------------------------------------------------
+FROP sll                          31,295  88.15%       1,752,520   0.51%
+FROP xor                          16,027   2.77%         961,620   0.28%
+FROP or                           15,046  15.50%         902,760   0.26%
+FROP pack_h                       16,031 100.00%         897,736   0.26%
+FROP ror_w                        14,026   2.44%         785,456   0.23%
+FROP srl                          13,213  31.99%         739,928   0.21%
+FROP rev8                          8,009  32.03%         448,504   0.13%
+FROP eq                            5,837  73.25%         350,220   0.10%
+FROP ltu                           3,367  99.79%         202,020   0.06%
+FROP add                           6,790   1.00%         169,750   0.05%
 
 ```
 
-**COST BY OPCODE Table:**
+**COST BY BASE OPCODE / COST BY PRECOMPILED OPCODE:**
 
-This table shows detailed statistics for each operation or precompile executed:
+The two tables have the same columns and are split so the cheap, high-volume ALU work does not hide
+the handful of precompile calls that often dominate the cost:
 
-- **COUNT**: Number of times this operation was called
+- **COUNT**: Number of times this operation was executed
 - **%**: Percentage of steps (cycles) that use this operation
 - **COST**: Total profiling cost for all executions of this operation
-- **%**: Percentage of total cost that this operation represents
-- **RANK**: The top 4 most expensive operations are marked with `#1`, `#2`, `#3`, `#4`
+- **%**: Percentage of the **variable** cost that this operation represents
 
-**Important**: Operations are **not sorted by cost**. They maintain a consistent order across executions to facilitate comparison between different runs. Look for the `#N` markers to identify the most expensive operations.
+Counts here exclude the executions that were resolved as FROPS — those are reported separately in
+the FROPS table, so the two never double-count.
 
-For example, in this output, `keccak` was executed 32,650 times (0.03% of steps) but accounts for 21.41% of the total cost, making it the #1 most expensive operation. This indicates that Keccak operations dominate the cost despite being relatively infrequent.
+**Looking at operand shapes**: ZiskEmu also classifies the shape of each operation's `a`, `b` and
+`c` operands (do they fit in 32 bits? is one of them all ones?), because an operation whose operands
+always have a given shape can be proven by a narrower, cheaper state machine. That information is
+*not* in this table — it has its own section, [`--pattern-analysis`](#operand-pattern-analysis),
+where it is named, filtered and grouped per opcode. See
+[Opcode Variant Breakdown](#opcode-variant-breakdown) for the shapes that are already exploited.
 
 **FROPS BY OPCODE Table:**
 
@@ -329,12 +338,15 @@ FROPS (Frequently-used OPerationS) are highly common operations that have been a
 The table shows:
 
 - **COUNT**: Number of times the FROP variant was executed
-- **HIT**: Hit rate percentage - how often the frequent operation pattern was matched and the optimization applied
+- **HIT**: Hit rate percentage - how often the frequent operation pattern was matched and the optimization applied, i.e. `FROP count / (FROP count + non-FROP count)` for that opcode
 - **COST**: Total cost with the optimization benefit already applied
-- **%**: Percentage of total cost
-- **RANK**: Top ranked FROPS by cost
+- **%**: Percentage of the variable cost
 
-High hit rates indicate that the program uses these common patterns frequently, benefiting from the pre-calculated optimizations. The FROPS total shown earlier (8.42% in this example) represents the cost that would be added if these optimizations were not available.
+High hit rates indicate that the program uses these common patterns frequently, benefiting from the pre-calculated optimizations. The FROPS total shown earlier (2.11% in this example) represents the cost that would be added if these optimizations were not available.
+
+Use `--legacy-frops` to recompute the FROPS coverage against the **previous** FROPS tables (the
+snapshot taken before the FROPS overhaul). That lets you measure what a new FROPS version actually
+bought you on a real program, by running the same ELF twice and comparing.
 
 **Key Insights from Statistics:**
 
@@ -343,6 +355,163 @@ Use this information to:
 - Find operations with high count but disproportionate cost (optimization candidates)
 - Verify that precompiles are being used where expected
 - Understand the balance between computation (OPCODES), memory access (MEMORY), and complex operations (PRECOMPILES)
+
+## Opcode Variant Breakdown
+
+Some opcodes have **variants that are cheaper to prove** when their operands take a particular
+shape. ZisK already charges the reduced cost for them automatically; `--opcode-breakdown` shows you
+how many of an opcode's executions took each cheap shape, as a tree under the opcode:
+
+```bash
+ziskemu -e <elf> -i <input> -X --opcode-breakdown
+```
+
+```
+COST BY BASE OPCODE                COUNT       %            COST       %
+------------------------------------------------------------------------
+OP add                           674,936  21.36%      15,889,840   4.61%
+├ add_hi0                         64,717   2.05%         970,755   0.28%
+└ add_hif                         33,639   1.06%         504,585   0.15%
+```
+
+Currently the tracked variants are the **BinaryAddHi** shapes of `add`, which are proven by a
+dedicated, much cheaper state machine:
+
+- **`add_hi0`**: `hi32(a) = hi32(c) = 0` and `hi32(b) = 0` — both operands fit in 32 bits
+- **`add_hif`**: `hi32(a) = hi32(c) = 0` and `hi32(b) = 0xFFFF_FFFF` — a subtraction encoded as an addition
+
+The variant rows are a **subset** of the opcode row above them: their counts are already included in
+the opcode's COUNT, and their reduced cost is already reflected in the opcode's COST. A high share of
+variant rows means the opcode is cheaper than its nominal cost suggests.
+
+## Operand Pattern Analysis
+
+`--pattern-analysis` answers the question the raw operand-category columns are too noisy to answer:
+**is there an operand shape common enough in this program to justify a cheaper state machine?**
+
+```bash
+ziskemu -e <elf> -i <input> -X --pattern-analysis
+```
+
+```
+OPERAND PATTERN ANALYSIS (>10% of opcode ops and >=4,000)
+PATTERN                                      COUNT        %
+-----------------------------------------------------------
+OP xor                                     561,981  100.00%
+  a,b,c hi32=0                             136,409   24.27%
+  a hi32=1,b hi32=0                        130,981   23.31%
+  a,b hi32=1                                85,565   15.23%
+  a hi32=0,b hi32=1                         85,543   15.22%
+OP ror_w                                   561,974  100.00%
+  b<64                                     561,974  100.00%
+OP or                                       82,038  100.00%
+  a,b,c hi32=0                              13,522   16.48%
+OP srl_w                                    78,992  100.00%
+  b<64                                      78,992  100.00%
+  a,b,c hi32=0                              27,749   35.13%
+OP rev8                                     16,993  100.00%
+  b hi32=1                                   7,951   46.79%
+OP signextend_b                             16,000  100.00%
+  b,c hi32=0                                12,086   75.54%
+  b<64                                      10,030   62.69%
+```
+
+**How to read it:**
+
+- Rows are **grouped by opcode**. The `OP <name>` row is the group header: it carries the opcode's
+  total operations, which is the 100% every pattern below it is measured against.
+- The indented rows are the operand shapes that opcode's operands actually took, ordered by count.
+- Groups are ordered like the opcode tables — by cost, or by count with `--sort-by-units`.
+
+**What gets reported.** Only shapes that are **significant**: more than **10%** of that opcode's
+operations *and* at least **4,000** operations in absolute terms. A shape that appears twice tells
+you nothing about where to spend engineering effort.
+
+**What gets filtered out**, so the signal is not buried:
+
+- **Non-ALU opcodes.** Only arithmetic and binary opcodes are analyzed. The operand shape of an
+  `fcall`, a `pubout` or a precompile says nothing about how it is proven.
+- **Patterns that are true by definition rather than by data.** Single-operand opcodes (`rev8`,
+  `brev8`, `signextend_b/h/w`, `clz`, `ctz`, `cpop`, `orc_b` and their `_w` variants) ignore `a`
+  entirely — it is always zero. Any condition on `a` therefore holds 100% of the time and means
+  nothing: reporting `rev8 a<64  100.00%` would be pure noise. For these opcodes the conditions on
+  `a` are dropped from the label (`a,b,c hi32=0` is reported as `b,c hi32=0`) and the patterns that
+  say nothing else are not reported at all.
+
+**Using the result.** A shape at or near 100% is the strongest possible finding: it means *every*
+execution of that opcode in this program has that property, so a specialized state machine would
+apply universally. In the example, all 561,974 `ror_w` operations have `b<64`, and 75% of the
+`signextend_b` ones have both operand and result inside 32 bits. Compare it against
+[`--opcode-breakdown`](#opcode-variant-breakdown) to see which shapes are *already* exploited.
+
+## Precompile Duplicate Analysis
+
+Precompiles are the most expensive operations in a program, and real programs call them repeatedly
+with **the same input**. Since a precompile is a pure function, every repeat recomputes a result the
+proof has already paid for. `--duplicates` measures exactly how much that costs you:
+
+```bash
+ziskemu -e <elf> -i <input> -X --duplicates
+```
+
+The analysis keys on the **content** of the operands, dereferencing indirections, so two calls with
+identical inputs stored in different buffers are still recognized as duplicates. It covers every
+precompile except DMA.
+
+```
+PRECOMPILE DUPLICATES
+PRECOMPILE                    TOTAL       UNIQUE        %          DUP        %   MAX DUP        DUP COST        %
+------------------------------------------------------------------------------------------------------------------
+keccak                        1,000           12    1.20%          988   98.80%       200      74,668,100  18.96%
+```
+
+- **TOTAL**: Calls to this precompile
+- **UNIQUE**: Distinct inputs among them
+- **DUP**: Calls that repeated an input already seen (`TOTAL - UNIQUE`), with its share of TOTAL
+- **MAX DUP**: How many times the single most-repeated input was computed
+- **DUP COST**: The cost spent on those repeats — **the saving available if you cache them** — and its share of the total cost
+
+A `TOTAL` row is added when more than one precompile is reported.
+
+### Restricting the analysis
+
+Tracking input content costs memory and time. Limit it to the precompiles you care about with
+`--duplicates-ops`, comma-separated by opcode name:
+
+```bash
+ziskemu -e <elf> -i <input> -X --duplicates --duplicates-ops keccak,sha256
+```
+
+### Finding where the duplicates come from
+
+Knowing that 98.8% of your keccak calls are redundant is only useful if you can find the call site.
+`--duplicates-detail` adds a second level showing the call paths responsible, most costly first.
+It needs symbols (`-S`):
+
+```bash
+ziskemu -e <elf> -i <input> -X -S --duplicates --duplicates-detail --duplicates-depth 3
+```
+
+```
+KECCAK DUPLICATES BY CALL PATH
+------------------------------
+796 duplicates / 800 total  (99.50%)
+    ziskos::zisklib::lib::keccak256::keccak256
+    <- dupguest::hash_block
+    <- main
+192 duplicates / 200 total  (96.00%)
+    ziskos::zisklib::lib::keccak256::keccak256
+    <- dupguest::hash_leaf
+    <- main
+```
+
+Each entry is one call path: the leaf function that issued the precompile, then its callers with
+`<-`. `--duplicates-depth N` sets how many frames are recorded (default 4, which is also the
+maximum useful depth for most code); `-T` limits how many paths are listed per precompile.
+
+This immediately tells you *which* call site to fix — here, `hash_block` recomputes the same four
+hashes on every round of the loop, so hoisting them out removes 79% of the precompile cost. See
+[Comparing Runs](#comparing-runs) for how to confirm the saving.
 
 ## Memory Statistics
 
@@ -446,6 +615,292 @@ before updating the byte (more expensive). The `TOTAL …` rows at the bottom su
 by read vs. write, which makes it easy to spot, for example, that unaligned 4-byte writes are cheap in
 count but expensive in cost.
 
+### DETAILED OFFSET BYTE MEMORY OPERATIONS (`--mem-full-stats`)
+
+Byte accesses are also broken down by their **offset inside the 8-byte word**:
+
+```
+DETAILED OFFSET BYTE MEMORY OPERATIONS
+--------------------------------------
+offset                    0            1            2            3            4            5            6            7        total
+reads                10,255        8,249        8,237        8,229        8,240        8,226        8,171        8,244       67,851
+clean writes          2,585          105            8            8           16           36           46          107        2,911
+dirty writes              0            0            0            0            2            2            2            0            6
+```
+
+A distribution concentrated on offset 0 means the byte accesses are at least word-aligned; a flat
+distribution (as above, for the reads) means the code is walking a byte buffer and paying the
+unaligned cost on every step — a candidate for reading whole words instead. **Dirty writes** are the
+expensive ones: they force a read of the surrounding word before updating the byte.
+
+### Ranking functions by memory cost
+
+When symbols are available (`-S`), `--mem-stats` / `--mem-full-stats` also add three rankings that
+attribute the memory cost to functions. Costs are shown in millions (marked `(M)` in the header);
+the SDK report keeps raw values.
+
+```bash
+ziskemu -e <elf> -i <input> -X -S --mem-full-stats
+```
+
+**TOP MEMORY COST FUNCTIONS** — who spends the most on memory, in absolute terms:
+
+```
+TOP MEMORY COST FUNCTIONS (MEM COST (M), % MEM COST, CALLS, COST/CALL (M), FUNCTION)
+------------------------------------------------------------------------------------
+       18.30  99.99%          1        18.30 guest::__zisk_entry
+       14.16  77.38%      1,000         0.01 sha2::sha256::compress256
+        0.45   2.47%          3         0.15 std::io::stdio::_print
+```
+
+**TOP UNALIGNED MEMORY FUNCTIONS** — the same ranking restricted to the *unaligned* cost, with the
+aligned cost alongside so you can see the ratio:
+
+```
+TOP UNALIGNED MEMORY FUNCTIONS (UNALIGNED (M), ALIGNED (M), % UNALIGNED, CALLS, FUNCTION)
+-----------------------------------------------------------------------------------------
+        8.06        10.24  44.05%          1 _zisk_main
+        5.27         8.89  37.19%      1,000 sha2::sha256::compress256
+        0.05         0.00  99.10%          3 <std::io::buffered::bufwriter::BufWriter<…>>::flush_buf
+```
+
+**TOP UNALIGNED/STEP RATIO FUNCTIONS** — the most useful of the three for optimization. It ranks
+functions by how far their unaligned cost *per step* exceeds the program's average, so a small
+function doing pathologically unaligned work rises to the top instead of being hidden behind the
+big ones:
+
+```
+TOP UNALIGNED/STEP RATIO FUNCTIONS (RATIO vs GLOBAL AVG, UNALIGNED (M), % UNALIGNED, UNALIGNED ACCESSES/CALL, CALLS, FUNCTION)
+------------------------------------------------------------------------------------------------------------------------------
+  1.40         0.17   2.09%          985          3 std::io::stdio::_print
+  1.39         0.17   2.05%          974          3 core::fmt::write
+  1.00         8.06 100.00%      103,111          1 _zisk_main
+  0.68         5.27  65.34%           81      1,000 sha2::sha256::compress256
+```
+
+A **RATIO** above 1 means the function is more unaligned-heavy than the program average. Only
+functions accounting for **more than 1% of the total unaligned cost** are listed, to keep low-volume
+outliers with a spectacular ratio but no impact out of the way.
+
+### Logging individual costly accesses (`--log-costly-unaligned`)
+
+When you have narrowed the problem down to a function and want to see the actual accesses,
+`--log-costly-unaligned` prints one line per **costly unaligned access** (a double 4B/8B access that
+crosses a word boundary) as it happens, with the execution context:
+
+```bash
+ziskemu -e <elf> -i <input> -X -S --log-costly-unaligned
+```
+
+```
+MEM MONITOR pc=0x800a38ec fn='sha2::sha256::compress256' addr=0x00000000a0410003 width=4 read offset=3
+MEM MONITOR pc=0x800a3904 fn='sha2::sha256::compress256' addr=0x00000000a0410007 width=8 write offset=7 value=0x00000000deadbeef
+```
+
+Each line gives the **pc**, the **function** it belongs to, the **address**, the access **width**,
+whether it is a read or a write, the **offset** within the 8-byte word, and (for writes) the value.
+This is verbose — redirect it to a file, and use it only after the rankings above have told you
+where to look.
+
+## Register Step Distance
+
+Between two accesses to a register, the proof has to carry the fact that the register kept its
+value across the whole gap. That gap is bounded: if a register goes untouched for more than a
+certain number of steps, the value can no longer be carried and the execution has to be split. The
+register step-distance analysis measures those gaps against that limit, so you can tell whether a
+program is anywhere near it.
+
+Two flags cover the two situations you will be in: a **detailed report** when you are investigating,
+and a **fast one-line check** when you just want a verdict on a whole program.
+
+### Detailed report (`--reg-step-distance`)
+
+```bash
+ziskemu -e <elf> -i <input> -X --reg-step-distance --reg-step-limit-bits 18 --reg-step-flush-bits 18
+```
+
+```
+REGISTER STEP DISTANCE (limit 262,144, flush 2^18 = 262,144 steps, 3,159,192 steps)
+REGISTER          ACCESSES      MAX DIST    RATIO     MAX FDIST   FRATIO      >=80%    >=LIMIT       >=2x
+---------------------------------------------------------------------------------------------------------
+x1 (ra)             46,892         1,490     0.01         1,490     0.01          0          0          0
+x2 (sp)            570,318         1,497     0.01         1,497     0.01          0          0          0
+x3 (gp)                  3     3,159,185    12.05       262,144     1.00          1          1          1
+x5 (t0)            448,954         1,634     0.01         1,634     0.01          0          0          0
+x7 (t2)            203,139        45,303     0.17        32,605     0.12          0          0          0
+x10 (a0)           716,914           186     0.00           186     0.00          0          0          0
+x28 (t3)           370,116        45,327     0.17        32,628     0.12          0          0          0
+x31 (t6)           290,005        46,067     0.18        32,603     0.12          0          0          0
+---------------------------------------------------------------------------------------------------------
+TOTAL            7,784,170     3,159,185    12.05       262,144     1.00          1          1          1
+```
+
+One row per register that was accessed at least once, in register-number order:
+
+- **ACCESSES**: Reads plus writes of that register
+- **MAX DIST**: Largest gap, in steps, between two consecutive accesses
+- **RATIO**: `MAX DIST` as a fraction of the limit — anything at or above `1.00` is over it
+- **MAX FDIST** / **FRATIO**: The same maximum, but assuming a **periodic flush**: every 2^`--reg-step-flush-bits` steps, every register is forcibly accessed. A gap that straddles a flush is broken into pieces, so `MAX FDIST` can never exceed the flush period. These forced accesses are *not* counted in ACCESSES — they only feed these two columns.
+- **>=80% / >=LIMIT / >=2x**: How many gaps reached 80%, 100% and 200% of the limit. `>=80%` is the early warning: gaps that are not yet a problem but would become one on a slightly different input.
+
+The gaps at the boundaries count like any other: from the program start to a register's first
+access, and from its last access to the program end. This is why `x3 (gp)` above — the global
+pointer, set once at startup and read twice — shows a `MAX DIST` of essentially the whole program
+and a ratio of 12.05. Its `MAX FDIST` of exactly 1.00 shows what the flush buys: with a forced
+access every 262,144 steps, the longest that register ever holds a value unobserved is one flush
+period.
+
+The `TOTAL` row sums the accesses and the threshold counters, and takes the **maximum** (not the
+sum) of the distance columns.
+
+**Choosing the limits.** `--reg-step-limit-bits` sets the limit to 2^bits steps (default 22, i.e.
+4,194,304) and `--reg-step-flush-bits` the flush period the same way (default 22). Lower the limit
+below the real one to see which registers would break first as programs grow.
+
+### Fast check (`--reg-step-check`)
+
+The detailed report needs the statistics path (`-X`), which is slow. When all you want to know is
+*"does this program overflow anywhere?"*, `--reg-step-check` answers it on the **fast emulation
+path**, so a whole program can be simulated quickly just for this:
+
+```bash
+ziskemu -e <elf> -i <input> --reg-step-check --reg-step-limit-bits 16 --reg-step-flush-bits 18
+```
+
+```
+REGISTER STEP CHECK: OK, no instance over the 65536 steps limit (limit=65536 instance=2^18=262144 steps max_dist=12702)
+```
+
+It splits the execution into **instances** of 2^`--reg-step-flush-bits` steps, each starting with a
+flush that accesses every register, and reports how many instances hold at least one distance above
+the limit. When the check fails it also names the registers involved:
+
+```
+REGISTER STEP CHECK: EXCEEDED in 2 of 4 instances (limit=5 instance=2^4=16 steps max_dist=12)
+REGISTER STEP CHECK: registers over the limit: x2(sp) max=12 in 2 inst/2 gaps, x1(ra) max=8 in 1 inst/1 gaps
+```
+
+For each register over the limit it gives its worst distance, in how many distinct instances it went
+over, and how many gaps did so in total — worst first. Unlike `--reg-step-distance`, this does not
+need `-X`.
+
+## Opcode Coverage
+
+`--coverage` reports which opcodes, precompiles and RISC-V instructions the run actually exercised.
+It answers a different question from the cost tables: not "what is expensive" but "what did this
+input reach at all".
+
+```bash
+ziskemu -e <elf> -i <input> -X --coverage
+```
+
+```
+OPS_COVERAGE:
+AVAILABLE: 122
+USED: 28
+USED NO FROPS: 27 (22.13%) [ltu, lt, eq, add, sub, and, or, xor, add_w, sub_w, sll, srl, srl_w, …]
+UNUSED NO FROPS: 95 (77.87%) [minu, min, maxu, max, leu, le, minu_w, min_w, maxu_w, max_w, …]
+USED FROPS: 19 (15.57%) [ltu, lt, eq, add, sub, and, or, xor, add_w, sub_w, sll, srl, srl_w, …]
+
+RISC-V INSTRUCTION COVERAGE: 20.73% (40 out of 193)
+UNSUPPORTED RISC-V INSTRUCTIONS EXECUTED: roriw andn andn roriw roriw rev8 …
+EXECUTED RISC-V INSTRUCTIONS: add addi addiw and andi auipc beq bge bgeu blt bltu bne …
+NON_EXECUTED RISC-V INSTRUCTIONS: addw amoadd.d amoadd.w amoand.d amoand.w …
+```
+
+This is useful to:
+
+- **Validate a test input**: low coverage means the input is not exercising the paths you think it is
+- **Check that the toolchain emits what you expect**: seeing `roriw`, `andn` or `rev8` in the
+  executed set confirms the bit-manipulation extensions are being used instead of multi-instruction
+  sequences
+- **Understand FROPS reach**: `USED FROPS` vs `USED NO FROPS` shows how many of the opcodes the
+  program uses have a pre-calculated fast path at all
+
+## Comparing Runs
+
+Optimization work is a loop of *change something, measure, confirm*. Reading two full reports side
+by side does not scale, so ZiskEmu can save an aggregate snapshot of a run and diff a later run
+against it.
+
+### Saving a snapshot (`--save-stats`)
+
+```bash
+ziskemu -e <elf> -i <input> -X --save-stats before.csv
+```
+
+The snapshot holds the aggregate counters only — cost distribution, per-opcode counts and costs,
+precompiles, FROPS and memory — with no per-function detail, so it is small enough to commit
+alongside a benchmark. `--csv-separator` changes the field separator (default `,`).
+
+### Diffing against a snapshot (`--ref-stats`)
+
+Run the modified program and compare it against the saved reference in the same command. The full
+report is printed as usual, followed by the comparison:
+
+```bash
+ziskemu -e <elf> -i <input> -X --ref-stats before.csv
+```
+
+```
+COMPARISON   before.csv  →  current run
+red = higher / worse   green = lower / better   % = share of total   sign always shown
+
+STEPS                         163,609               -148,968 (-47.66%)
+
+COST DISTRIBUTION                   COST        %                     Δ (Δ%)
+------------------------------------------------------------------------------
+MAIN                          11,125,412    3.50%      -10,129,824 (-47.66%)
+OPCODES                          188,671    0.06%         -650,730 (-77.52%)
+PRECOMPILES                   15,553,188    4.89%      -60,706,144 (-79.60%)
+MEMORY                         3,775,257    1.19%       -4,310,854 (-53.31%)
+VARIABLE                      30,642,528    9.64%      -75,797,552 (-71.21%)
+BASE                         287,309,824   90.36%                +0 (+0.00%)
+TOTAL                        317,952,352  100.00%      -75,797,552 (-19.25%)
+FROPS                          2,340,075    7.64%         -997,172 (-29.88%)
+
+COST BY PRECOMPILED OPCODE
+                                COUNT       %            Δ            COST       %                   Δ (Δ%)
+--------------------------------------------------------------------------------------------------------------
+OP keccak                         204   0.12%         -796      15,417,300   4.85%    -60,157,700 (-79.60%)
+OP dma_xmemset                    413   0.25%       -2,388          75,348   0.02%       -368,548 (-83.03%)
+
+FROPS BY OPCODE                 COUNT      HIT      ΔHIT            COST       %                   Δ (Δ%)
+----------------------------------------------------------------------------------------------------------------
+FROP xor                       34,979   98.62%   +11.0pp       2,098,740   6.85%       -477,600 (-18.54%)
+FROP eq                         1,447   89.54%    -5.2pp          86,820   0.28%        -95,520 (-52.39%)
+```
+
+Every section shows the **current** value alongside the **delta** against the reference, absolute
+and relative, with the sign always displayed. FROPS hit rates are compared in **percentage points**
+(`pp`), since a percentage of a percentage would be meaningless.
+
+This example is the payoff of the [duplicate analysis](#precompile-duplicate-analysis) shown
+earlier: hoisting the four repeated hashes out of the loop removed 796 of the 1,000 keccak calls,
+cutting the precompile cost by 79.6% and the variable cost by 71.2%. Note how **TOTAL** only moves
+19.25% — the constant BASE dilutes it — which is exactly why **VARIABLE** is the line to read.
+
+### Diffing two snapshots (`--diff-stats`)
+
+To compare two saved snapshots without running anything, pass both files. No ELF or input is
+needed:
+
+```bash
+ziskemu --diff-stats before.csv after.csv
+```
+
+The first file is the reference, so deltas are `after - before`. This is the form to use in CI,
+where the runs happen on different machines or at different times.
+
+### Comparison output format
+
+| Flag | Effect |
+|------|--------|
+| `--color <auto\|always\|never>` | Colourize the comparison. `auto` (default) colours only when stdout is a terminal — so a redirected log stays clean. |
+| `--diff-format <color\|csv>` | `color` (default) is the human-readable view above; `csv` is a plain semicolon-separated view for scripting. |
+| `--legacy-display` | Equivalent to `--diff-format csv`. Also implied by `--sdk`. |
+| `--csv-separator <SEP>` | Field separator for `--save-stats` and the `csv` view (default `,`). |
+
 ## SDK Report Mode
 
 For a **cleaner, more compact output** ideal for continuous integration or quick checks, use the `--sdk` flag. This provides a streamlined report with only the essential summary information.
@@ -453,8 +908,11 @@ For a **cleaner, more compact output** ideal for continuous integration or quick
 ### Command
 
 ```bash
-ziskemu -e <elf> -i <input> --sdk
+ziskemu -e <elf> -i <input> --sdk -X
 ```
+
+**Note**: `--sdk` selects the *format* of the report; `-X` is what makes the statistics be collected
+in the first place. Without `-X` nothing is printed.
 
 ### Output Example
 
@@ -462,23 +920,23 @@ ziskemu -e <elf> -i <input> --sdk
 ╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗
 ║  ◆ REPORT SUMMARY                                                                                                    ║
 ╠══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╣
-║  STEPS                                                                                                    92,875,129  ║
-║  COST                                                                                              11,437,643,381  ║
-║  RAM                                                                                                  17.61 MB /  64.00 MB  ║
+║  STEPS                                                                                                    3,159,193  ║
+║  COST                                                                                                   632,033,308  ║
+║  RAM                                                                                            0.00 MB / 507.75 MB  ║
 ╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝
 
 ╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗
 ║  ◆ COST DISTRIBUTION SUMMARY                                                                                         ║
 ╠══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╣
-║  CATEGORY     ∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙          COST      %  ║
+║  CATEGORY                                                                                               COST      %  ║
 ║  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄  ║
-║  Base         ▎∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙     293,601,280   2.6%  ║
-║  Main         ███████████████████████████████████████████████████████∙∙∙∙   6,315,508,772  55.2%  ║
-║  Opcodes      ████████████▊∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙   1,334,639,984  11.7%  ║
-║  Precompiles  █████████████████████████▊∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙   2,565,960,716  22.4%  ║
-║  Memory       █████████▎∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙     927,932,629   8.1%  ║
+║  Base         ███████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░     287,309,824  45.5%  ║
+║  Main         ███████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░     214,825,124  34.0%  ║
+║  Opcodes      ██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░     110,764,355  17.5%  ║
+║  Precompiles  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░         836,980   0.1%  ║
+║  Memory       ██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      18,297,025   2.9%  ║
 ║  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄  ║
-║  Total                                                                       11,437,643,381 100.0%  ║
+║  Total                                                                                           632,033,308 100.0%  ║
 ╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -871,8 +1329,8 @@ Shows for each function:
 **2. TOP COST FUNCTIONS** - Analysis by profiling cost:
 
 ```
-TOP COST FUNCTIONS (COST, % COST, CALLS, COST/CALL, FUNCTION)
--------------------------------------------------------------
+TOP COST FUNCTIONS (COST, % VARIABLE COST, CALLS, COST/CALL, FUNCTION)
+----------------------------------------------------------------------
   5,255,204,123  45.95%          1   5,255,204,123 <reth_evm::execute::BasicBlockExecutor<&reth_evm
   5,172,696,823  45.23%          1   5,172,696,823 <alloy_evm::eth::block::EthBlockExecutor<alloy_e
   4,997,989,104  43.70%         70      71,399,844 <revm_handler::mainnet_handler::MainnetHandler<r
@@ -883,7 +1341,7 @@ TOP COST FUNCTIONS (COST, % COST, CALLS, COST/CALL, FUNCTION)
 
 Shows for each function:
 - **COST**: Total cumulative profiling cost of the function (including all nested calls)
-- **% COST**: Percentage of total program cost this function represents
+- **% VARIABLE COST**: Percentage of the program's **variable** cost this function represents. It is measured against VARIABLE rather than TOTAL because the constant BASE cost belongs to no function — including it would shrink every percentage by the same arbitrary factor.
 - **CALLS**: Number of times this function was called
 - **COST/CALL**: Average profiling cost per call to this function
 - **FUNCTION**: Function name from symbol table
@@ -1014,20 +1472,18 @@ DETAIL FUNCTION ziskos::zisklib::lib::keccak256::keccak256
 |                                             -----------------------------------------------
 |    TOTAL                                          1,440,768 100.00%      74,973,696 100.00%
 
-|    COST BY OPCODE                     COUNT            COST       % RANK
-|    ---------------------------------------------------------------------
-|    OP ltu                            28,516       1,710,960   0.05%
-|    OP add                           169,207       4,230,175   0.11%
-|    OP sub                             3,644         218,640   0.01%
-|    OP and                            94,545       5,672,700   0.15%
-|    OP or                          2,489,249     149,354,940   3.97% #2
-|    OP xor                           492,192      29,531,520   0.79% #3
-|    OP sll                           360,008      19,080,424   0.51% #4
-|    OP dma_memcpy                     21,010         882,420   0.02%
-|    OP dma_xmemset                    21,010         882,420   0.02%
-|    OP _dma_pre                        2,346         206,448   0.01%
-|    OP _dma_post                       9,863         867,944   0.02%
-|    OP keccak                         32,650   2,466,707,500  65.61% #1
+|    COST BY OPCODE                     COUNT       %            COST       %
+|    ------------------------------------------------------------------------
+|    OP keccak                         32,650   0.04%  2,466,707,500  65.61%
+|    OP or                          2,489,249   3.27%    149,354,940   3.97%
+|    OP xor                           492,192   0.65%     29,531,520   0.79%
+|    OP sll                           360,008   0.47%     19,080,424   0.51%
+|    OP and                            94,545   0.12%      5,672,700   0.15%
+|    OP add                           169,207   0.22%      4,230,175   0.11%
+|    OP ltu                            28,516   0.04%      1,710,960   0.05%
+|    OP dma_memcpy                     21,010   0.03%        882,420   0.02%
+|    OP dma_xmemset                    21,010   0.03%        882,420   0.02%
+|    OP sub                             3,644   0.00%        218,640   0.01%
 
 |    TOP STEP CALLERS (calls, steps)
 |    -------------------------------
@@ -1072,17 +1528,17 @@ unaligned/double accesses to the exact function that causes them.
 
 **COST BY OPCODE section:**
 ```
-|    COST BY OPCODE                     COUNT            COST       % RANK
-|    ---------------------------------------------------------------------
-|    OP keccak                         32,650   2,466,707,500  65.61% #1
-|    OP or                          2,489,249     149,354,940   3.97% #2
-|    OP xor                           492,192      29,531,520   0.79% #3
+|    COST BY OPCODE                     COUNT       %            COST       %
+|    ------------------------------------------------------------------------
+|    OP keccak                         32,650   0.04%  2,466,707,500  65.61%
+|    OP or                          2,489,249   3.27%    149,354,940   3.97%
+|    OP xor                           492,192   0.65%     29,531,520   0.79%
 ```
-Breaks down which operations consume resources within this function:
-- **COUNT**: Number of times each operation was executed
+Breaks down which operations consume resources within this function, **sorted by cost**, base and
+precompiled opcodes together (unlike the top-level report, which splits them into two tables):
+- **COUNT**: Number of times each operation was executed, and its share of the program's steps
 - **COST**: Total profiling cost for all executions
 - **%**: Percentage of this function's total cost
-- **RANK**: Top 4 most expensive operations marked `#1` through `#4`
 
 This shows that `keccak` precompile dominates this function's cost at 65.61%, making it the primary optimization target.
 
@@ -1175,7 +1631,7 @@ Each line contains the parameter values (in hexadecimal) for one function call, 
 
 ## PC Histogram Analysis
 
-The `-H` (or `--histogram`) flag provides a **low-level view** of the most frequently executed code positions in your program. Unlike function-level profiling, this analysis operates at the **program counter (PC)** level, showing you the exact assembly instructions that execute most often.
+The `-H` (or `--top-histogram`) flag provides a **low-level view** of the most frequently executed code positions in your program. Unlike function-level profiling, this analysis operates at the **program counter (PC)** level, showing you the exact assembly instructions that execute most often.
 
 ### What This Shows
 
@@ -1279,6 +1735,78 @@ This 17-instruction sequence accounts for 7.86% of total execution, making it a 
 - **Finding unexpected hotspots**: Sometimes a small instruction sequence accounts for disproportionate execution time
 - **Comparing implementations**: See how different code structures affect instruction-level execution patterns
 
+## Instruction Tracing and Disassembly
+
+When the aggregate reports are not enough and you need to see the program instruction by
+instruction, there are three tools, from most verbose to most compact.
+
+### Full instruction trace (`--trace-steps`)
+
+Prints every executed instruction to stdout — step, pc and the decoded instruction. Unlike
+`--log-step`, it works in release builds:
+
+```bash
+ziskemu -e <elf> -i <input> --trace-steps > trace.txt
+```
+
+```
+### S:0 PC 1000: Jump over end instruction
+### S:1 PC 1008: Set marchid: fffeeee
+### S:2 PC 100c: Set mtvec: 4188
+### S:3 PC 1010: Set 1st Param (pInput): 0x40000000
+```
+
+This forces full (non-fast) emulation and produces one line per step, so **always redirect it to a
+file** — a program of a few million steps produces hundreds of MB.
+
+### Change trace over a step window (`--trace-from` / `--trace-to`)
+
+Usually you do not want the whole program, only the few thousand steps around a divergence. The
+change trace prints each executed instruction in a window **followed by every register and stack
+write it caused**, as `prev (0xhex) => post (0xhex)`:
+
+```bash
+ziskemu -e <elf> -i <input> --trace-from 1000 --trace-to 1006
+```
+
+```
+### S:1000 PC 800034f4: xor r12, r12, r14
+### S:1001 PC 800034f8: srliw r14, r6, 0xa
+    reg x14 (a4): 0 (0x0) => 281248 (0x44aa0)
+### S:1002 PC 800034fc: xor r22, r15, r14
+    reg x22 (s6): 2563236514 (0x98c7e2a2) => 268435472 (0x10000010)
+### S:1003 PC 80003500: srliw r14, r11, 0x3
+    reg x14 (a4): 281248 (0x44aa0) => 0 (0x0)
+### S:1004 PC 80003504: sd r11, 0x380(r2)
+    stack 0xa03ffd40 [sp+0x380]: 0 (0x0) => 0 (0x0)
+```
+
+Register writes show the register number and its ABI name. **Stack writes** are RAM writes in the
+range `[RAM_ADDR, SYS_ADDR)` and show both the absolute address and its offset relative to `sp`
+(`x2`), which is what makes a trace comparable across runs whose stacks sit at different addresses.
+
+`--trace-from` defaults to 0 and `--trace-to` to the end, so either can be given alone. Like
+`--trace-steps`, this forces full emulation.
+
+### Annotated disassembly (`--disasm`)
+
+Writes an objdump-like disassembly of the whole program to a file, with the **execution count** of
+each instruction next to it. Requires `-S -X`:
+
+```bash
+ziskemu -e <elf> -i <input> -X -S --disasm program.asm
+```
+
+```
+  00001018:             1                                  copyb x1, 0, 0x80000000 ; store_pc
+  0000101c:             1                                  copyb x11, 0, 0x20
+  00001020:             1                                  copyb x12, 0, 0
+```
+
+Unlike [the PC histogram](#pc-histogram-analysis), which lists only the hottest sequences, this
+covers the whole program including the instructions that never executed (count 0) — useful to spot
+dead code, or to confirm that a branch you expected to be taken never was.
+
 ## Additional Options
 
 ### Show Steps Without Full Statistics
@@ -1304,6 +1832,41 @@ For machine-readable output, disable the thousands separator with `--no-thousand
 ```bash
 ziskemu -e target/elf/riscv64ima-zisk-zkvm-elf/release/guest -i input.bin -X --no-thousands-sep
 ```
+
+### Sort Statistics by Operation Count
+
+By default the opcode, precompile and FROPS tables are sorted by cost. `--sort-by-units` sorts them
+by operation count instead, which is what you want when hunting for the most *frequent* operation
+rather than the most expensive one:
+
+```bash
+ziskemu -e target/elf/riscv64ima-zisk-zkvm-elf/release/guest -i input.bin -X --sort-by-units
+```
+
+It also changes the group order of the [operand pattern analysis](#operand-pattern-analysis).
+
+### Call-Stack Tracking Mode
+
+The per-function report (`-S -X`) reconstructs a call stack by watching calls and returns. Some
+code — notably GCC/C++ tail recursion such as `std::sort`'s `__introsort_loop` — returns in a way
+that does not match the recorded stack. `--callstack-mode` decides what happens then:
+
+```bash
+# auto (default): resync the call stack when a mismatch is detected
+ziskemu -e <elf> -i <input> -X -S --callstack-mode auto
+
+# strict: disable call-stack tracking on the first mismatch
+ziskemu -e <elf> -i <input> -X -S --callstack-mode strict
+```
+
+Use `strict` when you suspect the resync is inventing call relationships and want to know whether a
+mismatch happened at all; `auto` otherwise, since it keeps the per-function report usable on C++
+code.
+
+### Legacy Statistics Format
+
+`-x` (lowercase) prints the legacy statistics report, kept for compatibility with older tooling.
+Use `-X` for everything described in this guide.
 
 ## Complete Example: Comprehensive Profiling
 
@@ -1347,9 +1910,29 @@ Begin with basic statistics (`-X`) to get an overview, then progressively add mo
 3. Callers: `ziskemu -e program.elf -i input.bin -X -S -D`
 4. Detailed: Add `-H` as needed
 
+### Follow the Cost to the Right Tool
+
+Once the cost distribution tells you *which category* dominates, there is a specific analysis for
+each:
+
+| If the cost is in… | Use | To find |
+|--------------------|-----|---------|
+| PRECOMPILES | [`--duplicates`](#precompile-duplicate-analysis) | Calls that recompute a result already proven |
+| OPCODES | [`--pattern-analysis`](#operand-pattern-analysis) / [`--opcode-breakdown`](#opcode-variant-breakdown) | Operand shapes that a cheaper state machine could prove |
+| MEMORY | [`--mem-full-stats`](#memory-statistics) | Unaligned accesses and the functions causing them |
+| MAIN | [`-H`](#pc-histogram-analysis) / [`-S -D`](#detailed-caller-analysis) | Hot instruction sequences and the functions running them |
+
+Then use [`--save-stats` / `--ref-stats`](#comparing-runs) to confirm the change actually paid off.
+
 ### Focus on High Impact
 
 Use the final_cost percentage to identify functions with the highest impact. Optimizing a function that represents 50% of execution time will have much more effect than optimizing one at 1%.
+
+### Compare Against VARIABLE, Not TOTAL
+
+The BASE cost is a constant that every program pays. When you compare two runs, a 70% cut in the
+work your code does can look like a 19% cut in TOTAL simply because BASE did not move. Read the
+**VARIABLE** line, which is what your changes actually control.
 
 ### Understand Profiling Cost vs. Final Cost
 
@@ -1402,8 +1985,8 @@ target/release/ziskemu \
 The output will show the TOP COST FUNCTIONS filtered to only include EVM instruction implementations, giving you a clear view of which Ethereum opcodes dominate the proving cost for this specific block:
 
 ```
-TOP COST FUNCTIONS (COST, % COST, CALLS, COST/CALL, FUNCTION)
--------------------------------------------------------------
+TOP COST FUNCTIONS (COST, % VARIABLE COST, CALLS, COST/CALL, FUNCTION)
+----------------------------------------------------------------------
   9,433,353,231  10.32%      5,824       1,619,737 revm_interpreter::instructions::contract::call_helpers::load_acc_
   9,396,093,086  10.28%      5,824       1,613,340 revm_interpreter::instructions::contract::call_helpers::load_acco
   9,377,741,662  10.26%      5,824       1,610,189 revm_interpreter::instructions::contract::call_helpers::load_acco

--- a/book/developer/profiling.md
+++ b/book/developer/profiling.md
@@ -24,29 +24,31 @@ This guide walks you through ZiskEmu's profiling capabilities, progressing from 
 
 9. **Comparing Runs**: Saving a statistics snapshot and diffing a later run against it to validate an optimization
 
-10. **SDK Report Mode**: Streamlined, compact output format ideal for CI/CD and quick checks, with selective section display options
+10. **HTML Report**: Rendering a run, or the comparison of two runs, as a standalone shareable page
 
-11. **Function Name Display Options**: Configure how long function names are displayed with compact and no-compact modes
+11. **SDK Report Mode**: Streamlined, compact output format ideal for CI/CD and quick checks, with selective section display options
 
-12. **Profile Tags**: Instrument your code to measure specific sections, with immediate or deferred reporting of steps and costs
+12. **Function Name Display Options**: Configure how long function names are displayed with compact and no-compact modes
 
-13. **Firefox Profiler Integration**: Export profiling data for advanced visualization and interactive analysis
+13. **Profile Tags**: Instrument your code to measure specific sections, with immediate or deferred reporting of steps and costs
 
-14. **Function-Level Profiling**: Identifying which functions consume the most resources with cumulative analysis
+14. **Firefox Profiler Integration**: Export profiling data for advanced visualization and interactive analysis
 
-15. **Customizing ROI Display**: Controlling how many functions to show and filtering by patterns
+15. **Function-Level Profiling**: Identifying which functions consume the most resources with cumulative analysis
 
-16. **Detailed Caller Analysis**: In-depth breakdown showing which operations are expensive within each function and who calls them
+16. **Customizing ROI Display**: Controlling how many functions to show and filtering by patterns
 
-17. **Tracking Function Calls**: Logging individual call parameters to analyze usage patterns and optimize for common cases
+17. **Detailed Caller Analysis**: In-depth breakdown showing which operations are expensive within each function and who calls them
 
-18. **PC Histogram Analysis**: Low-level view of the most frequently executed RISC-V instruction sequences
+18. **Tracking Function Calls**: Logging individual call parameters to analyze usage patterns and optimize for common cases
 
-19. **Instruction Tracing and Disassembly**: Step-by-step traces, change traces and an annotated disassembly with execution counts
+19. **PC Histogram Analysis**: Low-level view of the most frequently executed RISC-V instruction sequences
 
-20. **Additional Options**: Quick reference for other useful flags (steps, progress indicators, formatting)
+20. **Instruction Tracing and Disassembly**: Step-by-step traces, change traces and an annotated disassembly with execution counts
 
-21. **Practical Example**: Real-world case study analyzing Ethereum opcode costs in a block validator
+21. **Additional Options**: Quick reference for other useful flags (steps, progress indicators, formatting)
+
+22. **Practical Example**: Real-world case study analyzing Ethereum opcode costs in a block validator
 
 ## Introduction
 
@@ -892,6 +894,9 @@ ziskemu --diff-stats before.csv after.csv
 The first file is the reference, so deltas are `after - before`. This is the form to use in CI,
 where the runs happen on different machines or at different times.
 
+Both comparison forms can also be rendered as a page instead of printed — see
+[HTML Report](#html-report).
+
 ### Comparison output format
 
 | Flag | Effect |
@@ -900,6 +905,53 @@ where the runs happen on different machines or at different times.
 | `--diff-format <color\|csv>` | `color` (default) is the human-readable view above; `csv` is a plain semicolon-separated view for scripting. |
 | `--legacy-display` | Equivalent to `--diff-format csv`. Also implied by `--sdk`. |
 | `--csv-separator <SEP>` | Field separator for `--save-stats` and the `csv` view (default `,`). |
+
+## HTML Report
+
+`--html-report` renders the statistics as a **standalone HTML page** instead of a CSV snapshot. The
+snapshot content is handed straight to the report renderer, so no intermediate CSV file is written
+unless you also ask for one with `--save-stats`.
+
+```bash
+# Single-run report, written to report.html
+ziskemu -e <elf> -i <input> -X --html-report
+
+# Choose the output path
+ziskemu -e <elf> -i <input> -X --html-report profile.html
+```
+
+The page contains the same data as the text report — cost distribution, base and precompiled
+opcodes, FROPS, and the memory breakdown — laid out as sortable tables and bars, which is easier to
+scan and to attach to a PR or a ticket than a wall of terminal output.
+
+### Comparison report
+
+Give it a reference and it renders the **comparison** of both snapshots instead of a single run.
+Two ways, matching the two text-mode forms:
+
+```bash
+# Run the program and compare it against a saved snapshot
+ziskemu -e <elf> -i <input> -X --ref-stats before.csv --html-report compare.html
+
+# Compare two saved snapshots, without running anything
+ziskemu --diff-stats before.csv after.csv --html-report compare.html
+```
+
+In both cases the first snapshot is the **baseline (A)** and the second is **B**, with the change
+shown as `B - A`: green for a lower cost, red for a higher one. With `--ref-stats` the current run
+is B, labelled *current run*; with `--diff-stats` each side is labelled with its snapshot path.
+
+**Note**: `--diff-stats` needs no ELF, input or emulation, which makes it the form to use in CI —
+save a snapshot per commit and render the page comparing the two.
+
+### Notes
+
+- `--html-report` implies collecting the full statistics, exactly like `--save-stats`, so it works
+  with or without `-X` (with `-X` you also get the text report on stdout).
+- Snapshots are read back with whatever separator they were saved with, so a reference saved using
+  `--csv-separator ';'` renders correctly.
+- The same renderer is available as a standalone binary that reads snapshots from disk:
+  `cargo run --bin report -- stats.csv [other.csv]`.
 
 ## SDK Report Mode
 

--- a/emulator/src/bin/ziskemu.rs
+++ b/emulator/src/bin/ziskemu.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
-use std::{fmt::Write, process};
+use std::{fmt::Write, fs, process};
 use zisk_common::EmuTrace;
-use ziskemu::{diff_stats_files, resolve_color, EmuOptions, Emulator, ZiskEmulator};
+use ziskemu::{diff_stats_files, report, resolve_color, EmuOptions, Emulator, ZiskEmulator};
 
 fn main() {
     // Create a emulator options instance based on arguments or default values
@@ -10,6 +10,23 @@ fn main() {
     // Compare two saved stats snapshots without running the emulator.
     if let Some(files) = &options.diff_stats {
         let (old, new) = (&files[0], &files[1]);
+        // `--html-report` renders the comparison as a page instead of printing it.
+        if let Some(html_path) = &options.html_report {
+            let written = fs::read_to_string(old)
+                .and_then(|old_csv| fs::read_to_string(new).map(|new_csv| (old_csv, new_csv)))
+                .and_then(|(old_csv, new_csv)| {
+                    let html = report::render_compare(&old_csv, old, &new_csv, new);
+                    fs::write(html_path, html)
+                });
+            match written {
+                Ok(()) => println!("HTML report written to: {html_path}"),
+                Err(e) => {
+                    eprintln!("Failed to render HTML report for '{old}' and '{new}': {e}");
+                    process::exit(1);
+                }
+            }
+            return;
+        }
         match diff_stats_files(
             old,
             new,

--- a/emulator/src/bin/ziskemu.rs
+++ b/emulator/src/bin/ziskemu.rs
@@ -1,11 +1,30 @@
 use clap::Parser;
 use std::{fmt::Write, process};
 use zisk_common::EmuTrace;
-use ziskemu::{EmuOptions, Emulator, ZiskEmulator};
+use ziskemu::{diff_stats_files, resolve_color, EmuOptions, Emulator, ZiskEmulator};
 
 fn main() {
     // Create a emulator options instance based on arguments or default values
     let options: EmuOptions = EmuOptions::parse();
+
+    // Compare two saved stats snapshots without running the emulator.
+    if let Some(files) = &options.diff_stats {
+        let (old, new) = (&files[0], &files[1]);
+        match diff_stats_files(
+            old,
+            new,
+            options.diff_use_csv(),
+            resolve_color(&options.color),
+            options.csv_sep(),
+        ) {
+            Ok(comparison) => print!("{comparison}"),
+            Err(e) => {
+                eprintln!("Failed to compare stats snapshots '{old}' and '{new}': {e}");
+                process::exit(1);
+            }
+        }
+        return;
+    }
 
     //println! {"options={}", options};
 

--- a/emulator/src/emu.rs
+++ b/emulator/src/emu.rs
@@ -1811,10 +1811,9 @@ impl<'a> Emu<'a> {
         self.ctx.stats.set_mem_stats(options.mem_stats);
         self.ctx.stats.set_mem_full_stats(options.mem_full_stats);
         // Byte-offset counters feed the on-screen table (--mem-full-stats) and the snapshot
-        // (--save-stats / --ref-stats), so collect them whenever any of those is requested.
-        self.ctx.stats.set_collect_offsets(
-            options.mem_full_stats || options.save_stats.is_some() || options.ref_stats.is_some(),
-        );
+        // (--save-stats / --ref-stats / --html-report), so collect them whenever any of those is
+        // requested.
+        self.ctx.stats.set_collect_offsets(options.mem_full_stats || options.snapshot_enabled());
         self.ctx.stats.set_log_costly_unaligned(options.log_costly_unaligned);
         self.ctx.stats.set_callstack_strict(options.callstack_mode == "strict");
         self.ctx.stats.set_opcode_breakdown(options.opcode_breakdown);
@@ -1927,8 +1926,7 @@ impl<'a> Emu<'a> {
             || options.legacy_stats
             || options.trace_steps
             || options.store_op_output.is_some()
-            || options.save_stats.is_some()
-            || options.ref_stats.is_some()
+            || options.snapshot_enabled()
             || options.trace_changes_enabled();
 
         // While not done
@@ -2007,11 +2005,7 @@ impl<'a> Emu<'a> {
         // Print stats report (only for real stats; a pure `--trace-steps` run
         // turns on do_stats just to emit the per-op trace, not the report).
         // `--save-stats` / `--ref-stats` also need this path to write / compare the snapshot.
-        if options.stats
-            || options.legacy_stats
-            || options.save_stats.is_some()
-            || options.ref_stats.is_some()
-        {
+        if options.stats || options.legacy_stats || options.snapshot_enabled() {
             self.ctx.stats.on_finish(&self.ctx.inst_ctx);
             let report = self.ctx.stats.report(self.rom);
             println!("{report}");
@@ -2038,6 +2032,29 @@ impl<'a> Emu<'a> {
                 ) {
                     Ok(comparison) => println!("{comparison}"),
                     Err(e) => eprintln!("Failed to read reference stats snapshot {ref_path}: {e}"),
+                }
+            }
+
+            // Render this run as an HTML page, comparing it against the reference snapshot when
+            // one was given. The snapshot content goes straight to the renderer, so no CSV file
+            // is involved unless `--save-stats` asked for one.
+            if let Some(html_path) = &options.html_report {
+                let current = self.ctx.stats.stats_csv(options.csv_sep());
+                // With a reference, render the comparison; on its own, render just this run.
+                // `None` means the reference could not be read — the text comparison above has
+                // already reported why, so do not blame the write for a read that failed.
+                let html = match &options.ref_stats {
+                    Some(ref_path) => std::fs::read_to_string(ref_path).ok().map(|reference| {
+                        crate::report::render_compare(&reference, ref_path, &current, "current run")
+                    }),
+                    None => Some(crate::report::render_single(&current)),
+                };
+                match html {
+                    Some(html) => match std::fs::write(html_path, html) {
+                        Ok(()) => println!("HTML report written to: {html_path}"),
+                        Err(e) => eprintln!("Failed to write HTML report to {html_path}: {e}"),
+                    },
+                    None => eprintln!("HTML report skipped: reference snapshot unavailable"),
                 }
             }
 

--- a/emulator/src/emu.rs
+++ b/emulator/src/emu.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::mem;
 
-use crate::{ElfSymbolReader, EmuContext, EmuOptions, EmuRegTrace, ParEmuOptions};
+use crate::{ElfSymbolReader, EmuContext, EmuOptions, EmuRegTrace, ParEmuOptions, RegStepCheck};
 use fields::PrimeField64;
 use mem_common::MemHelpers;
 use riscv::RiscVRegisters;
@@ -23,6 +23,23 @@ use zisk_core::{
 };
 
 const LOAD_SYMBOLS: [&str; 3] = ["_heap_bottom", "_heap_top", "ZISK_BUMP_HEAP_POS"];
+
+/// Feeds the fast register step-distance check (`--reg-step-check`) with the registers accessed by
+/// one instruction: the `a` and `b` operands when they are sourced from a register, and the store
+/// destination when it is a register. Which registers those are mirrors `source_a`, `source_b` and
+/// `store_c`. All of them are accounted at the same step, so their relative order is irrelevant.
+#[inline(always)]
+fn track_reg_step_check(check: &mut RegStepCheck, instruction: &ZiskInst, step: u64) {
+    if instruction.a_src == SRC_REG {
+        check.on_access(instruction.a_offset_imm0 as usize, step);
+    }
+    if instruction.b_src == SRC_REG {
+        check.on_access(instruction.b_offset_imm0 as usize, step);
+    }
+    if instruction.store == STORE_REG {
+        check.on_access(instruction.store_offset as usize, step);
+    }
+}
 
 /// ZisK emulator structure, containing the ZisK rom, the list of ZisK operations, and the
 /// execution context
@@ -1528,7 +1545,11 @@ impl<'a> Emu<'a> {
     /// Run the whole program, fast
     #[inline(always)]
     pub fn run_fast(&mut self, options: &EmuOptions) {
-        if options.with_progress {
+        if self.ctx.reg_step_check.is_some() {
+            // `--reg-step-check` gets its own loop so that `step_fast`, the hot path, stays free of
+            // any check of its own.
+            self.run_fast_reg_step_check(options);
+        } else if options.with_progress {
             while !self.ctx.inst_ctx.end && (self.ctx.inst_ctx.step < options.max_steps) {
                 self.step_fast_with_progress();
             }
@@ -1544,6 +1565,20 @@ impl<'a> Emu<'a> {
                 "Emu::run_fast() finished with error at step={} pc=0x{:x}",
                 self.ctx.inst_ctx.step, self.ctx.inst_ctx.pc
             );
+        }
+    }
+
+    /// Run the whole program fast while measuring the register step distances (`--reg-step-check`).
+    /// Same loop as `run_fast`, only adding the per-instruction register accounting, which is a
+    /// handful of comparisons per step.
+    fn run_fast_reg_step_check(&mut self, options: &EmuOptions) {
+        while !self.ctx.inst_ctx.end && (self.ctx.inst_ctx.step < options.max_steps) {
+            let instruction = self.rom.get_instruction(self.ctx.inst_ctx.pc);
+            let step = self.ctx.inst_ctx.step;
+            if let Some(check) = self.ctx.reg_step_check.as_mut() {
+                track_reg_step_check(check, instruction, step);
+            }
+            self.step_fast_inst(instruction);
         }
     }
 
@@ -1605,6 +1640,14 @@ impl<'a> Emu<'a> {
         //     );*/
         //     [0u64; 32]
         // };
+        self.step_fast_inst(instruction);
+    }
+
+    /// Body of `step_fast` for an already fetched instruction, so a caller that has to inspect the
+    /// instruction before executing it (`run_fast_reg_step_check`) does not look it up twice. Always
+    /// inlined, so `step_fast` keeps the exact same shape it had.
+    #[inline(always)]
+    fn step_fast_inst(&mut self, instruction: &ZiskInst) {
         self.source_a(instruction);
         self.source_b(instruction);
 
@@ -1775,6 +1818,7 @@ impl<'a> Emu<'a> {
         self.ctx.stats.set_log_costly_unaligned(options.log_costly_unaligned);
         self.ctx.stats.set_callstack_strict(options.callstack_mode == "strict");
         self.ctx.stats.set_opcode_breakdown(options.opcode_breakdown);
+        self.ctx.stats.set_pattern_analysis(options.pattern_analysis);
         self.ctx.stats.set_duplicates(options.duplicates);
         self.ctx.stats.set_duplicates_depth(options.duplicates_depth);
         self.ctx.stats.set_duplicates_detail(options.duplicates_detail);
@@ -1799,6 +1843,15 @@ impl<'a> Emu<'a> {
                 }
             }
             self.ctx.stats.set_duplicates_ops(Some(set));
+        }
+        self.ctx.stats.set_reg_step_distance(options.reg_step_distance);
+        self.ctx.stats.set_reg_step_limit(options.reg_step_limit());
+        self.ctx.stats.set_reg_step_flush_bits(options.reg_step_flush_bits);
+        if options.reg_step_check {
+            self.ctx.reg_step_check = Some(Box::new(RegStepCheck::new(
+                options.reg_step_limit(),
+                options.reg_step_flush_bits,
+            )));
         }
         self.ctx.stats.set_sdk_width(options.sdk_width);
         self.ctx.stats.set_store_ops(options.store_op_output.is_some());
@@ -2014,6 +2067,11 @@ impl<'a> Emu<'a> {
                 }
             }
         }
+
+        // Single-line verdict of the fast register step-distance check (`--reg-step-check`).
+        if let Some(check) = &self.ctx.reg_step_check {
+            println!("{}", check.report(self.ctx.inst_ctx.step));
+        }
     }
 
     /// Run the whole program
@@ -2136,7 +2194,14 @@ impl<'a> Emu<'a> {
         let instruction = self.rom.get_instruction(self.ctx.inst_ctx.pc);
 
         if self.ctx.do_stats {
-            self.ctx.stats.set_current_pc(pc);
+            self.ctx.stats.set_current_pc(pc, self.ctx.inst_ctx.step);
+        }
+
+        // `--reg-step-check` normally runs on the fast path (`run_fast_reg_step_check`); this keeps
+        // it working when another option forces the full emulation path, e.g. combined with -X.
+        let step = self.ctx.inst_ctx.step;
+        if let Some(check) = &mut self.ctx.reg_step_check {
+            track_reg_step_check(check, instruction, step);
         }
 
         if options.with_progress && self.ctx.inst_ctx.step & 0xF_FFFF == 0 {

--- a/emulator/src/emu.rs
+++ b/emulator/src/emu.rs
@@ -1767,9 +1767,43 @@ impl<'a> Emu<'a> {
         self.ctx.stats.set_sdk_top_functions(options.top_functions);
         self.ctx.stats.set_mem_stats(options.mem_stats);
         self.ctx.stats.set_mem_full_stats(options.mem_full_stats);
+        // Byte-offset counters feed the on-screen table (--mem-full-stats) and the snapshot
+        // (--save-stats / --ref-stats), so collect them whenever any of those is requested.
+        self.ctx.stats.set_collect_offsets(
+            options.mem_full_stats || options.save_stats.is_some() || options.ref_stats.is_some(),
+        );
+        self.ctx.stats.set_log_costly_unaligned(options.log_costly_unaligned);
+        self.ctx.stats.set_callstack_strict(options.callstack_mode == "strict");
+        self.ctx.stats.set_opcode_breakdown(options.opcode_breakdown);
+        self.ctx.stats.set_duplicates(options.duplicates);
+        self.ctx.stats.set_duplicates_depth(options.duplicates_depth);
+        self.ctx.stats.set_duplicates_detail(options.duplicates_detail);
+        if let Some(list) = &options.duplicates_ops {
+            // Parse the comma-separated opcode names, keeping only supported precompiles.
+            let supported: std::collections::HashSet<u8> =
+                crate::Stats::dup_supported_opcodes().into_iter().collect();
+            let mut set = std::collections::HashSet::new();
+            for name in list.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                match ZiskOp::try_from_name(name) {
+                    Ok(op) if supported.contains(&op.code()) => {
+                        set.insert(op.code());
+                    }
+                    Ok(op) => eprintln!(
+                        "--duplicates-ops: '{name}' (0x{:02x}) is not a duplicate-analyzed \
+                         precompile, ignoring",
+                        op.code()
+                    ),
+                    Err(_) => {
+                        eprintln!("--duplicates-ops: unknown opcode name '{name}', ignoring")
+                    }
+                }
+            }
+            self.ctx.stats.set_duplicates_ops(Some(set));
+        }
         self.ctx.stats.set_sdk_width(options.sdk_width);
         self.ctx.stats.set_store_ops(options.store_op_output.is_some());
         self.ctx.stats.set_legacy_frops(options.legacy_frops);
+        self.ctx.stats.set_sort_by_units(options.sort_by_units);
         if let Some(profiler_output) = &options.profiler_output {
             self.ctx.stats.set_profiler_output(profiler_output.clone());
         }
@@ -1840,6 +1874,8 @@ impl<'a> Emu<'a> {
             || options.legacy_stats
             || options.trace_steps
             || options.store_op_output.is_some()
+            || options.save_stats.is_some()
+            || options.ref_stats.is_some()
             || options.trace_changes_enabled();
 
         // While not done
@@ -1917,12 +1953,39 @@ impl<'a> Emu<'a> {
 
         // Print stats report (only for real stats; a pure `--trace-steps` run
         // turns on do_stats just to emit the per-op trace, not the report).
-        if options.stats || options.legacy_stats {
+        // `--save-stats` / `--ref-stats` also need this path to write / compare the snapshot.
+        if options.stats
+            || options.legacy_stats
+            || options.save_stats.is_some()
+            || options.ref_stats.is_some()
+        {
             self.ctx.stats.on_finish(&self.ctx.inst_ctx);
             let report = self.ctx.stats.report(self.rom);
             println!("{report}");
             if let Some(store_op_output_file) = &options.store_op_output {
                 self.ctx.stats.flush_op_data_to_file(store_op_output_file).unwrap();
+            }
+
+            // Save an aggregate stats snapshot for later comparison.
+            if let Some(save_path) = &options.save_stats {
+                match std::fs::write(save_path, self.ctx.stats.stats_csv(options.csv_sep())) {
+                    Ok(()) => println!("Stats snapshot saved to: {save_path}"),
+                    Err(e) => eprintln!("Failed to save stats snapshot to {save_path}: {e}"),
+                }
+            }
+
+            // Compare this run against a previously saved reference snapshot.
+            if let Some(ref_path) = &options.ref_stats {
+                let color = crate::resolve_color(&options.color);
+                match self.ctx.stats.compare_stats(
+                    ref_path,
+                    options.diff_use_csv(),
+                    color,
+                    options.csv_sep(),
+                ) {
+                    Ok(comparison) => println!("{comparison}"),
+                    Err(e) => eprintln!("Failed to read reference stats snapshot {ref_path}: {e}"),
+                }
             }
 
             // Generate disassembly if requested

--- a/emulator/src/emu_context.rs
+++ b/emulator/src/emu_context.rs
@@ -1,4 +1,4 @@
-use crate::{EmuOptions, Stats};
+use crate::{EmuOptions, RegStepCheck, Stats};
 use zisk_common::EmuTrace;
 use zisk_core::{InstContext, INPUT_ADDR, RAM_ADDR, RAM_SIZE, REGS_IN_MAIN_TOTAL_NUMBER};
 
@@ -21,6 +21,9 @@ pub struct EmuContext {
     /// defaults to 0 and `trace_to` to unbounded.
     pub trace_from: Option<u64>,
     pub trace_to: Option<u64>,
+    /// Fast register step-distance check (ziskemu's `--reg-step-check`), `None` when not requested.
+    /// Boxed to keep the context small, as this is a diagnostic-only mode.
+    pub reg_step_check: Option<Box<RegStepCheck>>,
 }
 
 /// RisK emulator context implementation
@@ -41,6 +44,7 @@ impl EmuContext {
             stats: Stats::default(),
             trace_from: None,
             trace_to: None,
+            reg_step_check: None,
         };
 
         // Check the input data size is inside the proper range

--- a/emulator/src/emu_costs.rs
+++ b/emulator/src/emu_costs.rs
@@ -25,6 +25,11 @@ pub const BASE_COST: usize = ROM_COST + TABLES_COST;
 
 pub const MAIN_COST: u64 = 68;
 
+/// Reduced cost of an ADD that can be proven by BinaryAddHi (hi32(a)=hi32(c)=0, hi32(b) all-0 or
+/// all-1). Cheaper than the regular ADD (BINARY_ADD_COST = 25). Used for the add_hi breakdown; tune
+/// once BinaryAddHi's final cost is fixed.
+pub const BINARY_ADD_HI_COST: u64 = 15;
+
 pub fn get_ops_costs(ops: &[u64]) -> (u64, u64) {
     let mut ops_cost = 0;
     let mut precompiled_cost = 0;

--- a/emulator/src/emu_options.rs
+++ b/emulator/src/emu_options.rs
@@ -139,6 +139,19 @@ pub struct EmuOptions {
     /// NEW - OLD). No ELF/input is needed.
     #[clap(long, num_args = 2, value_names = ["OLD", "NEW"])]
     pub diff_stats: Option<Vec<String>>,
+    /// Render the statistics as a standalone HTML page instead of a CSV snapshot: the snapshot
+    /// content is passed straight to the report renderer, no intermediate CSV file is written.
+    /// With a reference (`--ref-stats <FILE>`, or `--diff-stats <OLD> <NEW>`, which needs no run)
+    /// both snapshots are passed and the comparison report is rendered instead. Optionally takes
+    /// the output path; defaults to `report.html`. Collects the statistics on its own, so -X is
+    /// not required (add it to also get the text report on stdout).
+    #[clap(
+        long,
+        value_name = "HTML_FILE",
+        num_args = 0..=1,
+        default_missing_value = "report.html"
+    )]
+    pub html_report: Option<String>,
     /// Colourize the stats comparison (`--ref-stats` / `--diff-stats`): `auto` (colour only when
     /// stdout is a terminal), `always`, or `never`.
     #[clap(long, value_name = "WHEN", default_value = "auto")]
@@ -336,6 +349,7 @@ impl Default for EmuOptions {
             save_stats: None,
             ref_stats: None,
             diff_stats: None,
+            html_report: None,
             color: "auto".to_string(),
             diff_format: "color".to_string(),
             legacy_display: false,
@@ -459,6 +473,14 @@ impl EmuOptions {
             // A full stats snapshot / comparison needs the per-opcode + memory collection path.
             && self.save_stats.is_none()
             && self.ref_stats.is_none()
+            && self.html_report.is_none()
+    }
+
+    /// True if the run has to produce a statistics snapshot, either to a CSV file
+    /// (`--save-stats`), to compare against a reference (`--ref-stats`) or to render the HTML
+    /// report (`--html-report`). All three need the same collection path.
+    pub fn snapshot_enabled(&self) -> bool {
+        self.save_stats.is_some() || self.ref_stats.is_some() || self.html_report.is_some()
     }
 
     /// Register step-distance limit in steps, i.e. 2^`--reg-step-limit-bits` (clamped to a

--- a/emulator/src/emu_options.rs
+++ b/emulator/src/emu_options.rs
@@ -168,6 +168,11 @@ pub struct EmuOptions {
     /// e.g. `add` split into `add_hi0` / `add_hif` (BinaryAddHi shapes). Requires option: -X
     #[clap(long, value_name = "OPCODE_BREAKDOWN", default_value = "false")]
     pub opcode_breakdown: bool,
+    /// Show an operand pattern-analysis section: per base opcode, the operand categories that cover
+    /// a significant share of its operations (more than 10% of the opcode's operations and at least
+    /// 4,000 in absolute terms). Requires option: -X
+    #[clap(long, value_name = "PATTERN_ANALYSIS", default_value = "false")]
+    pub pattern_analysis: bool,
     /// Analyze duplicate precompile calls: report, per precompile, how many calls repeat the same
     /// input content (same input → same output) and the cost spent on those repeats (the potential
     /// deduplication saving). Covers every precompile except DMA. Requires option: -X
@@ -186,6 +191,29 @@ pub struct EmuOptions {
     /// duplicates come from, most costly first. Requires options: -S --duplicates
     #[clap(long, value_name = "DUPLICATES_DETAIL", default_value = "false")]
     pub duplicates_detail: bool,
+    /// Analyze the step distance between consecutive accesses of each register: report per register
+    /// the accesses, the maximum distance and its ratio to the limit, the same maximum assuming a
+    /// periodic flush (`--reg-step-flush-bits`), and how many gaps reach 80% / 100% / 200% of the
+    /// limit (`--reg-step-limit-bits`). Requires option: -X
+    #[clap(long, value_name = "REG_STEP_DISTANCE", default_value = "false")]
+    pub reg_step_distance: bool,
+    /// Distance limit, in bits, for the register step-distance thresholds: the limit is 2^bits
+    /// steps. Default 22, i.e. 4194304 steps.
+    #[clap(long, value_name = "BITS", default_value = "22")]
+    pub reg_step_limit_bits: u32,
+    /// Flush period, in bits, for the `--reg-step-distance` analysis: every 2^bits steps every
+    /// register is assumed to be forcibly accessed (a flush). These forced accesses are not counted
+    /// in the ACCESSES column, they only feed the MAX FDIST / FRATIO columns. Default 22.
+    #[clap(long, value_name = "BITS", default_value = "22")]
+    pub reg_step_flush_bits: u32,
+    /// Fast one-line check of the register step distances, so a whole program can be simulated
+    /// quickly just to see this. Splits the execution in instances of 2^bits steps
+    /// (`--reg-step-flush-bits`), each one starting with a flush that accesses every register, and
+    /// reports how many instances hold at least one distance above the limit
+    /// (`--reg-step-limit-bits`).
+    /// Unlike `--reg-step-distance` it does not need -X and runs on the fast emulation path.
+    #[clap(long, value_name = "REG_STEP_CHECK", default_value = "false")]
+    pub reg_step_check: bool,
     /// Load function names and symbols from the ELF file.
     #[clap(short = 'S', long, value_name = "READ_SYMBOLS", default_value = "false")]
     pub read_symbols: bool,
@@ -315,10 +343,15 @@ impl Default for EmuOptions {
             log_costly_unaligned: false,
             callstack_mode: "auto".to_string(),
             opcode_breakdown: false,
+            pattern_analysis: false,
             duplicates: false,
             duplicates_ops: None,
             duplicates_depth: 4,
             duplicates_detail: false,
+            reg_step_distance: false,
+            reg_step_limit_bits: 22,
+            reg_step_flush_bits: 22,
+            reg_step_check: false,
             read_symbols: false,
             roi_callers: 10,
             top_roi: 25,
@@ -426,6 +459,12 @@ impl EmuOptions {
             // A full stats snapshot / comparison needs the per-opcode + memory collection path.
             && self.save_stats.is_none()
             && self.ref_stats.is_none()
+    }
+
+    /// Register step-distance limit in steps, i.e. 2^`--reg-step-limit-bits` (clamped to a
+    /// representable limit).
+    pub fn reg_step_limit(&self) -> u64 {
+        1u64 << self.reg_step_limit_bits.min(63)
     }
 
     /// True if a change-trace window was requested (via `--trace-from`/`--trace-to`).

--- a/emulator/src/emu_options.rs
+++ b/emulator/src/emu_options.rs
@@ -121,6 +121,71 @@ pub struct EmuOptions {
     /// coverage statistics, so a new FROPS version can be compared against the previous one.
     #[clap(long, value_name = "LEGACY_FROPS", default_value = "false")]
     pub legacy_frops: bool,
+    /// Sort the opcode / precompiled / FROPS statistics sections by operation count (units)
+    /// instead of by cost. Requires option: -X
+    #[clap(long, value_name = "SORT_BY_UNITS", default_value = "false")]
+    pub sort_by_units: bool,
+    /// Save an aggregate statistics snapshot (semicolon-separated, no per-function detail) to this
+    /// file, so a later run can compare against it with `--ref-stats`. Requires option: -X
+    #[clap(long, value_name = "SAVE_STATS")]
+    pub save_stats: Option<String>,
+    /// Load an aggregate statistics snapshot saved with `--save-stats` and print a comparison
+    /// (reference vs current) of the cost distribution, base opcodes, precompiles and FROPS.
+    /// Requires option: -X
+    #[clap(long, value_name = "REF_STATS")]
+    pub ref_stats: Option<String>,
+    /// Compare two statistics snapshots saved with `--save-stats` and print the comparison, without
+    /// running the emulator. Takes two files: `<OLD> <NEW>` (OLD is the reference; deltas are
+    /// NEW - OLD). No ELF/input is needed.
+    #[clap(long, num_args = 2, value_names = ["OLD", "NEW"])]
+    pub diff_stats: Option<Vec<String>>,
+    /// Colourize the stats comparison (`--ref-stats` / `--diff-stats`): `auto` (colour only when
+    /// stdout is a terminal), `always`, or `never`.
+    #[clap(long, value_name = "WHEN", default_value = "auto")]
+    pub color: String,
+    /// Format of the stats comparison output: `color` (human-readable, colour-coded — the default)
+    /// or `csv` (the previous plain, semicolon-separated view, for scripting).
+    #[clap(long, value_name = "FORMAT", default_value = "color")]
+    pub diff_format: String,
+    /// Render the stats comparison in the previous plain view (equivalent to `--diff-format csv`).
+    /// Also implied by `--sdk`.
+    #[clap(long, value_name = "LEGACY_DISPLAY", default_value = "false")]
+    pub legacy_display: bool,
+    /// Field separator for the CSV stats output (`--save-stats` and the `csv` comparison view).
+    /// A single character; defaults to a comma.
+    #[clap(long, value_name = "SEP", default_value = ",")]
+    pub csv_separator: String,
+    /// Log every costly unaligned memory access (double 4B/8B word-crossing) with its execution
+    /// context (pc, function, address, offset, value). Off by default. Requires option: -X
+    #[clap(long, value_name = "LOG_COSTLY_UNALIGNED", default_value = "false")]
+    pub log_costly_unaligned: bool,
+    /// Call-stack tracking mode for the per-function report (`-S -X`): `auto` (default) resyncs the
+    /// call stack when a mismatch is detected — needed for GCC/C++ tail-recursion such as
+    /// std::sort's __introsort_loop; `strict` keeps the original behaviour (disable on mismatch).
+    #[clap(long, value_name = "MODE", default_value = "auto")]
+    pub callstack_mode: String,
+    /// Show a per-opcode breakdown of cheaper-to-prove variants under each opcode in the report,
+    /// e.g. `add` split into `add_hi0` / `add_hif` (BinaryAddHi shapes). Requires option: -X
+    #[clap(long, value_name = "OPCODE_BREAKDOWN", default_value = "false")]
+    pub opcode_breakdown: bool,
+    /// Analyze duplicate precompile calls: report, per precompile, how many calls repeat the same
+    /// input content (same input → same output) and the cost spent on those repeats (the potential
+    /// deduplication saving). Covers every precompile except DMA. Requires option: -X
+    #[clap(long, value_name = "DUPLICATES", default_value = "false")]
+    pub duplicates: bool,
+    /// Restrict the duplicate analysis (`--duplicates`) to these precompiles, comma-separated by
+    /// opcode name (e.g. `keccak,sha256,arith256`). If omitted, all supported precompiles are
+    /// analyzed. Requires option: --duplicates
+    #[clap(long, value_name = "OPCODES")]
+    pub duplicates_ops: Option<String>,
+    /// Number of innermost call-stack functions (leaf + callers) to record per precompile call for
+    /// the duplicate detail report (`--duplicates-detail`). Requires option: --duplicates
+    #[clap(long, value_name = "DEPTH", default_value = "4")]
+    pub duplicates_depth: usize,
+    /// Show the per-precompile call-path detail (level 2) of the duplicate report: where the
+    /// duplicates come from, most costly first. Requires options: -S --duplicates
+    #[clap(long, value_name = "DUPLICATES_DETAIL", default_value = "false")]
+    pub duplicates_detail: bool,
     /// Load function names and symbols from the ELF file.
     #[clap(short = 'S', long, value_name = "READ_SYMBOLS", default_value = "false")]
     pub read_symbols: bool,
@@ -239,6 +304,21 @@ impl Default for EmuOptions {
             generate_minimal_traces: false,
             store_op_output: None,
             legacy_frops: false,
+            sort_by_units: false,
+            save_stats: None,
+            ref_stats: None,
+            diff_stats: None,
+            color: "auto".to_string(),
+            diff_format: "color".to_string(),
+            legacy_display: false,
+            csv_separator: ",".to_string(),
+            log_costly_unaligned: false,
+            callstack_mode: "auto".to_string(),
+            opcode_breakdown: false,
+            duplicates: false,
+            duplicates_ops: None,
+            duplicates_depth: 4,
+            duplicates_detail: false,
             read_symbols: false,
             roi_callers: 10,
             top_roi: 25,
@@ -317,6 +397,17 @@ impl fmt::Display for EmuOptions {
 }
 
 impl EmuOptions {
+    /// Whether the stats comparison should use the previous plain semicolon-separated view instead
+    /// of the colour-coded one: explicit `--diff-format csv`, `--legacy-display`, or SDK mode.
+    pub fn diff_use_csv(&self) -> bool {
+        self.diff_format == "csv" || self.legacy_display || self.sdk
+    }
+
+    /// The CSV field separator as a single character (first char of `--csv-separator`, `,` if empty).
+    pub fn csv_sep(&self) -> char {
+        self.csv_separator.chars().next().unwrap_or(',')
+    }
+
     /// Returns true if the configuration allows to emulate in fast mode, maximizing the performance
     pub fn is_fast(&self) -> bool {
         self.chunk_size.is_none()
@@ -332,6 +423,9 @@ impl EmuOptions {
             && !self.generate_minimal_traces
             && !self.log_output
             && !self.log_output_riscof
+            // A full stats snapshot / comparison needs the per-opcode + memory collection path.
+            && self.save_stats.is_none()
+            && self.ref_stats.is_none()
     }
 
     /// True if a change-trace window was requested (via `--trace-from`/`--trace-to`).

--- a/emulator/src/lib.rs
+++ b/emulator/src/lib.rs
@@ -23,6 +23,7 @@ mod emu_reg_trace;
 mod emu_segment;
 mod emulator;
 mod emulator_errors;
+mod reg_step_check;
 pub mod stats;
 
 pub use disasm::*;
@@ -36,5 +37,6 @@ pub use emu_reg_trace::*;
 pub use emu_segment::*;
 pub use emulator::*;
 pub use emulator_errors::*;
+pub use reg_step_check::*;
 pub use stats::*;
 pub use zisk_common::ProfilingMode;

--- a/emulator/src/reg_step_check.rs
+++ b/emulator/src/reg_step_check.rs
@@ -1,0 +1,210 @@
+//! Fast register step-distance check (`--reg-step-check`).
+//!
+//! Unlike the full `--reg-step-distance` report, which lives in [`crate::stats`] and needs the
+//! statistics path (`-X`), this is a self-contained counter cheap enough to run on the fast
+//! emulation path: it only keeps the last access step of each register and a couple of counters, so
+//! a whole program can be simulated quickly just to answer "does any instance overflow?".
+//!
+//! Execution is split into instances of 2^`instance_bits` steps. Every instance starts with a flush
+//! that accesses every register, so the distance of an access is measured from the later of the
+//! previous access to that register and the start of the current instance. An instance is reported
+//! as overflowing when it holds at least one such distance above the limit.
+
+use riscv::RiscVRegisters;
+use zisk_core::REGS_IN_MAIN_TOTAL_NUMBER;
+
+/// Per-register step-distance overflow counter, aggregated per instance.
+pub struct RegStepCheck {
+    /// A distance strictly above this limit overflows the instance.
+    limit: u64,
+    /// Instance size in bits: one instance spans 2^`instance_bits` steps.
+    instance_bits: u32,
+    /// Step of the last access (read or write) of each register; 0 until first accessed, which is
+    /// also the step the program starts at.
+    last_step: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
+    /// Number of distinct instances holding at least one distance above the limit.
+    instances_over: u64,
+    /// Last instance already counted in `instances_over`, so several overflows inside the same
+    /// instance are counted once. `u64::MAX` means none counted yet.
+    last_instance_over: u64,
+    /// Largest distance seen, to give the single output line some context.
+    max_dist: u64,
+    /// Per register, how many of its distances were above the limit, so a failing run can name the
+    /// registers involved. Only touched when a distance overflows, which keeps the common path
+    /// untouched.
+    reg_over: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
+    /// Per register, its largest distance above the limit; 0 for registers that never overflowed.
+    reg_max_dist: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
+    /// Per register, the last instance already counted in `reg_instances_over`.
+    reg_last_instance_over: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
+    /// Per register, in how many distinct instances it went over the limit.
+    reg_instances_over: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
+}
+
+impl RegStepCheck {
+    /// Creates the checker for the given distance limit and instance size in bits (clamped to a
+    /// representable instance).
+    pub fn new(limit: u64, instance_bits: u32) -> Self {
+        Self {
+            limit,
+            instance_bits: instance_bits.min(63),
+            last_step: [0; REGS_IN_MAIN_TOTAL_NUMBER],
+            instances_over: 0,
+            last_instance_over: u64::MAX,
+            max_dist: 0,
+            reg_over: [0; REGS_IN_MAIN_TOTAL_NUMBER],
+            reg_max_dist: [0; REGS_IN_MAIN_TOTAL_NUMBER],
+            reg_last_instance_over: [u64::MAX; REGS_IN_MAIN_TOTAL_NUMBER],
+            reg_instances_over: [0; REGS_IN_MAIN_TOTAL_NUMBER],
+        }
+    }
+
+    /// Accounts one register access at `step`. The distance is measured from the later of the
+    /// previous access and the flush that opens the current instance; distances between the flush
+    /// and a later flush are irrelevant here, an untouched register is always re-read by the flush.
+    #[inline(always)]
+    pub fn on_access(&mut self, reg: usize, step: u64) {
+        debug_assert!(reg < REGS_IN_MAIN_TOTAL_NUMBER);
+        let instance = step >> self.instance_bits;
+        let base = self.last_step[reg].max(instance << self.instance_bits);
+        self.last_step[reg] = step;
+
+        let dist = step - base;
+        if dist > self.max_dist {
+            self.max_dist = dist;
+        }
+        if dist > self.limit {
+            self.reg_over[reg] += 1;
+            if dist > self.reg_max_dist[reg] {
+                self.reg_max_dist[reg] = dist;
+            }
+            if self.reg_last_instance_over[reg] != instance {
+                self.reg_last_instance_over[reg] = instance;
+                self.reg_instances_over[reg] += 1;
+            }
+            if self.last_instance_over != instance {
+                self.last_instance_over = instance;
+                self.instances_over += 1;
+            }
+        }
+    }
+
+    /// Number of instances holding at least one distance above the limit.
+    pub fn instances_over(&self) -> u64 {
+        self.instances_over
+    }
+
+    /// Total number of instances an execution of `end_step` steps spans.
+    pub fn total_instances(&self, end_step: u64) -> u64 {
+        (end_step >> self.instance_bits) + 1
+    }
+
+    /// Registers that went over the limit, worst first: `(register, instances, distances, max
+    /// distance)`. Empty when the check passed.
+    pub fn registers_over(&self) -> Vec<(usize, u64, u64, u64)> {
+        let mut regs: Vec<(usize, u64, u64, u64)> = (0..REGS_IN_MAIN_TOTAL_NUMBER)
+            .filter(|&r| self.reg_over[r] > 0)
+            .map(|r| (r, self.reg_instances_over[r], self.reg_over[r], self.reg_max_dist[r]))
+            .collect();
+        regs.sort_by(|a, b| b.3.cmp(&a.3).then(a.0.cmp(&b.0)));
+        regs
+    }
+
+    /// Verdict of the check, for an execution that ended at `end_step`: one line, plus a second one
+    /// naming the registers involved when it failed.
+    pub fn report(&self, end_step: u64) -> String {
+        let over = self.instances_over;
+        let verdict = if over == 0 {
+            format!("OK, no instance over the {} steps limit", self.limit)
+        } else {
+            format!("EXCEEDED in {} of {} instances", over, self.total_instances(end_step))
+        };
+        let mut report = format!(
+            "REGISTER STEP CHECK: {verdict} (limit={} instance=2^{}={} steps max_dist={})",
+            self.limit,
+            self.instance_bits,
+            1u64 << self.instance_bits,
+            self.max_dist,
+        );
+        let regs = self.registers_over();
+        if !regs.is_empty() {
+            let detail: Vec<String> = regs
+                .iter()
+                .map(|&(r, instances, times, max_dist)| {
+                    let name = RiscVRegisters::name_from_usize(r).unwrap_or("?");
+                    format!("x{r}({name}) max={max_dist} in {instances} inst/{times} gaps")
+                })
+                .collect();
+            report.push_str(&format!(
+                "\nREGISTER STEP CHECK: registers over the limit: {}",
+                detail.join(", ")
+            ));
+        }
+        report
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_one_instance_per_overflow_and_measures_from_the_instance_start() {
+        // Instances of 16 steps, distances above 5 overflow.
+        let mut check = RegStepCheck::new(5, 4);
+
+        check.on_access(1, 0); // first access, distance 0 from the program start
+        check.on_access(1, 3); // distance 3
+        check.on_access(1, 20); // instance 1: measured from its start (16), not from step 3 -> 4
+        assert_eq!(check.instances_over(), 0);
+
+        check.on_access(1, 40); // instance 2: 40 - 32 = 8 > 5
+        assert_eq!(check.instances_over(), 1);
+
+        check.on_access(2, 41); // 41 - 32 = 9 > 5, but the same instance is not counted twice
+        assert_eq!(check.instances_over(), 1);
+
+        check.on_access(2, 60); // instance 3: 60 - 48 = 12 > 5
+        assert_eq!(check.instances_over(), 2);
+
+        assert_eq!(check.total_instances(60), 4);
+        assert!(check.report(60).starts_with("REGISTER STEP CHECK: EXCEEDED in 2 of 4 instances"));
+
+        // Both registers overflowed once; x2 did it by a wider margin, so it is reported first.
+        assert_eq!(check.registers_over(), vec![(2, 2, 2, 12), (1, 1, 1, 8)]);
+    }
+
+    #[test]
+    fn registers_that_never_overflow_are_not_reported() {
+        let mut check = RegStepCheck::new(5, 4);
+        check.on_access(1, 2); // never overflows
+        check.on_access(1, 6);
+        check.on_access(3, 15); // 15 - 0 = 15 > 5, twice in two different instances
+        check.on_access(3, 40); // 40 - 32 = 8 > 5
+        assert_eq!(check.registers_over(), vec![(3, 2, 2, 15)]);
+        assert!(check
+            .report(40)
+            .contains("registers over the limit: x3(gp) max=15 in 2 inst/2 gaps"));
+    }
+
+    #[test]
+    fn a_distance_equal_to_the_limit_does_not_overflow() {
+        let mut check = RegStepCheck::new(5, 8);
+        check.on_access(1, 2); // 2 steps from the program start
+        check.on_access(1, 7); // exactly the limit
+        assert_eq!(check.instances_over(), 0);
+        check.on_access(1, 13); // one step above it
+        assert_eq!(check.instances_over(), 1);
+    }
+
+    #[test]
+    fn an_instance_can_be_counted_again_after_a_quiet_one() {
+        // Instance 0 and instance 2 overflow, instance 1 does not: the counter must not collapse
+        // them, and must not miss the second one either.
+        let mut check = RegStepCheck::new(5, 4);
+        check.on_access(1, 10); // instance 0: 10 - 0 = 10 > 5
+        check.on_access(1, 20); // instance 1: 20 - 16 = 4
+        check.on_access(1, 46); // instance 2: 46 - 32 = 14 > 5
+        assert_eq!(check.instances_over(), 2);
+    }
+}

--- a/emulator/src/report/parser.rs
+++ b/emulator/src/report/parser.rs
@@ -1,3 +1,5 @@
+use crate::stats::detect_sep;
+
 #[derive(Debug, Default)]
 pub struct Report {
     pub steps: u64,
@@ -62,13 +64,14 @@ pub struct Offsets {
 
 pub fn parse(csv: &str) -> Report {
     let mut r = Report::default();
+    let sep = detect_sep(csv);
 
     for line in csv.lines() {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
-        let f: Vec<&str> = line.split(',').collect();
+        let f: Vec<&str> = line.split(sep).collect();
 
         match f[0] {
             "STEPS" => r.steps = num(f.get(1)),

--- a/emulator/src/stats/ops_costs.rs
+++ b/emulator/src/stats/ops_costs.rs
@@ -93,21 +93,35 @@ impl OpsCosts {
     }
 
     pub fn add_fixed_cost_op(&mut self, op_code: u8) {
-        if let Some((index, fixed_cost)) = TABLE.table[op_code as usize] {
-            // PubOut has a fixed cost of 0 but must still be counted, so that the
-            // aggregate counts (total_count()) stay consistent with the per-opcode
-            // count_and_cost table below.
-            let counted = fixed_cost > 0 || op_code == ZiskOp::PubOut.code();
+        match TABLE.table[op_code as usize] {
+            Some((_, fixed_cost)) => self.add_cost_op(op_code, fixed_cost),
+            None => panic!("Invalid op code: {}", op_code),
+        }
+    }
+
+    /// Accounts one execution of `op_code` charging an explicit `cost` instead of the opcode's
+    /// tabulated fixed cost. Used for cheaper opcode variants (e.g. an add_hi ADD charged at
+    /// `BINARY_ADD_HI_COST`), so the per-opcode and aggregate costs reflect the reduced cost.
+    pub fn add_cost_op(&mut self, op_code: u8, cost: u64) {
+        if let Some((index, _)) = TABLE.table[op_code as usize] {
+            // Some opcodes have a cost of 0 but must still be counted, so that the aggregate counts
+            // (total_count()) stay consistent with the per-opcode count_and_cost table below and
+            // they remain visible in the report: PubOut and the free-input calls (fcall*).
+            let counted = cost > 0
+                || op_code == ZiskOp::PubOut.code()
+                || op_code == ZiskOp::Fcall.code()
+                || op_code == ZiskOp::FcallGet.code()
+                || op_code == ZiskOp::FcallParam.code();
             if counted && !self.is_compact() {
                 self.count_and_cost[index].0 += 1;
-                self.count_and_cost[index].1 += fixed_cost;
+                self.count_and_cost[index].1 += cost;
             }
             if counted {
                 if index >= TABLE.base_count {
-                    self.precompiled_cost += fixed_cost;
+                    self.precompiled_cost += cost;
                     self.precompiled_count += 1;
                 } else {
-                    self.base_cost += fixed_cost;
+                    self.base_cost += cost;
                     self.base_count += 1;
                 }
             }

--- a/emulator/src/stats/stats.rs
+++ b/emulator/src/stats/stats.rs
@@ -17,7 +17,7 @@ use std::{
     io::{BufWriter, IsTerminal, Write},
 };
 use zisk_core::{
-    zisk_ops::{OpStats, ZiskOp},
+    zisk_ops::{OpStats, OpType, ZiskOp},
     InstContext, ZiskInst, ZiskOperationType, ZiskRom, RAM_ADDR, REGS_IN_MAIN_TOTAL_NUMBER,
     ROM_ADDR, ROM_ENTRY, ROM_ENTRY_SIZE, ROM_EXIT, ROM_SIZE, STORE_NONE, SYS_ADDR,
 };
@@ -57,6 +57,53 @@ const OP_BIN_EXT_LT_64_CATS: usize = 2;
 const OP_CATEGORIES: usize = OP_MASK_CATEGORIES + OP_BIN_EXT_LT_64_CATS;
 const OP_BIN_EXT_A_LT_64_CAT: usize = OP_MASK_CATEGORIES;
 const OP_BIN_EXT_B_LT_64_CAT: usize = OP_BIN_EXT_A_LT_64_CAT + 1;
+
+// Pattern analysis (`--pattern-analysis`): human-readable label for each operand category (see the
+// `CAT_MASK` handling in `on_op`). For each mask the four shapes are: a,b,c masked bits all zero;
+// a zero / b all-ones; a all-ones / b zero; a,b all-ones. `hi32`/`hi48` = the high 32/48 bits,
+// `lo32` = the low 32 bits; `=0` means those bits are zero, `=1` means all ones.
+//
+// The second label is the one used for the single-operand opcodes of `B_ONLY_OPS`, whose `a` is
+// zero by definition: the condition on `a` holds trivially and is dropped from the label. `None`
+// means the whole category is vacuous for them — either it only constrains `a` (`a<64`), or it
+// requires `a` to be all-ones, which can never happen — so the pattern is not reported at all.
+const CAT_LABELS: [(&str, Option<&str>); OP_CATEGORIES] = [
+    ("a,b,c hi32=0", Some("b,c hi32=0")),
+    ("a hi32=0,b hi32=1", Some("b hi32=1")),
+    ("a hi32=1,b hi32=0", None),
+    ("a,b hi32=1", None),
+    ("a,b,c hi48=0", Some("b,c hi48=0")),
+    ("a hi48=0,b hi48=1", Some("b hi48=1")),
+    ("a hi48=1,b hi48=0", None),
+    ("a,b hi48=1", None),
+    ("a,b,c lo32=0", Some("b,c lo32=0")),
+    ("a lo32=0,b lo32=1", Some("b lo32=1")),
+    ("a lo32=1,b lo32=0", None),
+    ("a,b lo32=1", None),
+    ("a<64", None),
+    ("b<64", Some("b<64")),
+];
+/// Opcodes that take a single operand: their `op_*` implementation ignores `a` (see `op_rev8`,
+/// `op_signextend_b`, … in `zisk_core`), so `a` is always zero and any pattern constraining it is
+/// true by definition. They are reported with the reduced `CAT_LABELS` labels.
+const B_ONLY_OPS: [u8; 12] = [
+    ZiskOp::SIGNEXTEND_B,
+    ZiskOp::SIGNEXTEND_H,
+    ZiskOp::SIGNEXTEND_W,
+    ZiskOp::REV8,
+    ZiskOp::BREV8,
+    ZiskOp::CLZ,
+    ZiskOp::CLZ_W,
+    ZiskOp::CTZ,
+    ZiskOp::CTZ_W,
+    ZiskOp::CPOP,
+    ZiskOp::CPOP_W,
+    ZiskOp::ORC_B,
+];
+/// A category is reported as a pattern only if it covers more than this percentage of the opcode's
+/// operations AND at least `PATTERN_MIN_COUNT` operations in absolute terms.
+const PATTERN_MIN_PCT: f64 = 10.0;
+const PATTERN_MIN_COUNT: u64 = 4_000;
 
 const REG_RA_IDX: u8 = 1;
 const REG_T0_IDX: u8 = 5;
@@ -166,6 +213,9 @@ pub struct Stats {
     cheap_variant_counts: [u64; CHEAP_VARIANT_COUNT],
     /// Show the per-opcode breakdown of cheap variants in the report (`--opcode-breakdown`).
     opcode_breakdown: bool,
+    /// Show the operand pattern-analysis section (`--pattern-analysis`): per opcode, the operand
+    /// categories that cover a significant share of its operations.
+    pattern_analysis: bool,
     /// Analyze duplicate precompile calls: count how many calls repeat the same input content
     /// (same input → same output) and the cost spent on those repeats, per precompile
     /// (`--duplicates`).
@@ -212,6 +262,36 @@ pub struct Stats {
     /// pc of the instruction currently being executed, set once per step; used to give execution
     /// context when reporting an invalid memory access.
     current_pc: u64,
+    /// step of the instruction currently being executed, set once per step; used by the
+    /// register step-distance analysis to timestamp each register access.
+    current_step: u64,
+    // --- Register step-distance analysis (`--reg-step-distance`) -------------------------------
+    /// Whether to measure, per register, the gap in steps between consecutive accesses.
+    reg_step_distance: bool,
+    /// Distance limit against which the 80% / 100% / 200% counters are compared (`--reg-step-limit-bits`).
+    reg_step_limit: u64,
+    /// Flush period in bits (`--reg-step-flush-bits`): every 2^bits steps every register is assumed
+    /// to be forcibly accessed. Kept only to label the report.
+    reg_flush_bits: u32,
+    /// Flush period in steps, i.e. 2^`reg_flush_bits`; always >= 1.
+    reg_flush_period: u64,
+    /// Program start step (minimum step seen): the baseline for the first-access distance, so the
+    /// gap from the program start to a register's first access is counted like any other gap.
+    reg_start_step: u64,
+    /// Last step each register was accessed (read or write); `None` until first accessed.
+    reg_last_step: [Option<u64>; REGS_IN_MAIN_TOTAL_NUMBER],
+    /// Maximum step distance seen per register.
+    reg_max_dist: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
+    /// Maximum step distance seen per register once the periodic flush accesses are inserted, i.e.
+    /// the longest a register keeps a value if it is forcibly accessed every `reg_flush_period`
+    /// steps. Never larger than `reg_flush_period`.
+    reg_max_fdist: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
+    /// Per-register count of distances reaching >=80% of the limit.
+    reg_near80: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
+    /// Per-register count of distances reaching >=100% of the limit (over the limit).
+    reg_over: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
+    /// Per-register count of distances reaching >=200% of the limit (double the limit).
+    reg_double: [u64; REGS_IN_MAIN_TOTAL_NUMBER],
     call_stack: Vec<CallStackEntry>,
     is_call: bool,
     is_return: bool,
@@ -297,6 +377,18 @@ impl Default for Stats {
             pc_histogram: HashMap::new(),
             previous_pc: 0,
             current_pc: 0,
+            current_step: 0,
+            reg_step_distance: false,
+            reg_step_limit: 1 << 22,
+            reg_flush_bits: 22,
+            reg_flush_period: 1 << 22,
+            reg_start_step: u64::MAX,
+            reg_last_step: [None; REGS_IN_MAIN_TOTAL_NUMBER],
+            reg_max_dist: [0; REGS_IN_MAIN_TOTAL_NUMBER],
+            reg_max_fdist: [0; REGS_IN_MAIN_TOTAL_NUMBER],
+            reg_near80: [0; REGS_IN_MAIN_TOTAL_NUMBER],
+            reg_over: [0; REGS_IN_MAIN_TOTAL_NUMBER],
+            reg_double: [0; REGS_IN_MAIN_TOTAL_NUMBER],
             call_stack: Vec::new(),
             is_call: false,
             is_tail_call: false,
@@ -347,6 +439,7 @@ impl Default for Stats {
             op_categories: OpsCount::<OP_CATEGORIES>::new(),
             cheap_variant_counts: [0; CHEAP_VARIANT_COUNT],
             opcode_breakdown: false,
+            pattern_analysis: false,
             duplicates: false,
             duplicates_ops: None,
             duplicates_depth: 4,
@@ -378,10 +471,76 @@ impl Stats {
         }
     }
 
-    /// Records the pc of the instruction currently being executed (set once per step), so an invalid
-    /// memory access can be reported with the pc/function where it happened.
-    pub fn set_current_pc(&mut self, pc: u64) {
+    /// Records the pc and step of the instruction currently being executed (set once per step,
+    /// before its register/memory accesses). The pc gives execution context when reporting an
+    /// invalid memory access; the step timestamps register accesses for the step-distance analysis.
+    pub fn set_current_pc(&mut self, pc: u64, step: u64) {
         self.current_pc = pc;
+        self.current_step = step;
+        // The first step seen is the program start, used as the baseline for the first-access gap.
+        if self.reg_step_distance && step < self.reg_start_step {
+            self.reg_start_step = step;
+        }
+    }
+
+    /// Register step-distance bookkeeping shared by reads and writes: records the gap in steps
+    /// since this register was last accessed (or since the program start, for the first access)
+    /// and updates the max / threshold counters. The final gap to the program end is added later
+    /// in `report_reg_step_distance`.
+    #[inline(always)]
+    fn on_register_access(&mut self, reg: usize) {
+        if !self.reg_step_distance {
+            return;
+        }
+        let step = self.current_step;
+        // Baseline: the previous access, or the program start for the first access — so the gap
+        // the register holds its initial value (start -> first access) is counted like any other.
+        let last = self.reg_last_step[reg].unwrap_or(self.reg_start_step);
+        self.account_reg_distance(reg, last, step);
+        self.reg_last_step[reg] = Some(step);
+    }
+
+    /// Folds the gap `last` -> `step` of one register into its max and threshold counters, both
+    /// without flushes (`reg_max_dist`) and with them (`reg_max_fdist`).
+    #[inline(always)]
+    fn account_reg_distance(&mut self, reg: usize, last: u64, step: u64) {
+        let dist = step - last;
+        if dist > self.reg_max_dist[reg] {
+            self.reg_max_dist[reg] = dist;
+        }
+        let fdist = Self::flushed_distance(last, step, self.reg_flush_period);
+        if fdist > self.reg_max_fdist[reg] {
+            self.reg_max_fdist[reg] = fdist;
+        }
+        let limit = self.reg_step_limit;
+        if dist >= limit / 5 * 4 {
+            self.reg_near80[reg] += 1;
+        }
+        if dist >= limit {
+            self.reg_over[reg] += 1;
+        }
+        if dist >= limit * 2 {
+            self.reg_double[reg] += 1;
+        }
+    }
+
+    /// Largest sub-gap inside `(last, step]` once the forced flush accesses — one at every multiple
+    /// of `period` steps — are inserted between the two real accesses. Since a flush touches every
+    /// register, a gap spanning two or more flushes is broken into pieces of at most `period`, so
+    /// the result is never larger than `period`.
+    #[inline(always)]
+    fn flushed_distance(last: u64, step: u64, period: u64) -> u64 {
+        // First flush strictly after `last`: a flush landing on `last` coincides with that access.
+        let first_flush = (last / period + 1) * period;
+        if first_flush > step {
+            // No flush in between, the gap is untouched.
+            return step - last;
+        }
+        let last_flush = step / period * period;
+        // Head (last access -> first flush), tail (last flush -> this access) and, when there is
+        // more than one flush in between, the full flush-to-flush gaps of `period` steps.
+        let mid = if last_flush > first_flush { period } else { 0 };
+        (first_flush - last).max(step - last_flush).max(mid)
     }
 
     /// Called every time some data is read from memory, if statistics are enabled
@@ -465,12 +624,14 @@ impl Stats {
     pub fn on_register_read(&mut self, reg: usize) {
         assert!(reg < REGS_IN_MAIN_TOTAL_NUMBER);
         self.regs[reg] += 1;
+        self.on_register_access(reg);
     }
 
     /// Called every time a register is written, if statistics are enabled
     pub fn on_register_write(&mut self, reg: usize) {
         assert!(reg < REGS_IN_MAIN_TOTAL_NUMBER);
         self.regs[reg] += 1;
+        self.on_register_access(reg);
     }
 
     /// Called at every step with the current number of executed steps, if statistics are enabled
@@ -1426,8 +1587,6 @@ impl Stats {
         precompiled: bool,
         breakdown: bool,
     ) {
-        let extended = base && !ops.is_frops();
-
         // Collect the opcodes to report, then order them from highest to lowest by cost (default) or
         // by operation count (units) when `sort_by_units` is set.
         let mut entries: Vec<(u8, u64, u64)> = Vec::new(); // (opcode, count, cost)
@@ -1458,19 +1617,7 @@ impl Stats {
                 Ok(inst) => inst,
                 Err(_) => continue,
             };
-            if extended {
-                let categories =
-                    self.op_categories.get_by_opcode(opcode).map(|c| &c[..]).unwrap_or(&[]);
-                report.add_count_cost_perc2_extended(
-                    &format!("{title} {:}", inst.name()),
-                    count,
-                    cost,
-                    "",
-                    categories,
-                );
-            } else {
-                report.add_count_cost_perc2(&format!("{title} {:}", inst.name()), count, cost, "");
-            }
+            report.add_count_cost_perc2(&format!("{title} {:}", inst.name()), count, cost, "");
 
             // Per-opcode breakdown of cheap variants (e.g. add → add_hif / add_hi0), as a tree.
             if breakdown {
@@ -1491,6 +1638,125 @@ impl Stats {
                         "",
                     );
                 }
+            }
+        }
+    }
+
+    /// Reports the operand pattern analysis: for each ALU opcode, the operand categories (see
+    /// `CAT_LABELS`) that cover a significant share of its operations — more than `PATTERN_MIN_PCT`%
+    /// of the opcode's operations AND at least `PATTERN_MIN_COUNT` in absolute terms. Reuses the
+    /// per-opcode category counters collected in `on_op`.
+    ///
+    /// Only arithmetic and binary opcodes are considered: the operand shape of the rest (fcalls,
+    /// pubout, profile, internal and precompiled opcodes) says nothing about how they are proven.
+    /// Patterns that are true by definition rather than by data are dropped too — see
+    /// `B_ONLY_OPS`, whose `a` operand is always zero.
+    ///
+    /// Rows are grouped by opcode, one group per opcode ordered like the opcode tables (by cost,
+    /// or by operation count with `--sort-by-units`), and the patterns inside each group ordered by
+    /// count, so a single opcode can be followed at a glance.
+    fn report_pattern_analysis(&self, report: &mut StatsReport) {
+        // One group per opcode, with the significant patterns found for it.
+        struct PatternGroup {
+            /// Opcode name, the group header.
+            name: &'static str,
+            /// Operations of this opcode, the base of the percentages below.
+            op_count: u64,
+            /// Cost / count pair the groups are ordered by (see `sort_by_units`).
+            sort_key: (u64, u64),
+            /// (label, operations matching it, percentage of `op_count`), most first.
+            patterns: Vec<(&'static str, u64, f64)>,
+        }
+        let mut groups: Vec<PatternGroup> = Vec::new();
+        for opcode in ZiskOp::MIN_OPCODE..=ZiskOp::MAX_OPCODE {
+            let (op_count, op_cost) = match self.costs.get_opcode_count_and_cost(opcode) {
+                Some((count, cost)) if count > 0 => (count as u64, cost),
+                _ => continue,
+            };
+            let inst = match ZiskOp::try_from_code(opcode) {
+                Ok(inst) => inst,
+                Err(_) => continue,
+            };
+            // Only the ALU opcodes: categories are not collected for precompiled opcodes, and for
+            // the remaining types (fcall, pubout, profile, internal, evm, dma) the operand shape
+            // is meaningless.
+            if !matches!(
+                inst.op_type(),
+                OpType::Arith
+                    | OpType::ArithA32
+                    | OpType::ArithAm32
+                    | OpType::Binary
+                    | OpType::BinaryE
+            ) {
+                continue;
+            }
+            let cats = match self.op_categories.get_by_opcode(opcode) {
+                Some(cats) => cats,
+                None => continue,
+            };
+            let b_only = B_ONLY_OPS.contains(&opcode);
+            let mut patterns: Vec<(&str, u64, f64)> = Vec::new();
+            for (i, &cat) in cats.iter().enumerate() {
+                if cat < PATTERN_MIN_COUNT {
+                    continue;
+                }
+                let pct = cat as f64 * 100.0 / op_count as f64;
+                if pct <= PATTERN_MIN_PCT {
+                    continue;
+                }
+                let Some(&(full_label, reduced_label)) = CAT_LABELS.get(i) else {
+                    continue;
+                };
+                // For single-operand opcodes the conditions on `a` hold by definition: report the
+                // pattern without them, or skip it when nothing is left to say.
+                let label = if b_only {
+                    match reduced_label {
+                        Some(label) => label,
+                        None => continue,
+                    }
+                } else {
+                    full_label
+                };
+                patterns.push((label, cat, pct));
+            }
+            if patterns.is_empty() {
+                continue;
+            }
+            patterns.sort_by_key(|&(_, count, _)| std::cmp::Reverse(count));
+            let sort_key =
+                if self.sort_by_units { (op_count, op_cost) } else { (op_cost, op_count) };
+            groups.push(PatternGroup { name: inst.name(), op_count, sort_key, patterns });
+        }
+        if groups.is_empty() {
+            return;
+        }
+        groups.sort_by_key(|group| std::cmp::Reverse(group.sort_key));
+
+        let fmt_row = |label: &str, count: &str, pct: &str| -> String {
+            format!("{label:<34} {count:>15} {pct:>8}\n")
+        };
+        let header = fmt_row("PATTERN", "COUNT", "%");
+        let width = header.trim_end().len();
+        report.add(&format!(
+            "\nOPERAND PATTERN ANALYSIS (>{:.0}% of opcode ops and >={})\n",
+            PATTERN_MIN_PCT,
+            report.format_number(PATTERN_MIN_COUNT),
+        ));
+        report.add(&header);
+        report.add(&format!("{}\n", "-".repeat(width)));
+        for group in &groups {
+            // Group header: the opcode and its total operations, the base of the percentages below.
+            report.add(&fmt_row(
+                &format!("OP {}", group.name),
+                &report.format_number(group.op_count),
+                "100.00%",
+            ));
+            for (label, count, pct) in &group.patterns {
+                report.add(&fmt_row(
+                    &format!("  {label}"),
+                    &report.format_number(*count),
+                    &format!("{pct:.2}%"),
+                ));
             }
         }
     }
@@ -1842,6 +2108,103 @@ impl Stats {
                 report.add(&format!("... and {} more call paths\n", paths.len() - top_n));
             }
         }
+    }
+
+    /// Reports the register step-distance analysis: for each register, the gap in steps between
+    /// consecutive accesses (read or write), including the boundary gaps — from the program start
+    /// to the first access and from the last access to the program end. Shows the number of
+    /// accesses, the maximum gap and its ratio to the limit (`--reg-step-limit-bits`), the same maximum
+    /// once a forced access every 2^bits steps is assumed (`MAX FDIST` / `FRATIO`, see
+    /// `--reg-step-flush-bits`; those flushes are not counted as accesses), and how many gaps
+    /// reached 80% / 100% / 200% of the limit. Large gaps are a concern because a register holds
+    /// its value across the whole gap, which the proof must carry. Rows are in register-number
+    /// order.
+    fn report_reg_step_distance(&self, report: &mut StatsReport) {
+        let limit = self.reg_step_limit;
+        let start = if self.reg_start_step == u64::MAX { 0 } else { self.reg_start_step };
+        // Program end: the last step executed (current_step is monotonic and set every step).
+        let end = self.current_step;
+        let near80_thr = limit / 5 * 4;
+
+        let fmt_row = |c: &[String; 9]| -> String {
+            format!(
+                "{:<12} {:>13} {:>13} {:>8} {:>13} {:>8} {:>10} {:>10} {:>10}\n",
+                c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7], c[8]
+            )
+        };
+        let ratio = |dist: u64| -> String { format!("{:.2}", dist as f64 / limit as f64) };
+        let header = [
+            "REGISTER".to_string(),
+            "ACCESSES".to_string(),
+            "MAX DIST".to_string(),
+            "RATIO".to_string(),
+            "MAX FDIST".to_string(),
+            "FRATIO".to_string(),
+            ">=80%".to_string(),
+            ">=LIMIT".to_string(),
+            ">=2x".to_string(),
+        ];
+        let header_line = fmt_row(&header);
+        let width = header_line.trim_end().len();
+        report.add(&format!(
+            "\nREGISTER STEP DISTANCE (limit {}, flush 2^{} = {} steps, {} steps)\n",
+            report.format_number(limit),
+            self.reg_flush_bits,
+            report.format_number(self.reg_flush_period),
+            report.format_number(end.saturating_sub(start)),
+        ));
+        report.add(&header_line);
+        report.add(&format!("{}\n", "-".repeat(width)));
+
+        // Accessed registers, in register-number order.
+        let order: Vec<usize> =
+            (0..REGS_IN_MAIN_TOTAL_NUMBER).filter(|&r| self.regs[r] > 0).collect();
+
+        let (mut t_acc, mut t_max, mut t_fmax, mut t_n80, mut t_over, mut t_dbl) =
+            (0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
+        for r in order {
+            let name = RiscVRegisters::name_from_usize(r).unwrap_or("?");
+            let last = self.reg_last_step[r].unwrap_or(start);
+            let end_dist = end.saturating_sub(last);
+            // reg_max_dist / reg_max_fdist / counters already cover the start gap and the
+            // inter-access gaps; fold in the final gap (last access -> program end) here so the
+            // reported values are complete.
+            let max_dist = self.reg_max_dist[r].max(end_dist);
+            let max_fdist =
+                self.reg_max_fdist[r].max(Self::flushed_distance(last, end, self.reg_flush_period));
+            let near80 = self.reg_near80[r] + (end_dist >= near80_thr) as u64;
+            let over = self.reg_over[r] + (end_dist >= limit) as u64;
+            let double = self.reg_double[r] + (end_dist >= 2 * limit) as u64;
+            report.add(&fmt_row(&[
+                format!("x{r} ({name})"),
+                report.format_number(self.regs[r]),
+                report.format_number(max_dist),
+                ratio(max_dist),
+                report.format_number(max_fdist),
+                ratio(max_fdist),
+                report.format_number(near80),
+                report.format_number(over),
+                report.format_number(double),
+            ]));
+            t_acc += self.regs[r];
+            t_max = t_max.max(max_dist);
+            t_fmax = t_fmax.max(max_fdist);
+            t_n80 += near80;
+            t_over += over;
+            t_dbl += double;
+        }
+        report.add(&format!("{}\n", "-".repeat(width)));
+        report.add(&fmt_row(&[
+            "TOTAL".to_string(),
+            report.format_number(t_acc),
+            report.format_number(t_max),
+            ratio(t_max),
+            report.format_number(t_fmax),
+            ratio(t_fmax),
+            report.format_number(t_n80),
+            report.format_number(t_over),
+            report.format_number(t_dbl),
+        ]));
     }
 
     // ------------------------------------------------------------------------------------------
@@ -2439,8 +2802,16 @@ impl Stats {
             self.report_frops_hit(&mut report, "FROP");
         }
 
+        if self.pattern_analysis {
+            self.report_pattern_analysis(&mut report);
+        }
+
         if self.duplicates {
             self.report_duplicates(&mut report, total_cost);
+        }
+
+        if self.reg_step_distance {
+            self.report_reg_step_distance(&mut report);
         }
 
         if self.coverage {
@@ -2524,7 +2895,8 @@ impl Stats {
                         roi_report.pop_label_width();
                     }
 
-                    roi_report.title_count_cost_perc("COST BY OPCODE", "COUNT", "COST", "");
+                    // `_perc2`: the rows carry a percentage for both the count and the cost.
+                    roi_report.title_count_cost_perc2("COST BY OPCODE", "COUNT", "COST", "");
                     self.report_opcodes(&mut roi_report, "OP", roi.ops_costs(), true, true, false);
 
                     roi_report.title_top_count_perc("TOP STEP CALLERS (calls, steps)");
@@ -2936,6 +3308,10 @@ impl Stats {
     pub fn set_opcode_breakdown(&mut self, value: bool) {
         self.opcode_breakdown = value;
     }
+    /// Enables the operand pattern-analysis section.
+    pub fn set_pattern_analysis(&mut self, value: bool) {
+        self.pattern_analysis = value;
+    }
     /// Enables the precompile duplicate analysis.
     pub fn set_duplicates(&mut self, value: bool) {
         self.duplicates = value;
@@ -2951,6 +3327,20 @@ impl Stats {
     /// Enables the per-precompile call-path detail (level 2) of the duplicate report.
     pub fn set_duplicates_detail(&mut self, value: bool) {
         self.duplicates_detail = value;
+    }
+    /// Enables the register step-distance analysis.
+    pub fn set_reg_step_distance(&mut self, value: bool) {
+        self.reg_step_distance = value;
+    }
+    /// Sets the distance limit for the register step-distance thresholds (must be > 0).
+    pub fn set_reg_step_limit(&mut self, value: u64) {
+        self.reg_step_limit = value.max(1);
+    }
+    /// Sets the flush period, in bits, of the register step-distance analysis: every 2^bits steps
+    /// every register is assumed to be forcibly accessed. Clamped to a representable period.
+    pub fn set_reg_step_flush_bits(&mut self, value: u32) {
+        self.reg_flush_bits = value.min(63);
+        self.reg_flush_period = 1u64 << self.reg_flush_bits;
     }
 
     /// Classifies an executed operation into a cheap variant (index into `CHEAP_VARIANTS`), or
@@ -3677,5 +4067,59 @@ pub fn resolve_color(when: &str) -> bool {
         "always" => true,
         "never" => false,
         _ => std::io::stdout().is_terminal(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reference implementation of `Stats::flushed_distance`: builds the explicit list of accesses
+    /// (the two real ones plus every flush in between) and takes the largest consecutive gap.
+    fn flushed_distance_ref(last: u64, step: u64, period: u64) -> u64 {
+        let mut points = vec![last];
+        let mut flush = (last / period + 1) * period;
+        while flush <= step {
+            points.push(flush);
+            flush += period;
+        }
+        points.push(step);
+        points.windows(2).map(|w| w[1] - w[0]).max().unwrap()
+    }
+
+    #[test]
+    fn flushed_distance_matches_reference() {
+        for period in [1u64, 2, 3, 4, 8, 16] {
+            for last in 0..40u64 {
+                for step in last..80u64 {
+                    assert_eq!(
+                        Stats::flushed_distance(last, step, period),
+                        flushed_distance_ref(last, step, period),
+                        "last={last} step={step} period={period}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn flushed_distance_splits_a_gap_that_straddles_one_flush() {
+        // Two accesses at 2^22 - 10 and 2^22 + 20 with a flush at 2^22: the raw gap is 30, but the
+        // flush splits it into 10 + 20, so the longest the register holds a value is 20.
+        let p = 1u64 << 22;
+        assert_eq!(Stats::flushed_distance(p - 10, p + 20, p), 20);
+        assert_eq!(Stats::flushed_distance(p - 20, p + 10, p), 20);
+    }
+
+    #[test]
+    fn flushed_distance_is_capped_by_the_flush_period() {
+        // However far apart the two real accesses are, the flushes in between break the gap into
+        // pieces of at most `period` steps.
+        assert_eq!(Stats::flushed_distance(3, 1_000_000, 64), 64);
+        // A gap that fits between two flushes is left untouched.
+        assert_eq!(Stats::flushed_distance(65, 100, 64), 35);
+        // A flush landing exactly on an access does not create a zero-length gap of its own.
+        assert_eq!(Stats::flushed_distance(64, 100, 64), 36);
+        assert_eq!(Stats::flushed_distance(50, 128, 64), 64);
     }
 }

--- a/emulator/src/stats/stats.rs
+++ b/emulator/src/stats/stats.rs
@@ -34,8 +34,8 @@ use zisk_core::{STORE_IND, UART_ADDR};
 
 use crate::{
     CallPathProfiler, MemoryOperationsStats, OpsCosts, OpsCount, RamMonitor, RegionsOfInterest,
-    StatsCosts, StatsCoverageReport, StatsReport, BASE_COST, MAIN_COST, MEM_ACCESS_INVALID,
-    MEM_ACCESS_MONITOR, MEM_WRITE_COST, NO_ROI_ID, ROM_READ_COST,
+    StatsCosts, StatsCoverageReport, StatsReport, BASE_COST, BINARY_ADD_HI_COST, MAIN_COST,
+    MEM_ACCESS_INVALID, MEM_ACCESS_MONITOR, MEM_WRITE_COST, NO_ROI_ID, ROM_READ_COST,
 };
 
 #[derive(Debug, Clone)]
@@ -52,11 +52,68 @@ pub struct CallStackEntry {
 
 const OP_DATA_BUFFER_DEFAULT_CAPACITY: usize = 128 * 1024 * 1024;
 const CAT_MASK: [u64; 3] = [0xFFFF_FFFF_0000_0000, 0xFFFF_FFFF_FFFF_0000, 0x0000_0000_FFFF_FFFF];
-const OP_CATEGORIES: usize = 4 * 3;
+const OP_MASK_CATEGORIES: usize = 4 * 3;
+const OP_BIN_EXT_LT_64_CATS: usize = 2;
+const OP_CATEGORIES: usize = OP_MASK_CATEGORIES + OP_BIN_EXT_LT_64_CATS;
+const OP_BIN_EXT_A_LT_64_CAT: usize = OP_MASK_CATEGORIES;
+const OP_BIN_EXT_B_LT_64_CAT: usize = OP_BIN_EXT_A_LT_64_CAT + 1;
 
 const REG_RA_IDX: u8 = 1;
 const REG_T0_IDX: u8 = 5;
 const RETURN_REGS: [u8; 2] = [REG_RA_IDX, REG_T0_IDX];
+
+// ------------------------------------------------------------------------------------------------
+// Cheap opcode variants: opcodes whose operands meet a condition that makes them cheaper to prove,
+// counted separately so their reduced cost can be accounted for and shown as a per-opcode
+// breakdown. A general mechanism — currently the BinaryAddHi shapes of ADD:
+//   add_hi0 : hi32(a)=hi32(c)=0 and hi32(b)=0            (both operands fit in 32 bits)
+//   add_hif : hi32(a)=hi32(c)=0 and hi32(b)=0xFFFF_FFFF  (a subtraction encoded as an addition)
+// ------------------------------------------------------------------------------------------------
+const ADD_CODE: u8 = ZiskOp::Add.code();
+const HI32_MASK: u64 = 0xFFFF_FFFF_0000_0000;
+const CHEAP_ADD_HI0: usize = 0;
+const CHEAP_ADD_HIF: usize = 1;
+const CHEAP_VARIANT_COUNT: usize = 2;
+/// (base opcode, label, reduced cost) for each cheap variant, indexed by `CHEAP_*`.
+const CHEAP_VARIANTS: [(u8, &str, u64); CHEAP_VARIANT_COUNT] =
+    [(ADD_CODE, "add_hi0", BINARY_ADD_HI_COST), (ADD_CODE, "add_hif", BINARY_ADD_HI_COST)];
+
+// ------------------------------------------------------------------------------------------------
+// Precompile duplicate analysis: detect precompile calls that repeat the same computation (same
+// input content → same output) so the redundant proving cost (the potential deduplication saving)
+// can be reported. Works for every precompile except DMA — the ones with a content descriptor
+// below. The key is the operand *content*, not the `b` address, so identical inputs stored at
+// different memory buffers are still detected as duplicates.
+// ------------------------------------------------------------------------------------------------
+/// Maximum number of innermost call-stack ROIs (leaf + callers) recorded per precompile call, so
+/// the detail report can show where the duplicates come from. The actual depth is configurable
+/// (`--duplicates-depth`) up to this maximum.
+const DUP_MAX_ROI_DEPTH: usize = 8;
+
+/// One segment of a precompile's input content, describing where to read operand words from,
+/// relative to the parameter block at `ctx.b` (all addresses are 8-byte words).
+#[derive(Clone, Copy)]
+enum DupSeg {
+    /// In-place operands: read `words` consecutive words starting at `ctx.b` (no indirection),
+    /// appended after any previous `Direct` segment.
+    Direct { words: usize },
+    /// Indirected operand: the param at `ctx.b + 8*param` is a pointer; read `words` words from it.
+    Indirect { param: usize, words: usize },
+    /// Inline scalar: the param at `ctx.b + 8*param` is a literal value (e.g. add256 carry-in,
+    /// blake2 block index), included as a single content word.
+    Literal { param: usize },
+}
+
+/// Per-precompile duplicate-analysis state.
+#[derive(Debug, Default)]
+struct DupStats {
+    /// Occurrence count of each input-content fingerprint (the number of words is precompile-fixed).
+    states: HashMap<Box<[u64]>, u32>,
+    /// Per-call-path stats: the innermost `duplicates_depth` ROIs (leaf first, padded with
+    /// `usize::MAX`) → (total calls on that path, of which duplicates). Lets the detail report
+    /// attribute the redundant calls to their call paths.
+    call_paths: HashMap<[usize; DUP_MAX_ROI_DEPTH], (u64, u64)>,
+}
 
 #[derive(Debug)]
 pub struct ProfileStats {
@@ -100,9 +157,29 @@ pub struct Stats {
     store_ops: bool,
     /// Flag to use the legacy FROPS tables when computing FROPS coverage statistics
     legacy_frops: bool,
+    /// Sort opcode/precompiled/FROPS report sections by operation count instead of by cost
+    sort_by_units: bool,
     costs: StatsCosts,
     // Global costs
     op_categories: OpsCount<OP_CATEGORIES>,
+    /// Execution count of each cheap opcode variant (see `CHEAP_VARIANTS`), e.g. add_hi0 / add_hif.
+    cheap_variant_counts: [u64; CHEAP_VARIANT_COUNT],
+    /// Show the per-opcode breakdown of cheap variants in the report (`--opcode-breakdown`).
+    opcode_breakdown: bool,
+    /// Analyze duplicate precompile calls: count how many calls repeat the same input content
+    /// (same input → same output) and the cost spent on those repeats, per precompile
+    /// (`--duplicates`).
+    duplicates: bool,
+    /// Restrict the duplicate analysis to these opcodes (`--duplicates-ops`). `None` = every
+    /// supported precompile (all with a content descriptor, i.e. all except DMA).
+    duplicates_ops: Option<HashSet<u8>>,
+    /// How many innermost call-stack ROIs to record per precompile call for the detail report
+    /// (`--duplicates-depth`), clamped to `1..=DUP_MAX_ROI_DEPTH`.
+    duplicates_depth: usize,
+    /// Show the per-precompile call-path detail (level 2) in the report (`--duplicates-detail`).
+    duplicates_detail: bool,
+    /// Per-precompile duplicate-analysis state, keyed by opcode.
+    dup_stats: HashMap<u8, DupStats>,
     /// Buffer to store operation data before writing to file
     op_data_buffer: Vec<u8>,
     rois_by_pc: BTreeMap<u32, u32>,
@@ -122,6 +199,13 @@ pub struct Stats {
     sdk_top_functions: bool,
     mem_stats: bool,
     mem_full_stats: bool,
+    /// Accumulate the per-offset byte read/write counters (MEM_OFFSETS). Enabled by
+    /// `--mem-full-stats` for the on-screen table, and by `--save-stats` / `--ref-stats` so the
+    /// snapshot always includes them.
+    collect_offsets: bool,
+    /// Log every costly unaligned memory access (double 4B/8B, i.e. `MEM_ACCESS_MONITOR`) with its
+    /// execution context. Off by default; enabled by `--log-costly-unaligned`.
+    log_costly_unaligned: bool,
     /// PC histogram, i.e. number of times each PC was executed
     pc_histogram: HashMap<u64, u64>,
     previous_pc: u64,
@@ -140,6 +224,11 @@ pub struct Stats {
     use_thousands_sep: bool,
     top_rois_filter: bool,
     disable_call_stack: bool,
+    /// Call-stack tracking mode. `false` (auto, default): on a stack mismatch, resync by unwinding
+    /// the collapsed self-recursive frames (handles GCC/C++ tail-recursion, e.g. std::sort's
+    /// __introsort_loop). `true` (strict): the original behaviour — report the mismatch and disable
+    /// the call stack.
+    callstack_strict: bool,
     use_colors: bool,
     compact_cost: bool,
     compact_names: Option<usize>,
@@ -193,6 +282,7 @@ impl Default for Stats {
             op_data_buffer: vec![],
             store_ops: false,
             legacy_frops: false,
+            sort_by_units: false,
             rois,
             rois_by_pc,
             current_roi: None,
@@ -222,6 +312,7 @@ impl Default for Stats {
             use_thousands_sep: true,
             top_rois_filter: false,
             disable_call_stack: false,
+            callstack_strict: false,
             use_colors: std::io::stdout().is_terminal(),
             compact_cost: true,
             compact_names: None,
@@ -231,6 +322,8 @@ impl Default for Stats {
             sdk_top_functions: false,
             mem_stats: false,
             mem_full_stats: false,
+            collect_offsets: false,
+            log_costly_unaligned: false,
             ram_monitor: RamMonitor::new(),
             profile_tags_map: HashMap::new(),
             profile_tags: Vec::new(),
@@ -252,6 +345,13 @@ impl Default for Stats {
             rom_init_count: 0,
             ram_init_count: 0,
             op_categories: OpsCount::<OP_CATEGORIES>::new(),
+            cheap_variant_counts: [0; CHEAP_VARIANT_COUNT],
+            opcode_breakdown: false,
+            duplicates: false,
+            duplicates_ops: None,
+            duplicates_depth: 4,
+            duplicates_detail: false,
+            dup_stats: HashMap::new(),
             byte_reads: [0; 8],
             byte_clean_writes: [0; 8],
             byte_dirty_writes: [0; 8],
@@ -286,7 +386,7 @@ impl Stats {
 
     /// Called every time some data is read from memory, if statistics are enabled
     pub fn on_memory_read(&mut self, address: u64, width: u64) {
-        if self.mem_full_stats && width == 1 {
+        if self.collect_offsets && width == 1 {
             self.byte_reads[(address as usize) & 0x7] += 1;
         }
         let status = self.costs.memory_read(address, width);
@@ -295,7 +395,7 @@ impl Stats {
 
     /// Called every time some data is writen to memory, if statistics are enabled
     pub fn on_memory_write(&mut self, address: u64, width: u64, value: u64) {
-        if self.mem_full_stats && width == 1 {
+        if self.collect_offsets && width == 1 {
             let offset = (address as usize) & 0x7;
             if value < 0x100 {
                 self.byte_clean_writes[offset] += 1;
@@ -309,19 +409,12 @@ impl Stats {
 
     /// Acts on the status code returned by `memory_read`/`memory_write`: an invalid access is an
     /// error, and a monitored access is logged with its execution context.
-    fn handle_mem_status(
-        &self,
-        status: u32,
-        is_write: bool,
-        address: u64,
-        width: u64,
-        _value: u64,
-    ) {
+    fn handle_mem_status(&self, status: u32, is_write: bool, address: u64, width: u64, value: u64) {
         if status & MEM_ACCESS_INVALID != 0 {
             self.report_invalid_mem_access(is_write, address, width);
         }
-        if status & MEM_ACCESS_MONITOR != 0 {
-            // self.monitor_mem_access(is_write, address, width, value);
+        if self.log_costly_unaligned && status & MEM_ACCESS_MONITOR != 0 {
+            self.monitor_mem_access(is_write, address, width, value);
         }
     }
 
@@ -575,42 +668,79 @@ impl Stats {
             // At this point ROI change, search the new ROI
             // let roi = &mut self.rois[*index as usize];
             // If return after call, need to add delta costs
-            if let Some(return_call) = return_call {
+            if let Some(mut return_call) = return_call {
                 if return_call.caller_roi_index != Some(roi_index) {
-                    self.call_stack_error(
-                        "ERROR: STACK MISMATCH DETECTED, disabled call stack feature",
-                    );
-                    #[cfg(feature = "debug_call_stack")]
-                    {
-                        println!("**** STACK MISMATCH DETECTED ****\n");
-                        println!(
-                            "PC:[0x{pc:08x}] RA:[0x{:08x}] P_PC:[0x{:08x}]",
-                            self.regs[1], self.previous_pc
+                    // The popped frame does not return into the ROI we landed in. With GCC/C++
+                    // tail-recursion (e.g. std::__introsort_loop from std::sort) a single machine
+                    // `ret` unwinds several nested self-recursive frames the heuristic tracked as
+                    // separate calls. In `auto` mode (default) we resync by discarding the extra
+                    // frames until the one that returns into the current ROI; `strict` keeps the
+                    // original behaviour (report the mismatch and disable the call stack).
+                    if self.callstack_strict {
+                        self.call_stack_error(
+                            "ERROR: STACK MISMATCH DETECTED, disabled call stack feature",
                         );
-                        if let Some(caller_roi_index) = return_call.caller_roi_index {
-                            let _roi = &self.rois[caller_roi_index];
-                            println!("caller_roi_index (expected): {caller_roi_index} [0x{:08x}, 0x{:08x}] {}", _roi.from_pc, _roi.to_pc, _roi.name);
-                        } else {
-                            println!("caller_roi_index (expected): None !!");
-                        }
-                        let _roi = &self.rois[roi_index];
-                        println!(
-                            "caller_roi_index (current): {roi_index} [0x{:08x}, 0x{:08x}] {}",
-                            _roi.from_pc, _roi.to_pc, _roi.name
-                        );
-                        if let Some(called_roi_index) = return_call.called_roi_index {
-                            let _roi = &self.rois[called_roi_index];
+                        #[cfg(feature = "debug_call_stack")]
+                        {
+                            println!("**** STACK MISMATCH DETECTED ****\n");
                             println!(
-                                "called_roi_index: {called_roi_index} [0x{:08x}, 0x{:08x}] {}",
+                                "PC:[0x{pc:08x}] RA:[0x{:08x}] P_PC:[0x{:08x}]",
+                                self.regs[1], self.previous_pc
+                            );
+                            if let Some(caller_roi_index) = return_call.caller_roi_index {
+                                let _roi = &self.rois[caller_roi_index];
+                                println!("caller_roi_index (expected): {caller_roi_index} [0x{:08x}, 0x{:08x}] {}", _roi.from_pc, _roi.to_pc, _roi.name);
+                            } else {
+                                println!("caller_roi_index (expected): None !!");
+                            }
+                            let _roi = &self.rois[roi_index];
+                            println!(
+                                "caller_roi_index (current): {roi_index} [0x{:08x}, 0x{:08x}] {}",
                                 _roi.from_pc, _roi.to_pc, _roi.name
                             );
-                        } else {
-                            println!("called_roi_index (expected): None !!");
+                            if let Some(called_roi_index) = return_call.called_roi_index {
+                                let _roi = &self.rois[called_roi_index];
+                                println!(
+                                    "called_roi_index: {called_roi_index} [0x{:08x}, 0x{:08x}] {}",
+                                    _roi.from_pc, _roi.to_pc, _roi.name
+                                );
+                            } else {
+                                println!("called_roi_index (expected): None !!");
+                            }
+                            println!("\n");
+                            Self::static_print_call_stack(&self.call_stack, "");
                         }
-                        println!("\n");
-                        Self::static_print_call_stack(&self.call_stack, "");
+                        return;
                     }
-                    return;
+
+                    // auto: a single machine `ret` unwound several collapsed self-recursive frames
+                    // (`return_call`, the top frame, was already popped above). Find the nearest
+                    // remaining frame that returns into the current ROI and drop the extra frames
+                    // above it, keeping the profiler call path balanced; the dropped frame becomes
+                    // the effective return. If no such frame exists the mismatch is not a collapsed
+                    // recursion, so fall back to the strict behaviour (report and disable) without
+                    // mutating the stack further.
+                    match self
+                        .call_stack
+                        .iter()
+                        .rposition(|f| f.caller_roi_index == Some(roi_index))
+                    {
+                        Some(idx) => {
+                            while self.call_stack.len() > idx {
+                                if let Some(profiler) = &mut self.profiler {
+                                    let ram_usage = self.ram_monitor.get_usage(inst_ctx);
+                                    profiler.pop_call_path(self.costs.total_cost(), ram_usage);
+                                }
+                                return_call = self.call_stack.pop().unwrap();
+                            }
+                        }
+                        None => {
+                            self.call_stack_error(
+                                "ERROR: STACK MISMATCH DETECTED, disabled call stack feature",
+                            );
+                            return;
+                        }
+                    }
                 }
 
                 let (last_caller_in_stack, ok_return_call) =
@@ -965,10 +1095,67 @@ impl Stats {
                         self.op_categories.inc(inst.op, i_mask * 4 + 3);
                     }
                 }
+                if inst.op_type == ZiskOperationType::BinaryE {
+                    match inst.op {
+                        ZiskOp::PACK | ZiskOp::PACK_H | ZiskOp::PACK_W => {
+                            if inst_ctx.a < 0x1_0000_0000 && inst_ctx.b < 0x1_0000_0000 {
+                                self.op_categories.inc(inst.op, OP_BIN_EXT_A_LT_64_CAT);
+                            }
+                        }
+                        _ => {
+                            if inst_ctx.a < 64 {
+                                self.op_categories.inc(inst.op, OP_BIN_EXT_A_LT_64_CAT);
+                            }
+                            if inst_ctx.b < 64 {
+                                self.op_categories.inc(inst.op, OP_BIN_EXT_B_LT_64_CAT);
+                            }
+                        }
+                    }
+                }
             }
-            self.costs.add_fixed_cost_op(inst.op);
+            // Cheap opcode variants (e.g. BinaryAddHi shapes of ADD) are counted and charged their
+            // reduced cost, so the per-opcode and aggregate costs reflect the saving. Only for
+            // non-FROPS fixed-cost ops, so the counts are a subset of the opcode's count.
+            if let Some(variant) = Self::cheap_variant(inst.op, inst_ctx.a, inst_ctx.b, inst_ctx.c)
+            {
+                self.cheap_variant_counts[variant] += 1;
+                self.costs.add_cost_op(inst.op, CHEAP_VARIANTS[variant].2);
+            } else {
+                self.costs.add_fixed_cost_op(inst.op);
+            }
         } else {
             self.costs.add_variable_cost_op(inst.op, self.current_variable_cost);
+        }
+
+        // Precompile duplicate analysis: fingerprint the input content of each precompile call
+        // (following its memory layout, dereferencing indirections, so the key is the content —
+        // not the `b` address) and mark the call a duplicate if that content was seen before.
+        if self.duplicates && self.dup_op_enabled(inst.op) {
+            if let Some(content) = Self::precompile_content(inst.op, inst_ctx) {
+                let depth = self.duplicates_depth;
+                let stats = self.dup_stats.entry(inst.op).or_default();
+                let entry = stats.states.entry(content.into_boxed_slice()).or_insert(0);
+                let is_duplicate = *entry > 0;
+                *entry += 1;
+
+                // Innermost `depth` call-stack ROIs (leaf first): current function plus its
+                // callers, so the detail report shows the call path a duplicate comes from. Only
+                // the first `depth` levels are filled, so paths aggregate at the configured depth.
+                let mut path = [usize::MAX; DUP_MAX_ROI_DEPTH];
+                path[0] = self.current_roi.unwrap_or(usize::MAX);
+                let n = self.call_stack.len();
+                for i in 0..depth.saturating_sub(1) {
+                    if i < n {
+                        path[i + 1] =
+                            self.call_stack[n - 1 - i].caller_roi_index.unwrap_or(usize::MAX);
+                    }
+                }
+                let path_stats = stats.call_paths.entry(path).or_insert((0, 0));
+                path_stats.0 += 1;
+                if is_duplicate {
+                    path_stats.1 += 1;
+                }
+            }
         }
 
         // Increase the PC histogram entry for this PC
@@ -1124,6 +1311,11 @@ impl Stats {
     pub fn set_legacy_frops(&mut self, legacy: bool) {
         self.legacy_frops = legacy;
     }
+    /// When true, the opcode/precompiled/FROPS report sections are sorted by operation count
+    /// (units) instead of by cost.
+    pub fn set_sort_by_units(&mut self, sort_by_units: bool) {
+        self.sort_by_units = sort_by_units;
+    }
     /// Store operation data in memory buffer
     fn store_op_data(&mut self, op: u8, a: u64, b: u64) {
         // Reserve space for: 1 byte (op) + 8 bytes (a) + 8 bytes (b) = 17 bytes
@@ -1232,9 +1424,13 @@ impl Stats {
         ops: &OpsCosts,
         base: bool,
         precompiled: bool,
+        breakdown: bool,
     ) {
-        let top_opcodes = ops.top_cost_opcodes(5, base, precompiled);
         let extended = base && !ops.is_frops();
+
+        // Collect the opcodes to report, then order them from highest to lowest by cost (default) or
+        // by operation count (units) when `sort_by_units` is set.
+        let mut entries: Vec<(u8, u64, u64)> = Vec::new(); // (opcode, count, cost)
         for opcode in ZiskOp::MIN_OPCODE..=ZiskOp::MAX_OPCODE {
             if let Some((count, cost)) = ops.get_opcode_count_and_cost(opcode) {
                 if count == 0 {
@@ -1247,29 +1443,53 @@ impl Stats {
                     if !precompiled && inst.is_precompiled() {
                         continue;
                     }
-                    let rank = if let Some(pos) = top_opcodes.iter().position(|&op| op == opcode) {
-                        format!(" #{}", pos + 1)
-                    } else {
-                        String::new()
-                    };
-                    if extended {
-                        let categories =
-                            self.op_categories.get_by_opcode(opcode).map(|c| &c[..]).unwrap_or(&[]);
-                        report.add_count_cost_perc2_extended(
-                            &format!("{title} {:}", inst.name()),
-                            count as u64,
-                            cost,
-                            &rank,
-                            categories,
-                        );
-                    } else {
-                        report.add_count_cost_perc2(
-                            &format!("{title} {:}", inst.name()),
-                            count as u64,
-                            cost,
-                            &rank,
-                        );
-                    }
+                    entries.push((opcode, count as u64, cost));
+                }
+            }
+        }
+        if self.sort_by_units {
+            entries.sort_by_key(|&(_, count, cost)| std::cmp::Reverse((count, cost)));
+        } else {
+            entries.sort_by_key(|&(_, count, cost)| std::cmp::Reverse((cost, count)));
+        }
+
+        for (opcode, count, cost) in entries {
+            let inst = match ZiskOp::try_from_code(opcode) {
+                Ok(inst) => inst,
+                Err(_) => continue,
+            };
+            if extended {
+                let categories =
+                    self.op_categories.get_by_opcode(opcode).map(|c| &c[..]).unwrap_or(&[]);
+                report.add_count_cost_perc2_extended(
+                    &format!("{title} {:}", inst.name()),
+                    count,
+                    cost,
+                    "",
+                    categories,
+                );
+            } else {
+                report.add_count_cost_perc2(&format!("{title} {:}", inst.name()), count, cost, "");
+            }
+
+            // Per-opcode breakdown of cheap variants (e.g. add → add_hif / add_hi0), as a tree.
+            if breakdown {
+                let mut variants: Vec<(usize, &str, u64)> = CHEAP_VARIANTS
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, (vop, _, _))| *vop == opcode && self.cheap_variant_counts[*i] > 0)
+                    .map(|(i, (_, label, vcost))| (i, *label, *vcost))
+                    .collect();
+                variants.sort_by_key(|&(i, _, _)| std::cmp::Reverse(self.cheap_variant_counts[i]));
+                for (n, (i, label, vcost)) in variants.iter().enumerate() {
+                    let glyph = if n + 1 == variants.len() { "└" } else { "├" };
+                    let vcount = self.cheap_variant_counts[*i];
+                    report.add_count_cost_perc2(
+                        &format!("{glyph} {label}"),
+                        vcount,
+                        vcount * vcost,
+                        "",
+                    );
                 }
             }
         }
@@ -1427,7 +1647,9 @@ impl Stats {
     }
 
     pub fn report_frops_hit(&self, report: &mut StatsReport, title: &str) {
-        let top_opcodes = self.costs.top_cost_frops_opcodes(5);
+        // Collect the FROPS opcodes, then order them from highest to lowest by cost (default) or by
+        // FROPS count (units) when `sort_by_units` is set.
+        let mut entries: Vec<(u8, u64, u64, u64)> = Vec::new(); // (opcode, frops_count, no_frops_count, frops_cost)
         for opcode in ZiskOp::MIN_OPCODE..=ZiskOp::MAX_OPCODE {
             if let Some((frops_count, frops_cost)) =
                 self.costs.get_opcode_frops_count_and_cost(opcode)
@@ -1442,21 +1664,508 @@ impl Stats {
                     }
                     let (no_frops_count, _) =
                         self.costs.get_opcode_count_and_cost(opcode).unwrap_or((0, 0));
-                    let rank = if let Some(pos) = top_opcodes.iter().position(|&op| op == opcode) {
-                        format!(" #{}", pos + 1)
-                    } else {
-                        String::new()
-                    };
-                    report.add_count_perc_cost_perc(
-                        &format!("{title} {:}", inst.name()),
-                        frops_count as u64,
-                        (frops_count as f64 * 100.0) / ((frops_count + no_frops_count) as f64),
-                        frops_cost,
-                        &rank,
-                    );
+                    entries.push((opcode, frops_count as u64, no_frops_count as u64, frops_cost));
                 }
             }
         }
+        if self.sort_by_units {
+            entries.sort_by_key(|&(_, frops_count, _, frops_cost)| {
+                std::cmp::Reverse((frops_count, frops_cost))
+            });
+        } else {
+            entries.sort_by_key(|&(_, frops_count, _, frops_cost)| {
+                std::cmp::Reverse((frops_cost, frops_count))
+            });
+        }
+
+        for (opcode, frops_count, no_frops_count, frops_cost) in entries {
+            let inst = match ZiskOp::try_from_code(opcode) {
+                Ok(inst) => inst,
+                Err(_) => continue,
+            };
+            report.add_count_perc_cost_perc(
+                &format!("{title} {:}", inst.name()),
+                frops_count,
+                (frops_count as f64 * 100.0) / ((frops_count + no_frops_count) as f64),
+                frops_cost,
+                "",
+            );
+        }
+    }
+
+    /// Reports the precompile duplicate analysis. Level 1 (always) is a per-precompile summary
+    /// table: total calls, unique inputs, duplicates and the cost spent on those duplicates (what
+    /// deduplication could save). Level 2 (`--duplicates-detail`) adds, per precompile with
+    /// duplicates, the call paths where the duplicates come from — most costly first.
+    fn report_duplicates(&self, report: &mut StatsReport, total_cost: u64) {
+        // One summary row per precompile that had calls, ordered by duplicate cost (most first).
+        struct DupRow {
+            op: u8,
+            total: u64,
+            unique: u64,
+            dup: u64,
+            max_dup: u64,
+            dup_cost: u64,
+        }
+        let mut rows: Vec<DupRow> = self
+            .dup_stats
+            .iter()
+            .filter(|(_, s)| !s.states.is_empty())
+            .map(|(&op, s)| {
+                let total: u64 = s.states.values().map(|&c| c as u64).sum();
+                let unique = s.states.len() as u64;
+                let dup = total.saturating_sub(unique);
+                let max_dup = s.states.values().copied().max().unwrap_or(0) as u64;
+                let (count, cost) = self.costs.get_opcode_count_and_cost(op).unwrap_or((0, 0));
+                let per_call = if count > 0 { cost / count as u64 } else { 0 };
+                DupRow { op, total, unique, dup, max_dup, dup_cost: dup * per_call }
+            })
+            .collect();
+        if rows.is_empty() {
+            return;
+        }
+        rows.sort_by_key(|r| std::cmp::Reverse((r.dup_cost, r.dup)));
+
+        // --- Level 1: summary table ---------------------------------------------------------
+        let pct = |num: u64, den: u64| -> String {
+            if den == 0 {
+                "0.00%".to_string()
+            } else {
+                format!("{:.2}%", 100.0 * num as f64 / den as f64)
+            }
+        };
+        let fmt_row = |c: &[String; 9]| -> String {
+            format!(
+                "{:<22} {:>12} {:>12} {:>8} {:>12} {:>8} {:>9} {:>15} {:>8}\n",
+                c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7], c[8]
+            )
+        };
+        let header = [
+            "PRECOMPILE".to_string(),
+            "TOTAL".to_string(),
+            "UNIQUE".to_string(),
+            "%".to_string(),
+            "DUP".to_string(),
+            "%".to_string(),
+            "MAX DUP".to_string(),
+            "DUP COST".to_string(),
+            "%".to_string(),
+        ];
+        let header_line = fmt_row(&header);
+        let width = header_line.trim_end().len();
+        report.add("\nPRECOMPILE DUPLICATES\n");
+        report.add(&header_line);
+        report.add(&format!("{}\n", "-".repeat(width)));
+
+        let (mut t_total, mut t_unique, mut t_dup, mut t_cost) = (0u64, 0u64, 0u64, 0u64);
+        for r in &rows {
+            let name =
+                ZiskOp::try_from_code(r.op).map(|z| z.name().to_string()).unwrap_or_default();
+            report.add(&fmt_row(&[
+                name,
+                report.format_number(r.total),
+                report.format_number(r.unique),
+                pct(r.unique, r.total),
+                report.format_number(r.dup),
+                pct(r.dup, r.total),
+                report.format_number(r.max_dup),
+                report.format_number(r.dup_cost),
+                pct(r.dup_cost, total_cost),
+            ]));
+            t_total += r.total;
+            t_unique += r.unique;
+            t_dup += r.dup;
+            t_cost += r.dup_cost;
+        }
+        if rows.len() > 1 {
+            report.add(&format!("{}\n", "-".repeat(width)));
+            report.add(&fmt_row(&[
+                "TOTAL".to_string(),
+                report.format_number(t_total),
+                report.format_number(t_unique),
+                pct(t_unique, t_total),
+                report.format_number(t_dup),
+                pct(t_dup, t_total),
+                "-".to_string(),
+                report.format_number(t_cost),
+                pct(t_cost, total_cost),
+            ]));
+        }
+
+        // --- Level 2: per-precompile call-path detail ---------------------------------------
+        if !self.duplicates_detail {
+            return;
+        }
+        let depth = self.duplicates_depth.clamp(1, DUP_MAX_ROI_DEPTH);
+        let top_n = self.top_rois.max(1);
+        let roi_name = |roi: usize| -> String {
+            if roi == usize::MAX {
+                "-".to_string()
+            } else {
+                self.format_roi_name(&self.rois[roi].name)
+            }
+        };
+        for r in &rows {
+            if r.dup == 0 {
+                continue;
+            }
+            let stats = match self.dup_stats.get(&r.op) {
+                Some(s) => s,
+                None => continue,
+            };
+            let mut paths: Vec<([usize; DUP_MAX_ROI_DEPTH], u64, u64)> = stats
+                .call_paths
+                .iter()
+                .map(|(&p, &(t, d))| (p, t, d))
+                .filter(|&(_, _, d)| d > 0)
+                .collect();
+            if paths.is_empty() {
+                continue;
+            }
+            paths.sort_by_key(|&(_, _, d)| std::cmp::Reverse(d));
+            let name =
+                ZiskOp::try_from_code(r.op).map(|z| z.name().to_string()).unwrap_or_default();
+            report.title(&format!("{} DUPLICATES BY CALL PATH", name.to_uppercase()));
+            for (path, path_total, dup) in paths.iter().take(top_n) {
+                report.add(&format!(
+                    "{} duplicates / {} total  ({:.2}%)\n",
+                    report.format_number(*dup),
+                    report.format_number(*path_total),
+                    100.0 * *dup as f64 / *path_total as f64,
+                ));
+                for (level, &roi) in path.iter().take(depth).enumerate() {
+                    let prefix = if level == 0 { "    " } else { "    <- " };
+                    report.add(&format!("{prefix}{}\n", roi_name(roi)));
+                }
+            }
+            if paths.len() > top_n {
+                report.add(&format!("... and {} more call paths\n", paths.len() - top_n));
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Aggregate stats snapshot (semicolon-separated) — save one run and compare against it later.
+    // No per-function/ROI detail is included, only aggregate counters.
+    // ------------------------------------------------------------------------------------------
+
+    /// Cost-distribution totals, mirroring [`Self::report`]:
+    /// `(steps, main, opcodes, precompiled, memory, base, total, frops)`.
+    fn cost_distribution(&self) -> (u64, u64, u64, u64, u64, u64, u64, u64) {
+        let ops_cost = self.costs.base_ops_cost();
+        let precompiled_cost = self.costs.precompiled_ops_cost();
+        let steps = self.costs.steps;
+        let mem_cost = self.costs.mops.get_cost()
+            + self.rom_init_count as u64 * ROM_READ_COST
+            + self.ram_init_count as u64 * MEM_WRITE_COST;
+        let main_cost = steps * MAIN_COST;
+        let base_cost = BASE_COST as u64;
+        let total_cost = base_cost + mem_cost + main_cost + ops_cost + precompiled_cost;
+        (
+            steps,
+            main_cost,
+            ops_cost,
+            precompiled_cost,
+            mem_cost,
+            base_cost,
+            total_cost,
+            self.costs.frops_cost(),
+        )
+    }
+
+    /// Collects opcode rows `(name, count, cost)` for base or precompiled ops, sorted desc by cost.
+    fn csv_opcode_rows(&self, precompiled: bool) -> Vec<(String, u64, u64)> {
+        let mut rows: Vec<(String, u64, u64)> = Vec::new();
+        for opcode in ZiskOp::MIN_OPCODE..=ZiskOp::MAX_OPCODE {
+            if let Some((count, cost)) = self.costs.get_opcode_count_and_cost(opcode) {
+                if count == 0 {
+                    continue;
+                }
+                if let Ok(inst) = ZiskOp::try_from_code(opcode) {
+                    if inst.is_precompiled() != precompiled {
+                        continue;
+                    }
+                    rows.push((inst.name().to_string(), count as u64, cost));
+                }
+            }
+        }
+        rows.sort_by_key(|(_, count, cost)| std::cmp::Reverse((*cost, *count)));
+        rows
+    }
+
+    /// Collects FROP rows `(name, count, hit_percentage, cost)`, sorted desc by cost.
+    fn csv_frop_rows(&self) -> Vec<(String, u64, f64, u64)> {
+        let mut rows: Vec<(String, u64, f64, u64)> = Vec::new();
+        for opcode in ZiskOp::MIN_OPCODE..=ZiskOp::MAX_OPCODE {
+            if let Some((frops_count, frops_cost)) =
+                self.costs.get_opcode_frops_count_and_cost(opcode)
+            {
+                if frops_count == 0 {
+                    continue;
+                }
+                if let Ok(inst) = ZiskOp::try_from_code(opcode) {
+                    if inst.is_precompiled() {
+                        continue;
+                    }
+                    let (no_frops_count, _) =
+                        self.costs.get_opcode_count_and_cost(opcode).unwrap_or((0, 0));
+                    let hit = frops_count as f64 * 100.0 / (frops_count + no_frops_count) as f64;
+                    rows.push((inst.name().to_string(), frops_count as u64, hit, frops_cost));
+                }
+            }
+        }
+        rows.sort_by_key(|(_, count, _, cost)| std::cmp::Reverse((*cost, *count)));
+        rows
+    }
+
+    /// Appends the memory sections (`MEM` cost by type, `DETAILED_MEM` and `DETAILED_MEM FULL`) to
+    /// `s`. Percentages are relative to the total memory count/cost; zero-cost rows are skipped
+    /// (mirroring the pretty report's hidden-no-cost behaviour).
+    fn append_mem_csv(&self, s: &mut String) {
+        let mops = &self.costs.mops;
+        let rom_init = self.rom_init_count as u64;
+        let ram_init = self.ram_init_count as u64;
+        let mem_count = mops.get_count() + rom_init + ram_init;
+        let mem_cost = mops.get_cost() + rom_init * ROM_READ_COST + ram_init * MEM_WRITE_COST;
+        let pct = |v: u64, total: u64| -> String {
+            if total == 0 {
+                "0.00%".to_string()
+            } else {
+                format!("{:.2}%", 100.0 * v as f64 / total as f64)
+            }
+        };
+        let row = |s: &mut String, tag: &str, label: &str, count: u64, cost: u64| {
+            if cost == 0 {
+                return; // hidden-no-cost
+            }
+            s.push_str(&format!(
+                "{tag};{label};{count};{};{cost};{}\n",
+                pct(count, mem_count),
+                pct(cost, mem_cost)
+            ));
+        };
+
+        // MEM cost by type.
+        s.push_str("MEM;COST BY TYPE;COUNT;%;COST;%\n");
+        row(
+            s,
+            "MEM",
+            "RAM STACK ALIGNED",
+            mops.get_ram_stack_aligned_count(),
+            mops.get_ram_stack_aligned_cost(),
+        );
+        row(
+            s,
+            "MEM",
+            "RAM NO STACK ALIGNED",
+            mops.get_ram_no_stack_aligned_count(),
+            mops.get_ram_no_stack_aligned_cost(),
+        );
+        row(s, "MEM", "RAM INIT", ram_init, ram_init * MEM_WRITE_COST);
+        row(s, "MEM", "ROM ALIGNED", mops.get_rom_aligned_count(), mops.get_rom_aligned_cost());
+        row(s, "MEM", "ROM INIT", rom_init, rom_init * ROM_READ_COST);
+        row(
+            s,
+            "MEM",
+            "INPUT ALIGNED",
+            mops.get_input_aligned_count(),
+            mops.get_input_aligned_cost(),
+        );
+        row(
+            s,
+            "MEM",
+            "RAM STACK UNALIGNED",
+            mops.get_ram_stack_unaligned_count(),
+            mops.get_ram_stack_unaligned_cost(),
+        );
+        row(
+            s,
+            "MEM",
+            "RAM NO STACK UNALIGNED",
+            mops.get_ram_no_stack_unaligned_count(),
+            mops.get_ram_no_stack_unaligned_cost(),
+        );
+        row(
+            s,
+            "MEM",
+            "ROM UNALIGNED",
+            mops.get_rom_unaligned_count(),
+            mops.get_rom_unaligned_cost(),
+        );
+        row(
+            s,
+            "MEM",
+            "INPUT UNALIGNED",
+            mops.get_input_unaligned_count(),
+            mops.get_input_unaligned_cost(),
+        );
+        s.push('\n');
+        row(
+            s,
+            "MEM",
+            "TOTAL ALIGNED",
+            mops.get_aligned_count() + ram_init + rom_init,
+            mops.get_aligned_cost() + ram_init * MEM_WRITE_COST + rom_init * ROM_READ_COST,
+        );
+        row(s, "MEM", "TOTAL UNALIGNED", mops.get_unaligned_count(), mops.get_unaligned_cost());
+        row(s, "MEM", "TOTAL RAM STACK", mops.get_ram_stack_count(), mops.get_ram_stack_cost());
+        row(
+            s,
+            "MEM",
+            "TOTAL RAM NO STACK",
+            mops.get_ram_no_stack_count(),
+            mops.get_ram_no_stack_cost(),
+        );
+        row(
+            s,
+            "MEM",
+            "TOTAL RAM",
+            mops.get_ram_count() + ram_init,
+            mops.get_ram_cost() + ram_init * MEM_WRITE_COST,
+        );
+        row(
+            s,
+            "MEM",
+            "TOTAL ROM",
+            mops.get_rom_count() + rom_init,
+            mops.get_rom_cost() + rom_init * ROM_READ_COST,
+        );
+        row(s, "MEM", "TOTAL INPUT", mops.get_input_count(), mops.get_input_cost());
+        s.push('\n');
+
+        // Detailed memory: per-subtype rows first, then aggregate totals (after the first empty
+        // separator returned by `get_detailed_items`) tagged as DETAILED_MEM FULL.
+        s.push_str("DETAILED_MEM;TYPE;COUNT;%;COST;%\n");
+        let mut full = false;
+        for (title, count, cost) in mops.get_detailed_items(rom_init, ram_init) {
+            if title.is_empty() {
+                full = true;
+                s.push('\n');
+                continue;
+            }
+            let tag = if full { "DETAILED_MEM FULL" } else { "DETAILED_MEM" };
+            s.push_str(&format!(
+                "{tag};{title};{count};{};{cost};{}\n",
+                pct(count, mem_count),
+                pct(cost, mem_cost)
+            ));
+        }
+        s.push('\n');
+    }
+
+    /// Builds the aggregate snapshot of this run, delimited by `sep`. The first column tags the
+    /// section (`STEPS`, `COST`, `MEM`, `DETAILED_MEM`, `MEM_OFFSETS`, `OP_BASE`, `PRECOMPILES`,
+    /// `FROP`); sections are separated by a blank line. Numbers are raw (no thousands separators)
+    /// for easy parsing.
+    pub fn stats_csv(&self, sep: char) -> String {
+        let (
+            steps,
+            main_cost,
+            ops_cost,
+            precompiled_cost,
+            mem_cost,
+            base_cost,
+            total_cost,
+            frops_cost,
+        ) = self.cost_distribution();
+        let variable = total_cost - base_cost;
+        let pct = |v: u64, total: u64| -> String {
+            if total == 0 {
+                "0.00%".to_string()
+            } else {
+                format!("{:.2}%", 100.0 * v as f64 / total as f64)
+            }
+        };
+
+        let mut s = String::new();
+        s += &format!("STEPS;{steps}\n\n");
+
+        s += "COST;COST DISTRIBUTION;COST;%\n";
+        s += &format!("COST;MAIN;{main_cost};{}\n", pct(main_cost, total_cost));
+        s += &format!("COST;OPCODES;{ops_cost};{}\n", pct(ops_cost, total_cost));
+        s +=
+            &format!("COST;PRECOMPILES;{precompiled_cost};{}\n", pct(precompiled_cost, total_cost));
+        s += &format!("COST;MEMORY;{mem_cost};{}\n", pct(mem_cost, total_cost));
+        s += &format!("COST;VARIABLE;{variable};{}\n", pct(variable, total_cost));
+        s += &format!("COST;BASE;{base_cost};{}\n", pct(base_cost, total_cost));
+        s += &format!("COST;TOTAL;{total_cost};{}\n", pct(total_cost, total_cost));
+        s += &format!("COST;FROPS;{frops_cost};{}\n\n", pct(frops_cost, variable));
+
+        if self.ram_monitor.ram_size > 0 {
+            s += &format!(
+                "RAM USAGE;{};{}\n",
+                self.ram_monitor.ram_used,
+                pct(self.ram_monitor.ram_used, self.ram_monitor.ram_size)
+            );
+        }
+        let rom_used_rows =
+            self.inst_count + self.rom_init_count.div_ceil(4) + self.ram_init_count.div_ceil(4);
+        let rom_size = RomRomTrace::<Goldilocks>::NUM_ROWS as u64;
+        s += &format!("ROM USAGE;{};{}\n\n", rom_used_rows, pct(rom_used_rows as u64, rom_size));
+
+        self.append_mem_csv(&mut s);
+
+        s += "MEM_OFFSETS;offset;0;1;2;3;4;5;6;7;total\n";
+        for (label, vals) in [
+            ("reads", &self.byte_reads),
+            ("clean writes", &self.byte_clean_writes),
+            ("dirty writes", &self.byte_dirty_writes),
+        ] {
+            let total: u64 = vals.iter().sum();
+            let joined = vals.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(";");
+            s += &format!("MEM_OFFSETS;{label};{joined};{total}\n");
+        }
+        s.push('\n');
+
+        s += "OP_BASE;OPCODE;COUNT;%;COST;%\n";
+        for (name, count, cost) in self.csv_opcode_rows(false) {
+            s += &format!(
+                "OP_BASE;{name};{count};{};{cost};{}\n",
+                pct(count, steps),
+                pct(cost, total_cost)
+            );
+        }
+        s.push('\n');
+
+        for (name, count, cost) in self.csv_opcode_rows(true) {
+            s += &format!(
+                "PRECOMPILES;{name};{count};{};{cost};{}\n",
+                pct(count, steps),
+                pct(cost, total_cost)
+            );
+        }
+        s.push('\n');
+
+        for (name, count, hit, cost) in self.csv_frop_rows() {
+            s += &format!("FROP;{name};{count};{hit:.2}%;{cost};{}\n", pct(cost, variable));
+        }
+
+        // Built internally with ';'; swap to the requested separator (field content never
+        // contains ';', so this is safe).
+        if sep != ';' {
+            s = s.replace(';', &sep.to_string());
+        }
+        s
+    }
+
+    /// Compares the current run against a reference snapshot saved with `--save-stats`. With
+    /// `csv = false` it returns the human-readable, colour-coded report (red = higher cost/calls,
+    /// green = lower; sign always shown); with `csv = true` it returns the previous plain
+    /// semicolon-separated view (used by SDK mode / `--legacy-display` / `--diff-format csv`).
+    pub fn compare_stats(
+        &self,
+        ref_path: &str,
+        csv: bool,
+        color: bool,
+        sep: char,
+    ) -> std::io::Result<String> {
+        let ref_text = std::fs::read_to_string(ref_path)?;
+        let cur_text = self.stats_csv(sep);
+        Ok(if csv {
+            diff_snapshots_csv(ref_path, &ref_text, "current run", &cur_text, sep)
+        } else {
+            diff_snapshots(ref_path, &ref_text, "current run", &cur_text, color)
+        })
     }
 
     fn sdk_report(&self) -> String {
@@ -1713,14 +2422,25 @@ impl Stats {
         }
 
         if show_opcodes {
-            report.title_count_cost_perc2("COST BY BASE OPCODE", "COUNT", "COST", " RANK");
-            self.report_opcodes(&mut report, "OP", self.costs.ops_costs(), true, false);
+            report.title_count_cost_perc2("COST BY BASE OPCODE", "COUNT", "COST", "");
+            self.report_opcodes(
+                &mut report,
+                "OP",
+                self.costs.ops_costs(),
+                true,
+                false,
+                self.opcode_breakdown,
+            );
 
-            report.title_count_cost_perc2("COST BY PRECOMPILED OPCODE", "COUNT", "COST", " RANK");
-            self.report_opcodes(&mut report, "OP", self.costs.ops_costs(), false, true);
+            report.title_count_cost_perc2("COST BY PRECOMPILED OPCODE", "COUNT", "COST", "");
+            self.report_opcodes(&mut report, "OP", self.costs.ops_costs(), false, true, false);
 
-            report.title_count_perc_cost_perc("FROPS BY OPCODE", "COUNT", "HIT", "COST", " RANK");
+            report.title_count_perc_cost_perc("FROPS BY OPCODE", "COUNT", "HIT", "COST", "");
             self.report_frops_hit(&mut report, "FROP");
+        }
+
+        if self.duplicates {
+            self.report_duplicates(&mut report, total_cost);
         }
 
         if self.coverage {
@@ -1804,8 +2524,8 @@ impl Stats {
                         roi_report.pop_label_width();
                     }
 
-                    roi_report.title_count_cost_perc("COST BY OPCODE", "COUNT", "COST", " RANK");
-                    self.report_opcodes(&mut roi_report, "OP", roi.ops_costs(), true, true);
+                    roi_report.title_count_cost_perc("COST BY OPCODE", "COUNT", "COST", "");
+                    self.report_opcodes(&mut roi_report, "OP", roi.ops_costs(), true, true, false);
 
                     roi_report.title_top_count_perc("TOP STEP CALLERS (calls, steps)");
                     let mut callers: Vec<_> = roi.get_callers().collect();
@@ -2066,27 +2786,28 @@ impl Stats {
         let mut current_internal_from = None;
         let mut current_internal_to = None;
         while let Some(inst) = rom.get_internal_instruction(internal_pc) {
-            let pc = inst.external_ref_addr.unwrap() as u32;
-            if pc >= current_roi_from && pc <= current_roi_to {
-                current_internal_to = Some(internal_pc as u32);
-            } else {
-                if let Some(internal_from) = current_internal_from {
-                    if let Some(roi_index) = current_roi_index {
-                        if !(self.update_roi_internal_pc_range(
-                            roi_index,
-                            internal_from,
-                            current_internal_to.unwrap_or(internal_from),
-                        )) {
-                            return;
+            if let Some(pc) = inst.external_ref_addr {
+                if pc as u32 >= current_roi_from && pc as u32 <= current_roi_to {
+                    current_internal_to = Some(internal_pc as u32);
+                } else {
+                    if let Some(internal_from) = current_internal_from {
+                        if let Some(roi_index) = current_roi_index {
+                            if !(self.update_roi_internal_pc_range(
+                                roi_index,
+                                internal_from,
+                                current_internal_to.unwrap_or(internal_from),
+                            )) {
+                                return;
+                            }
                         }
                     }
-                }
-                if let Some((roi_index, roi)) = self.get_roi_from_pc(pc) {
-                    current_roi_index = Some(roi_index);
-                    current_roi_from = roi.from_pc;
-                    current_roi_to = roi.to_pc;
-                    current_internal_from = Some(internal_pc as u32);
-                    current_internal_to = None;
+                    if let Some((roi_index, roi)) = self.get_roi_from_pc(pc as u32) {
+                        current_roi_index = Some(roi_index);
+                        current_roi_from = roi.from_pc;
+                        current_roi_to = roi.to_pc;
+                        current_internal_from = Some(internal_pc as u32);
+                        current_internal_to = None;
+                    }
                 }
             }
 
@@ -2197,6 +2918,166 @@ impl Stats {
     }
     pub fn set_mem_full_stats(&mut self, value: bool) {
         self.mem_full_stats = value;
+    }
+    /// Enables accumulation of the per-offset byte read/write counters (MEM_OFFSETS).
+    pub fn set_collect_offsets(&mut self, value: bool) {
+        self.collect_offsets = value;
+    }
+    /// Enables logging of costly unaligned memory accesses (double 4B/8B) with execution context.
+    pub fn set_log_costly_unaligned(&mut self, value: bool) {
+        self.log_costly_unaligned = value;
+    }
+    /// Selects strict call-stack tracking (original behaviour): a stack mismatch disables the call
+    /// stack instead of resyncing by unwinding collapsed recursive frames.
+    pub fn set_callstack_strict(&mut self, value: bool) {
+        self.callstack_strict = value;
+    }
+    /// Shows the per-opcode breakdown of cheap variants (e.g. add → add_hi0 / add_hif).
+    pub fn set_opcode_breakdown(&mut self, value: bool) {
+        self.opcode_breakdown = value;
+    }
+    /// Enables the precompile duplicate analysis.
+    pub fn set_duplicates(&mut self, value: bool) {
+        self.duplicates = value;
+    }
+    /// Restricts the duplicate analysis to the given opcodes (`None` = every supported precompile).
+    pub fn set_duplicates_ops(&mut self, value: Option<HashSet<u8>>) {
+        self.duplicates_ops = value;
+    }
+    /// Sets the recorded call-path depth for the duplicate detail report (clamped to a sane range).
+    pub fn set_duplicates_depth(&mut self, value: usize) {
+        self.duplicates_depth = value.clamp(1, DUP_MAX_ROI_DEPTH);
+    }
+    /// Enables the per-precompile call-path detail (level 2) of the duplicate report.
+    pub fn set_duplicates_detail(&mut self, value: bool) {
+        self.duplicates_detail = value;
+    }
+
+    /// Classifies an executed operation into a cheap variant (index into `CHEAP_VARIANTS`), or
+    /// `None` if it is a regular operation. Currently the BinaryAddHi shapes of ADD:
+    /// hi32(a)=hi32(c)=0 with hi32(b)=0 (add_hi0) or hi32(b)=0xFFFF_FFFF (add_hif).
+    #[inline(always)]
+    fn cheap_variant(op: u8, a: u64, b: u64, c: u64) -> Option<usize> {
+        if op == ADD_CODE && a & HI32_MASK == 0 && c & HI32_MASK == 0 {
+            if b & HI32_MASK == 0 {
+                return Some(CHEAP_ADD_HI0);
+            } else if b & HI32_MASK == HI32_MASK {
+                return Some(CHEAP_ADD_HIF);
+            }
+        }
+        None
+    }
+
+    /// Content descriptor for a precompile opcode, or `None` if the opcode is not a precompile
+    /// eligible for duplicate analysis (this excludes DMA, EVM `jump_dest`, `halt`, fcalls, etc.).
+    /// See the layout notes in `DupSeg`. The segments read the operand *content* (dereferencing
+    /// indirections) so two calls with the same inputs at different buffers are seen as duplicates.
+    fn dup_descriptor(op: u8) -> Option<&'static [DupSeg]> {
+        use DupSeg::{Direct, Indirect, Literal};
+        let z = ZiskOp::try_from_code(op).ok()?;
+        Some(match z {
+            // In-place operands read directly from `ctx.b`.
+            ZiskOp::Keccak => &[Direct { words: 25 }][..],
+            ZiskOp::Poseidon1 | ZiskOp::Poseidon2 => &[Direct { words: 16 }][..],
+            ZiskOp::Secp256k1Dbl | ZiskOp::Secp256r1Dbl | ZiskOp::Bn254CurveDbl => {
+                &[Direct { words: 8 }][..]
+            }
+            ZiskOp::Bls12_381CurveDbl => &[Direct { words: 12 }][..],
+            // Indirected operands: `ctx.b` holds pointers to the operand buffers.
+            ZiskOp::Sha256 => {
+                &[Indirect { param: 0, words: 4 }, Indirect { param: 1, words: 8 }][..]
+            }
+            ZiskOp::Blake2 => &[
+                Literal { param: 0 },
+                Indirect { param: 1, words: 16 },
+                Indirect { param: 2, words: 16 },
+            ][..],
+            ZiskOp::Add256 => &[
+                Indirect { param: 0, words: 4 },
+                Indirect { param: 1, words: 4 },
+                Literal { param: 2 },
+            ][..],
+            ZiskOp::Arith256 => &[
+                Indirect { param: 0, words: 4 },
+                Indirect { param: 1, words: 4 },
+                Indirect { param: 2, words: 4 },
+            ][..],
+            ZiskOp::Arith256Mod => &[
+                Indirect { param: 0, words: 4 },
+                Indirect { param: 1, words: 4 },
+                Indirect { param: 2, words: 4 },
+                Indirect { param: 3, words: 4 },
+            ][..],
+            ZiskOp::Secp256k1Add
+            | ZiskOp::Secp256r1Add
+            | ZiskOp::Bn254CurveAdd
+            | ZiskOp::Bn254ComplexAdd
+            | ZiskOp::Bn254ComplexSub
+            | ZiskOp::Bn254ComplexMul => {
+                &[Indirect { param: 0, words: 8 }, Indirect { param: 1, words: 8 }][..]
+            }
+            ZiskOp::Arith384Mod => &[
+                Indirect { param: 0, words: 6 },
+                Indirect { param: 1, words: 6 },
+                Indirect { param: 2, words: 6 },
+                Indirect { param: 3, words: 6 },
+            ][..],
+            ZiskOp::Bls12_381CurveAdd
+            | ZiskOp::Bls12_381ComplexAdd
+            | ZiskOp::Bls12_381ComplexSub
+            | ZiskOp::Bls12_381ComplexMul => {
+                &[Indirect { param: 0, words: 12 }, Indirect { param: 1, words: 12 }][..]
+            }
+            _ => return None,
+        })
+    }
+
+    /// Reads the input-content fingerprint of a precompile call from memory, following the layout
+    /// in `dup_descriptor`. Returns `None` for opcodes that are not duplicate-analyzed precompiles.
+    /// Read post-execution (as `on_op` runs after the op): for in-place ops the words are the
+    /// output state, but since the precompile is deterministic, identical inputs still map to an
+    /// identical fingerprint — which is all duplicate detection needs.
+    fn precompile_content(op: u8, ctx: &InstContext) -> Option<Vec<u64>> {
+        let segs = Self::dup_descriptor(op)?;
+        let base = ctx.b;
+        let mut content = Vec::new();
+        let mut direct_off = 0u64;
+        for seg in segs {
+            match *seg {
+                DupSeg::Direct { words } => {
+                    for i in 0..words as u64 {
+                        content.push(ctx.mem.read(base + 8 * (direct_off + i), 8));
+                    }
+                    direct_off += words as u64;
+                }
+                DupSeg::Indirect { param, words } => {
+                    let ptr = ctx.mem.read(base + 8 * param as u64, 8);
+                    for i in 0..words as u64 {
+                        content.push(ctx.mem.read(ptr + 8 * i, 8));
+                    }
+                }
+                DupSeg::Literal { param } => {
+                    content.push(ctx.mem.read(base + 8 * param as u64, 8));
+                }
+            }
+        }
+        Some(content)
+    }
+
+    /// Whether the duplicate analysis should process this opcode: it must be a supported precompile
+    /// and, if a restriction list was given (`--duplicates-ops`), be in it.
+    fn dup_op_enabled(&self, op: u8) -> bool {
+        match &self.duplicates_ops {
+            Some(set) => set.contains(&op),
+            None => true,
+        }
+    }
+
+    /// The opcodes eligible for duplicate analysis (every precompile with a content descriptor).
+    pub fn dup_supported_opcodes() -> Vec<u8> {
+        (ZiskOp::MIN_OPCODE..=ZiskOp::MAX_OPCODE)
+            .filter(|&op| Self::dup_descriptor(op).is_some())
+            .collect()
     }
     pub fn set_sdk_width(&mut self, value: usize) {
         self.sdk_width = value;
@@ -2315,5 +3196,486 @@ impl OpStats for Stats {
     }
     fn set_variable_cost(&mut self, cost: u64) {
         self.current_variable_cost = cost;
+    }
+}
+
+// ==============================================================================================
+// Stats snapshot comparison — human-readable, colour-coded diff of two runs.
+// Red  = value went up (more cost / more calls → regression).
+// Green = value went down (improvement).  Dim = unchanged.  Magenta = hit% (inverted axis).
+// The sign is always printed, so the diff reads correctly with colour disabled.
+// ==============================================================================================
+
+const C_RESET: &str = "\x1b[0m";
+const C_RED: &str = "\x1b[31m";
+const C_GREEN: &str = "\x1b[32m";
+const C_DIM: &str = "\x1b[2m";
+const C_MAGENTA: &str = "\x1b[35m";
+const C_HEAD: &str = "\x1b[36m";
+
+#[derive(Default)]
+struct OpRow {
+    name: String,
+    count: u64,
+    count_pct: String,
+    cost: u64,
+    cost_pct: String,
+}
+
+#[derive(Default)]
+struct FrRow {
+    name: String,
+    count: u64,
+    hit: f64,
+    hit_pct: String,
+    cost: u64,
+    cost_pct: String,
+}
+
+#[derive(Default)]
+struct Snap {
+    steps: u64,
+    cost_rows: Vec<(String, u64, String)>, // (metric, cost, pct string)
+    cost_map: HashMap<String, u64>,
+    op_rows: Vec<OpRow>,
+    op_map: HashMap<String, (u64, u64)>,
+    pc_rows: Vec<OpRow>,
+    pc_map: HashMap<String, (u64, u64)>,
+    fr_rows: Vec<FrRow>,
+    fr_map: HashMap<String, (u64, u64, f64)>, // (count, cost, hit)
+}
+
+/// Detects the field separator of a snapshot: the character right after the leading `STEPS` tag on
+/// the first `STEPS` line. Defaults to `,` (also handles files saved with `;` or any single char).
+fn detect_sep(text: &str) -> char {
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("STEPS") {
+            if let Some(c) = rest.chars().next() {
+                return c;
+            }
+        }
+    }
+    ','
+}
+
+/// Parses a `--save-stats` snapshot, preserving row order and the original share-of-total strings.
+/// The field separator is auto-detected, so snapshots saved with any separator parse correctly.
+fn parse_snapshot(text: &str) -> Snap {
+    let sep = detect_sep(text);
+    let mut snap = Snap::default();
+    for line in text.lines() {
+        let f: Vec<&str> = line.split(sep).collect();
+        match f.first().copied() {
+            Some("STEPS") if f.len() >= 2 => {
+                snap.steps = f[1].parse().unwrap_or(0);
+            }
+            Some("COST") if f.len() >= 4 && f[1] != "COST DISTRIBUTION" => {
+                if let Ok(c) = f[2].parse::<u64>() {
+                    snap.cost_rows.push((f[1].to_string(), c, f[3].to_string()));
+                    snap.cost_map.insert(f[1].to_string(), c);
+                }
+            }
+            Some("OP_BASE") if f.len() >= 6 && f[1] != "OPCODE" => {
+                if let (Ok(cnt), Ok(cst)) = (f[2].parse::<u64>(), f[4].parse::<u64>()) {
+                    snap.op_rows.push(OpRow {
+                        name: f[1].into(),
+                        count: cnt,
+                        count_pct: f[3].into(),
+                        cost: cst,
+                        cost_pct: f[5].into(),
+                    });
+                    snap.op_map.insert(f[1].into(), (cnt, cst));
+                }
+            }
+            Some("PRECOMPILES") if f.len() >= 6 && f[1] != "OPCODE" => {
+                if let (Ok(cnt), Ok(cst)) = (f[2].parse::<u64>(), f[4].parse::<u64>()) {
+                    snap.pc_rows.push(OpRow {
+                        name: f[1].into(),
+                        count: cnt,
+                        count_pct: f[3].into(),
+                        cost: cst,
+                        cost_pct: f[5].into(),
+                    });
+                    snap.pc_map.insert(f[1].into(), (cnt, cst));
+                }
+            }
+            Some("FROP") if f.len() >= 6 && f[1] != "OPCODE" => {
+                if let (Ok(cnt), Ok(cst)) = (f[2].parse::<u64>(), f[4].parse::<u64>()) {
+                    let hit = f[3].trim_end_matches('%').parse::<f64>().unwrap_or(0.0);
+                    snap.fr_rows.push(FrRow {
+                        name: f[1].into(),
+                        count: cnt,
+                        hit,
+                        hit_pct: f[3].into(),
+                        cost: cst,
+                        cost_pct: f[5].into(),
+                    });
+                    snap.fr_map.insert(f[1].into(), (cnt, cst, hit));
+                }
+            }
+            _ => {}
+        }
+    }
+    snap
+}
+
+/// Groups a non-negative integer with thousands separators: `1234567` -> `"1,234,567"`.
+fn group_u64(n: u64) -> String {
+    let s = n.to_string();
+    let len = s.len();
+    let mut out = String::with_capacity(len + len / 3);
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (len - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Signed, grouped delta: `1203` -> `"+1,203"`, `-48720` -> `"-48,720"`, `0` -> `"+0"`.
+fn fmt_delta(d: i64) -> String {
+    format!("{}{}", if d < 0 { "-" } else { "+" }, group_u64(d.unsigned_abs()))
+}
+
+/// Percentage change of `cur` vs `ref`, signed. `n/a` when the reference is zero but current isn't.
+fn pct_change(r: u64, c: u64) -> String {
+    if r == 0 {
+        if c == 0 {
+            "0.00%".to_string()
+        } else {
+            "n/a".to_string()
+        }
+    } else {
+        format!("{:+.2}%", 100.0 * (c as i64 - r as i64) as f64 / r as f64)
+    }
+}
+
+/// ANSI colour for a delta: red up (worse), green down (better), dim when flat.
+fn dir(d: i64) -> &'static str {
+    if d > 0 {
+        C_RED
+    } else if d < 0 {
+        C_GREEN
+    } else {
+        C_DIM
+    }
+}
+
+fn wrap(on: bool, code: &str, text: &str) -> String {
+    if on {
+        format!("{code}{text}{C_RESET}")
+    } else {
+        text.to_string()
+    }
+}
+
+/// The `Δ (Δ%)` cell for a cost/value delta, tagging brand-new and removed entries.
+fn delta_cell(r: u64, c: u64) -> String {
+    let d = c as i64 - r as i64;
+    if r == 0 && c > 0 {
+        format!("{} (new)", fmt_delta(d))
+    } else if c == 0 && r > 0 {
+        format!("{} (gone)", fmt_delta(d))
+    } else {
+        format!("{} ({})", fmt_delta(d), pct_change(r, c))
+    }
+}
+
+/// Joins pre-padded cells `(text, colour_code)` with single spaces, applying colour when enabled.
+/// `colour_code` empty means no colour. Widths live in the padded `text`, so alignment is preserved.
+fn row_line(color: bool, cells: &[(String, &str)]) -> String {
+    cells
+        .iter()
+        .map(|(text, code)| if code.is_empty() { text.clone() } else { wrap(color, code, text) })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Renders an opcode-style section (base opcodes or precompiles): current value + share%, then a
+/// coloured signed delta for count and for cost. Reference-only entries are appended as `(gone)`.
+fn render_op_section(
+    out: &mut String,
+    color: bool,
+    title: &str,
+    prefix: &str,
+    cur_rows: &[OpRow],
+    ref_map: &HashMap<String, (u64, u64)>,
+) {
+    let header: [(String, &str); 7] = [
+        (format!("{:<24}", ""), C_DIM),
+        (format!("{:>12}", "COUNT"), C_DIM),
+        (format!("{:>7}", "%"), C_DIM),
+        (format!("{:>12}", "Δ"), C_DIM),
+        (format!("{:>15}", "COST"), C_DIM),
+        (format!("{:>7}", "%"), C_DIM),
+        (format!("{:>24}", "Δ (Δ%)"), C_DIM),
+    ];
+    out.push('\n');
+    out.push_str(&wrap(color, C_HEAD, title));
+    out.push('\n');
+    let plain_len = header.iter().map(|(t, _)| t.len()).sum::<usize>() + header.len() - 1;
+    out.push_str(&row_line(color, &header));
+    out.push('\n');
+    out.push_str(&wrap(color, C_DIM, &"-".repeat(plain_len)));
+    out.push('\n');
+
+    let mut seen: HashSet<String> = HashSet::new();
+    for row in cur_rows {
+        seen.insert(row.name.clone());
+        let (rcount, rcost) = ref_map.get(&row.name).copied().unwrap_or((0, 0));
+        let dcount = row.count as i64 - rcount as i64;
+        let dcost = row.cost as i64 - rcost as i64;
+        let cells: [(String, &str); 7] = [
+            (format!("{:<24}", format!("{prefix}{}", row.name)), ""),
+            (format!("{:>12}", group_u64(row.count)), ""),
+            (format!("{:>7}", row.count_pct), C_DIM),
+            (format!("{:>12}", fmt_delta(dcount)), dir(dcount)),
+            (format!("{:>15}", group_u64(row.cost)), ""),
+            (format!("{:>7}", row.cost_pct), C_DIM),
+            (format!("{:>24}", delta_cell(rcost, row.cost)), dir(dcost)),
+        ];
+        out.push_str(&row_line(color, &cells));
+        out.push('\n');
+    }
+    let mut removed: Vec<(&String, &(u64, u64))> =
+        ref_map.iter().filter(|(k, _)| !seen.contains(*k)).collect();
+    removed.sort_by_key(|(_, (_, cost))| std::cmp::Reverse(*cost));
+    for (rname, (rcount, rcost)) in removed {
+        let cells: [(String, &str); 7] = [
+            (format!("{:<24}", format!("{prefix}{rname}")), ""),
+            (format!("{:>12}", "0"), ""),
+            (format!("{:>7}", "-"), C_DIM),
+            (format!("{:>12}", fmt_delta(-(*rcount as i64))), dir(-(*rcount as i64))),
+            (format!("{:>15}", "0"), ""),
+            (format!("{:>7}", "-"), C_DIM),
+            (format!("{:>24}", delta_cell(*rcost, 0)), dir(-(*rcost as i64))),
+        ];
+        out.push_str(&row_line(color, &cells));
+        out.push('\n');
+    }
+}
+
+/// Renders a human-readable, colour-coded comparison of two snapshots (each in the `--save-stats`
+/// format). `ref_*` is the baseline, `cur_*` the run being evaluated; deltas are `cur - ref`.
+/// Pass `color = false` for plain output (piped / `--color=never`).
+pub fn diff_snapshots(
+    ref_label: &str,
+    ref_text: &str,
+    cur_label: &str,
+    cur_text: &str,
+    color: bool,
+) -> String {
+    let refs = parse_snapshot(ref_text);
+    let cur = parse_snapshot(cur_text);
+    let mut out = String::new();
+
+    out.push('\n');
+    out.push_str(&wrap(color, C_HEAD, &format!("COMPARISON   {ref_label}  →  {cur_label}")));
+    out.push('\n');
+    out.push_str(&wrap(
+        color,
+        C_DIM,
+        "red = higher / worse   green = lower / better   % = share of total   sign always shown",
+    ));
+    out.push('\n');
+
+    // STEPS
+    let dsteps = cur.steps as i64 - refs.steps as i64;
+    out.push('\n');
+    out.push_str(&row_line(
+        color,
+        &[
+            (format!("{:<24}", "STEPS"), ""),
+            (format!("{:>12}", group_u64(cur.steps)), ""),
+            (format!("{:>7}", ""), ""),
+            (format!("{:>24}", delta_cell(refs.steps, cur.steps)), dir(dsteps)),
+        ],
+    ));
+    out.push('\n');
+
+    // COST DISTRIBUTION
+    let cd_header: [(String, &str); 4] = [
+        (format!("{:<24}", "COST DISTRIBUTION"), C_DIM),
+        (format!("{:>15}", "COST"), C_DIM),
+        (format!("{:>8}", "%"), C_DIM),
+        (format!("{:>26}", "Δ (Δ%)"), C_DIM),
+    ];
+    out.push('\n');
+    let cd_len = cd_header.iter().map(|(t, _)| t.len()).sum::<usize>() + cd_header.len() - 1;
+    out.push_str(&row_line(color, &cd_header));
+    out.push('\n');
+    out.push_str(&wrap(color, C_DIM, &"-".repeat(cd_len)));
+    out.push('\n');
+    for (metric, cost, pct) in &cur.cost_rows {
+        let r = refs.cost_map.get(metric).copied().unwrap_or(0);
+        let d = *cost as i64 - r as i64;
+        out.push_str(&row_line(
+            color,
+            &[
+                (format!("{metric:<24}"), ""),
+                (format!("{:>15}", group_u64(*cost)), ""),
+                (format!("{pct:>8}"), C_DIM),
+                (format!("{:>26}", delta_cell(r, *cost)), dir(d)),
+            ],
+        ));
+        out.push('\n');
+    }
+
+    // Base opcodes and precompiles.
+    render_op_section(&mut out, color, "COST BY BASE OPCODE", "OP ", &cur.op_rows, &refs.op_map);
+    render_op_section(
+        &mut out,
+        color,
+        "COST BY PRECOMPILED OPCODE",
+        "OP ",
+        &cur.pc_rows,
+        &refs.pc_map,
+    );
+
+    // FROPS — hit% is an inverted axis (up is good), shown in magenta with an explicit sign.
+    let fr_header: [(String, &str); 7] = [
+        (format!("{:<24}", "FROPS BY OPCODE"), C_DIM),
+        (format!("{:>12}", "COUNT"), C_DIM),
+        (format!("{:>8}", "HIT"), C_DIM),
+        (format!("{:>9}", "ΔHIT"), C_DIM),
+        (format!("{:>15}", "COST"), C_DIM),
+        (format!("{:>7}", "%"), C_DIM),
+        (format!("{:>24}", "Δ (Δ%)"), C_DIM),
+    ];
+    out.push('\n');
+    let fr_len = fr_header.iter().map(|(t, _)| t.len()).sum::<usize>() + fr_header.len() - 1
+        + "ΔHIT".chars().count(); // ΔHIT header has a 2-byte char; pad-len uses bytes, keep rule long enough
+    out.push_str(&row_line(color, &fr_header));
+    out.push('\n');
+    out.push_str(&wrap(color, C_DIM, &"-".repeat(fr_len.min(120))));
+    out.push('\n');
+    for row in &cur.fr_rows {
+        let (rcount, rcost, rhit) = refs.fr_map.get(&row.name).copied().unwrap_or((0, 0, 0.0));
+        let present = refs.fr_map.contains_key(&row.name);
+        let dhit = if present { format!("{:+.1}pp", row.hit - rhit) } else { "new".to_string() };
+        let dcost = row.cost as i64 - rcost as i64;
+        let _ = rcount;
+        out.push_str(&row_line(
+            color,
+            &[
+                (format!("{:<24}", format!("FROP {}", row.name)), ""),
+                (format!("{:>12}", group_u64(row.count)), ""),
+                (format!("{:>8}", row.hit_pct), C_DIM),
+                (format!("{dhit:>9}"), C_MAGENTA),
+                (format!("{:>15}", group_u64(row.cost)), ""),
+                (format!("{:>7}", row.cost_pct), C_DIM),
+                (format!("{:>24}", delta_cell(rcost, row.cost)), dir(dcost)),
+            ],
+        ));
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Renders the comparison of two snapshots in the previous plain, semicolon-separated view
+/// (machine-friendly, no colour). Used by SDK mode, `--legacy-display`, and `--diff-format csv`.
+pub fn diff_snapshots_csv(
+    ref_label: &str,
+    ref_text: &str,
+    cur_label: &str,
+    cur_text: &str,
+    sep: char,
+) -> String {
+    let refs = parse_snapshot(ref_text);
+    let cur = parse_snapshot(cur_text);
+    let mut s = String::new();
+    s += &format!("\nCOMPARISON: {ref_label} (ref) -> {cur_label}\n\n");
+
+    s += "COST;metric;ref;current;delta;%\n";
+    for name in ["MAIN", "OPCODES", "PRECOMPILES", "MEMORY", "VARIABLE", "BASE", "TOTAL", "FROPS"] {
+        let r = refs.cost_map.get(name).copied().unwrap_or(0);
+        let c = cur.cost_map.get(name).copied().unwrap_or(0);
+        s += &format!("COST;{name};{r};{c};{:+};{}\n", c as i64 - r as i64, pct_change(r, c));
+    }
+    s.push('\n');
+
+    // Diffs a (name, count, cost) section: current rows first (order preserved), then
+    // reference-only entries (removed in the current run), sorted by cost.
+    let diff_cc = |tag: &str,
+                   cur_rows: &[(&str, u64, u64)],
+                   ref_map: &HashMap<String, (u64, u64)>|
+     -> String {
+        let mut out =
+            format!("{tag};name;ref_count;cur_count;d_count;ref_cost;cur_cost;d_cost;%\n");
+        let mut seen: HashSet<String> = HashSet::new();
+        for (name, ccount, ccost) in cur_rows {
+            seen.insert((*name).to_string());
+            let (rcount, rcost) = ref_map.get(*name).copied().unwrap_or((0, 0));
+            out += &format!(
+                "{tag};{name};{rcount};{ccount};{:+};{rcost};{ccost};{:+};{}\n",
+                *ccount as i64 - rcount as i64,
+                *ccost as i64 - rcost as i64,
+                pct_change(rcost, *ccost),
+            );
+        }
+        let mut removed: Vec<(&String, &(u64, u64))> =
+            ref_map.iter().filter(|(k, _)| !seen.contains(*k)).collect();
+        removed.sort_by_key(|(_, (_, cost))| std::cmp::Reverse(*cost));
+        for (name, (rcount, rcost)) in removed {
+            out += &format!(
+                "{tag};{name};{rcount};0;{:+};{rcost};0;{:+};{}\n",
+                -(*rcount as i64),
+                -(*rcost as i64),
+                pct_change(*rcost, 0),
+            );
+        }
+        out
+    };
+
+    let op_rows: Vec<(&str, u64, u64)> =
+        cur.op_rows.iter().map(|r| (r.name.as_str(), r.count, r.cost)).collect();
+    let pc_rows: Vec<(&str, u64, u64)> =
+        cur.pc_rows.iter().map(|r| (r.name.as_str(), r.count, r.cost)).collect();
+    let fr_rows: Vec<(&str, u64, u64)> =
+        cur.fr_rows.iter().map(|r| (r.name.as_str(), r.count, r.cost)).collect();
+    let fr_ref: HashMap<String, (u64, u64)> =
+        refs.fr_map.iter().map(|(k, (c, co, _))| (k.clone(), (*c, *co))).collect();
+
+    s += &diff_cc("OP_BASE", &op_rows, &refs.op_map);
+    s.push('\n');
+    s += &diff_cc("PRECOMPILES", &pc_rows, &refs.pc_map);
+    s.push('\n');
+    s += &diff_cc("FROP", &fr_rows, &fr_ref);
+
+    // Built internally with ';'; swap to the requested separator (field content never contains ';').
+    if sep != ';' {
+        s = s.replace(';', &sep.to_string());
+    }
+    s
+}
+
+/// Compares two aggregate stats snapshots (each saved with `--save-stats`) without running the
+/// emulator. `old_path` is the reference; deltas are `new - old`. `csv = true` selects the previous
+/// plain view (delimited by `sep`); otherwise the colour-coded view (honouring `color`).
+pub fn diff_stats_files(
+    old_path: &str,
+    new_path: &str,
+    csv: bool,
+    color: bool,
+    sep: char,
+) -> std::io::Result<String> {
+    let old_text = std::fs::read_to_string(old_path)?;
+    let new_text = std::fs::read_to_string(new_path)?;
+    Ok(if csv {
+        diff_snapshots_csv(old_path, &old_text, new_path, &new_text, sep)
+    } else {
+        diff_snapshots(old_path, &old_text, new_path, &new_text, color)
+    })
+}
+
+/// Resolves a `--color=auto|always|never` choice to an on/off flag. `auto` (and any unknown value)
+/// enables colour only when stdout is a terminal.
+pub fn resolve_color(when: &str) -> bool {
+    match when {
+        "always" => true,
+        "never" => false,
+        _ => std::io::stdout().is_terminal(),
     }
 }

--- a/emulator/src/stats/stats.rs
+++ b/emulator/src/stats/stats.rs
@@ -155,7 +155,7 @@ enum DupSeg {
 #[derive(Debug, Default)]
 struct DupStats {
     /// Occurrence count of each input-content fingerprint (the number of words is precompile-fixed).
-    states: HashMap<Box<[u64]>, u32>,
+    states: HashMap<Box<[u64]>, u64>,
     /// Per-call-path stats: the innermost `duplicates_depth` ROIs (leaf first, padded with
     /// `usize::MAX`) → (total calls on that path, of which duplicates). Lets the detail report
     /// attribute the redundant calls to their call paths.
@@ -552,7 +552,7 @@ impl Stats {
         self.handle_mem_status(status, false, address, width, 0);
     }
 
-    /// Called every time some data is writen to memory, if statistics are enabled
+    /// Called every time some data is written to memory, if statistics are enabled
     pub fn on_memory_write(&mut self, address: u64, width: u64, value: u64) {
         if self.collect_offsets && width == 1 {
             let offset = (address as usize) & 0x7;
@@ -1978,13 +1978,16 @@ impl Stats {
             .iter()
             .filter(|(_, s)| !s.states.is_empty())
             .map(|(&op, s)| {
-                let total: u64 = s.states.values().map(|&c| c as u64).sum();
+                let total: u64 = s.states.values().sum();
                 let unique = s.states.len() as u64;
                 let dup = total.saturating_sub(unique);
-                let max_dup = s.states.values().copied().max().unwrap_or(0) as u64;
+                let max_dup = s.states.values().copied().max().unwrap_or(0);
                 let (count, cost) = self.costs.get_opcode_count_and_cost(op).unwrap_or((0, 0));
-                let per_call = if count > 0 { cost / count as u64 } else { 0 };
-                DupRow { op, total, unique, dup, max_dup, dup_cost: dup * per_call }
+                // dup * cost / count, multiplying first so the average per-call cost is not
+                // truncated before scaling. In u128: the product overflows u64 on a long run.
+                let dup_cost =
+                    if count > 0 { (dup as u128 * cost as u128 / count as u128) as u64 } else { 0 };
+                DupRow { op, total, unique, dup, max_dup, dup_cost }
             })
             .collect();
         if rows.is_empty() {
@@ -3637,7 +3640,8 @@ struct Snap {
 
 /// Detects the field separator of a snapshot: the character right after the leading `STEPS` tag on
 /// the first `STEPS` line. Defaults to `,` (also handles files saved with `;` or any single char).
-fn detect_sep(text: &str) -> char {
+/// Shared with the HTML report parser, so both read snapshots the same way.
+pub(crate) fn detect_sep(text: &str) -> char {
     for line in text.lines() {
         if let Some(rest) = line.strip_prefix("STEPS") {
             if let Some(c) = rest.chars().next() {
@@ -3782,6 +3786,14 @@ fn row_line(color: bool, cells: &[(String, &str)]) -> String {
         .join(" ")
 }
 
+/// Printed width of a header row built from pre-padded cells joined by single spaces, i.e. the
+/// length its underline must have. Counts characters, not bytes: the headers contain `Δ`, which
+/// `{:>width$}` pads by character count while `str::len` would report its two UTF-8 bytes and make
+/// the rule too long.
+fn rule_len(cells: &[(String, &str)]) -> usize {
+    cells.iter().map(|(text, _)| text.chars().count()).sum::<usize>() + cells.len() - 1
+}
+
 /// Renders an opcode-style section (base opcodes or precompiles): current value + share%, then a
 /// coloured signed delta for count and for cost. Reference-only entries are appended as `(gone)`.
 fn render_op_section(
@@ -3804,7 +3816,7 @@ fn render_op_section(
     out.push('\n');
     out.push_str(&wrap(color, C_HEAD, title));
     out.push('\n');
-    let plain_len = header.iter().map(|(t, _)| t.len()).sum::<usize>() + header.len() - 1;
+    let plain_len = rule_len(&header);
     out.push_str(&row_line(color, &header));
     out.push('\n');
     out.push_str(&wrap(color, C_DIM, &"-".repeat(plain_len)));
@@ -3892,7 +3904,7 @@ pub fn diff_snapshots(
         (format!("{:>26}", "Δ (Δ%)"), C_DIM),
     ];
     out.push('\n');
-    let cd_len = cd_header.iter().map(|(t, _)| t.len()).sum::<usize>() + cd_header.len() - 1;
+    let cd_len = rule_len(&cd_header);
     out.push_str(&row_line(color, &cd_header));
     out.push('\n');
     out.push_str(&wrap(color, C_DIM, &"-".repeat(cd_len)));
@@ -3934,8 +3946,7 @@ pub fn diff_snapshots(
         (format!("{:>24}", "Δ (Δ%)"), C_DIM),
     ];
     out.push('\n');
-    let fr_len = fr_header.iter().map(|(t, _)| t.len()).sum::<usize>() + fr_header.len() - 1
-        + "ΔHIT".chars().count(); // ΔHIT header has a 2-byte char; pad-len uses bytes, keep rule long enough
+    let fr_len = rule_len(&fr_header);
     out.push_str(&row_line(color, &fr_header));
     out.push('\n');
     out.push_str(&wrap(color, C_DIM, &"-".repeat(fr_len.min(120))));

--- a/emulator/src/stats/stats_costs.rs
+++ b/emulator/src/stats/stats_costs.rs
@@ -110,6 +110,10 @@ impl StatsCosts {
         self.ops.add_fixed_cost_op(op_code);
     }
     #[inline(always)]
+    pub fn add_cost_op(&mut self, op_code: u8, cost: u64) {
+        self.ops.add_cost_op(op_code, cost);
+    }
+    #[inline(always)]
     pub fn add_variable_cost_op(&mut self, op_code: u8, variable_cost: u64) {
         self.ops.add_variable_cost_op(op_code, variable_cost);
     }

--- a/emulator/src/stats/stats_report.rs
+++ b/emulator/src/stats/stats_report.rs
@@ -11,8 +11,6 @@ pub struct StatsReport {
     pub label_width_stack: Vec<usize>,
     pub use_thousands_sep: bool,
     pub sdk_width: usize,
-    /// Width of each extra category column added by `add_count_cost_perc2_extended` (same for all).
-    pub category_width: usize,
     pub custom_total_count_factor: f64,
     pub custom_total_cost_factor: f64,
     title_len: usize,
@@ -37,7 +35,6 @@ impl StatsReport {
             label_width_stack: Vec::new(),
             use_thousands_sep: true,
             sdk_width: 120,
-            category_width: 12,
             custom_total_count_factor: 0.0,
             custom_total_cost_factor: 0.0,
             title_len: 0,
@@ -57,9 +54,6 @@ impl StatsReport {
     }
     pub fn set_label_width(&mut self, width: usize) {
         self.label_width = width;
-    }
-    pub fn set_category_width(&mut self, width: usize) {
-        self.category_width = width;
     }
     pub fn set_and_push_label_width(&mut self, width: usize) {
         self.push_label_width();
@@ -480,35 +474,6 @@ impl StatsReport {
             cost as f64 / self.cost_divisor,
             label_width = self.label_width,
         );
-    }
-
-    /// Same as [`Self::add_count_cost_perc2`] but appends one extra column per `categories` value,
-    /// each formatted with `format_number` and right-aligned to `category_width` (the same width for
-    /// all category columns), before the trailing `comment`.
-    pub fn add_count_cost_perc2_extended(
-        &mut self,
-        label: &str,
-        count: u64,
-        cost: u64,
-        comment: &str,
-        categories: &[u64],
-    ) {
-        let mut line = format!(
-            "{}{:<label_width$} {:>15} {:6.2}% {:>15} {:6.2}%",
-            self.identation,
-            label,
-            self.format_number(count),
-            count as f64 / self.step_divisor,
-            self.format_number(cost),
-            cost as f64 / self.cost_divisor,
-            label_width = self.label_width,
-        );
-        for &value in categories {
-            line += &format!(" {:>width$}", self.format_number(value), width = self.category_width);
-        }
-        line += comment;
-        line.push('\n');
-        self.output += &line;
     }
 
     pub fn title_count_perc_cost_perc(


### PR DESCRIPTION
# ziskemu: operand pattern analysis, precompile duplicates, register step distance and HTML report

`feature/ziskemu-dups-and-mems` → `pre-develop-1.1.0-alpha`

Four new analyses in the emulator's statistics report, plus the snapshot/comparison plumbing they
build on. Everything is opt-in: with no new flag the output is unchanged except for one removal
(see [Behaviour changes](#behaviour-changes)).

## New options

### Snapshots and comparison

| Option | Default | What it does |
|---|---|---|
| `--save-stats <FILE>` | — | Saves an aggregate statistics snapshot (no per-function detail) for later comparison. |
| `--ref-stats <FILE>` | — | Runs the program and prints a comparison against a saved snapshot. |
| `--diff-stats <OLD> <NEW>` | — | Compares two saved snapshots. No ELF, input or emulation needed — the form to use in CI. |
| `--html-report [<FILE>]` | `report.html` | Renders the statistics as a standalone HTML page instead of a CSV. With `--ref-stats` / `--diff-stats` it renders the comparison report. |
| `--color <auto\|always\|never>` | `auto` | Colours the comparison. `auto` only when stdout is a terminal. |
| `--diff-format <color\|csv>` | `color` | Human-readable comparison, or a plain delimited one for scripting. |
| `--legacy-display` | off | Equivalent to `--diff-format csv`. Implied by `--sdk`. |
| `--csv-separator <SEP>` | `,` | Field separator for the snapshot and the `csv` view. |

Snapshots are read back with whatever separator they were written with, so mixing is safe.

### Operand analysis

| Option | Default | What it does |
|---|---|---|
| `--pattern-analysis` | off | Per opcode, the operand shapes covering a significant share of its operations (>10% and ≥4,000). Grouped by opcode, ordered by cost. |
| `--opcode-breakdown` | off | Splits an opcode into the cheaper-to-prove variants its operands took (currently the BinaryAddHi shapes of `add`). |
| `--sort-by-units` | off | Sorts the opcode / precompile / FROPS tables by operation count instead of by cost. |

`--pattern-analysis` reports only ALU opcodes, and drops shapes that are true by definition rather
than by data — single-operand opcodes (`rev8`, `signextend_*`, `clz`, …) ignore `a`, so conditions
on it hold 100% of the time and say nothing.

### Precompile duplicates

| Option | Default | What it does |
|---|---|---|
| `--duplicates` | off | Per precompile, how many calls repeat an input already computed and the cost spent on those repeats — the saving available from caching. Covers every precompile except DMA. |
| `--duplicates-ops <OPCODES>` | all | Restricts the analysis to the given precompiles (`keccak,sha256,…`). |
| `--duplicates-detail` | off | Shows the call paths the duplicates come from, most costly first. Needs `-S`. |
| `--duplicates-depth <N>` | `4` | Call-stack frames recorded per precompile call for the detail report. |

Keyed on operand **content**, dereferencing indirections, so identical inputs in different buffers
are still detected.

### Register step distance

| Option | Default | What it does |
|---|---|---|
| `--reg-step-distance` | off | Per register, the gap in steps between consecutive accesses vs. the proof's distance limit: max gap and ratio, the same under a periodic flush, and how many gaps reach 80% / 100% / 200% of the limit. |
| `--reg-step-check` | off | One-line verdict on the **fast emulation path** (no `-X`): splits the run into instances and reports how many hold a gap over the limit, naming the registers when it fails. |
| `--reg-step-limit-bits <BITS>` | `22` | Distance limit, 2^bits steps. |
| `--reg-step-flush-bits <BITS>` | `22` | Flush period, 2^bits steps. |

### Diagnostics

| Option | Default | What it does |
|---|---|---|
| `--log-costly-unaligned` | off | Logs each costly unaligned access (double word-crossing) with pc, function, address, width and offset. Verbose — redirect it. |
| `--callstack-mode <auto\|strict>` | `auto` | `auto` resyncs the call stack on a mismatch (needed for GCC/C++ tail recursion such as `std::sort`'s `__introsort_loop`); `strict` keeps the old behaviour of disabling tracking. |

## Behaviour changes

- **`COST BY BASE OPCODE` no longer prints the 14 trailing operand-category columns.** They were
  unlabeled raw counters; the same data is now reported named, filtered and grouped by
  `--pattern-analysis`. The dead `add_count_cost_perc2_extended` helper and its `category_width`
  field were removed with them.
- **Per-function `COST BY OPCODE` header fixed.** It used a 3-column header while the rows printed
  four, so the header did not line up with the data.
- `--html-report`, like `--save-stats`, collects the statistics on its own: `-X` is not required
  (add it to also get the text report on stdout).

## Implementation notes

- `EmuOptions::snapshot_enabled()` groups `--save-stats` / `--ref-stats` / `--html-report`, which
  all need the same collection path, replacing the condition that was repeated in three places.
- The HTML report module stays a pure renderer: it takes snapshot content and returns a page.
  Reading the snapshots and writing the page is the caller's job (`emu.rs` and `bin/ziskemu.rs`).
- Fixed: the report parser split on a hardcoded `,`, so a snapshot saved with `--csv-separator ';'`
  parsed as all zeros. It now uses the same `detect_sep` as the text comparison, so both read
  snapshots identically by construction.

## Docs

`book/developer/profiling.md` covers every option above with real captured output, and the
previously stale parts were corrected: the `VARIABLE` cost row and why it is the line to read, the
split base/precompiled opcode tables, the fact that they are sorted by cost (the doc claimed the
opposite and pointed at `#N` rank markers that no longer exist), and `% VARIABLE COST` in
`TOP COST FUNCTIONS`.

## Testing

- Unit tests for `flushed_distance` (against a reference implementation, exhaustive over small
  inputs) and for `RegStepCheck` instance accounting.
- Every option exercised end to end on a real guest; the operand filtering verified by lowering the
  reporting thresholds and confirming fcalls/`pubout` and definitional patterns never appear.
- Separator round-trip checked by diffing the same run saved with `,` and with `;` — 0.00% on every
  row.
- `cargo clippy` clean, `cargo fmt` clean, emulator test suite passing.
