### PR TITLE
perf(keccak): use lane-native rounds and bulk-pack witness rows

### DIFF
--- a/precompiles/keccakf/src/keccakf.rs
+++ b/precompiles/keccakf/src/keccakf.rs
@@ -7,11 +7,7 @@ use proofman_common::{AirInstance, FromTrace, ProofmanResult, SetupCtx};
 use proofman_util::{timer_start_trace, timer_stop_and_log_trace};
 
 use zisk_common::OperationKeccakData;
-use zisk_pil::{KeccakfTrace, KeccakfTraceRowOps};
-use zisk_precomp_helpers::{
-    keccak_f_round, keccakf_bit_pos, keccakf_state_from_linear, KeccakState,
-};
-
+use zisk_pil::{KeccakfTrace, KeccakfTraceRow, KeccakfTraceRowOps, KeccakfTraceRowPacked};
 use super::{keccakf_constants::*, KeccakfChiTableSM, KeccakfXor5TableSM};
 
 use rayon::prelude::*;
@@ -49,40 +45,157 @@ pub struct KeccakfSM<F: PrimeField64> {
 
 /// Per-instance round data derived from a clean (bit-valued) state:
 /// column sums (values in [0,5]) and their parities.
+type LaneState = [u64; 25];
+
+/// Spread sixteen bits into the low bit of sixteen consecutive nibbles.
+///
+/// A packed Keccak trace cell is four bits.  Applying this to the A and B
+/// bit-planes separately lets the hot witness path construct sixteen sliced
+/// cells with a handful of word operations instead of sixteen scalar setters.
+#[inline(always)]
+fn spread_16_to_nibbles(mut value: u64) -> u64 {
+    value &= 0xffff;
+    value = (value | (value << 24)) & 0x0000_00ff_0000_00ff;
+    value = (value | (value << 12)) & 0x000f_000f_000f_000f;
+    value = (value | (value << 6)) & 0x0303_0303_0303_0303;
+    (value | (value << 3)) & 0x1111_1111_1111_1111
+}
+
+#[inline(always)]
+fn pack_sliced_lanes<const LANES: usize>(a: &[u64; LANES], b: &[u64; LANES], out: &mut [u64]) {
+    debug_assert_eq!(out.len(), LANES * 4);
+    for lane in 0..LANES {
+        for chunk in 0..4 {
+            let shift = chunk * 16;
+            let a_bits = spread_16_to_nibbles(a[lane] >> shift);
+            let b_bits = spread_16_to_nibbles(b[lane] >> shift);
+            out[lane * 4 + chunk] = a_bits | (b_bits << 3);
+        }
+    }
+}
+
+/// Keccak-specific bulk writer.  The fallback retains the generic unpacked
+/// representation, while the reached GPU path writes the generated packed row
+/// directly.  The offsets below are derived from the generated row declaration:
+/// four flag bits, 1600 four-bit state cells, 320 four-bit parity cells, then
+/// the 40-bit step/address field.
+trait KeccakfTraceWriter<F: PrimeField64>: KeccakfTraceRowOps<F> {
+    fn set_state_lanes(&mut self, a: &LaneState, b: &LaneState);
+    fn set_c_parities(&mut self, a: &[u64; 5], b: &[u64; 5]);
+}
+
+impl<F: PrimeField64> KeccakfTraceWriter<F> for KeccakfTraceRow<F> {
+    #[inline(always)]
+    fn set_state_lanes(&mut self, a: &LaneState, b: &LaneState) {
+        let mut cells = [0u8; WIDTH];
+        for lane in 0..LANES {
+            for z in 0..LANE_BITS {
+                cells[lane * LANE_BITS + z] =
+                    ((a[lane] >> z) & 1) as u8 + SLOT * ((b[lane] >> z) & 1) as u8;
+            }
+        }
+        self.set_all_state(&cells);
+    }
+
+    #[inline(always)]
+    fn set_c_parities(&mut self, a: &[u64; 5], b: &[u64; 5]) {
+        let mut cells = [0u8; 320];
+        for x in 0..5 {
+            for z in 0..LANE_BITS {
+                cells[x * LANE_BITS + z] =
+                    ((a[x] >> z) & 1) as u8 + SLOT * ((b[x] >> z) & 1) as u8;
+            }
+        }
+        self.set_all_c(&cells);
+    }
+}
+
+impl<F: PrimeField64> KeccakfTraceWriter<F> for KeccakfTraceRowPacked<F> {
+    #[inline(always)]
+    fn set_state_lanes(&mut self, a: &LaneState, b: &LaneState) {
+        debug_assert_eq!(self.packed.len(), 121);
+        let mut words = [0u64; 100];
+        pack_sliced_lanes(a, b, &mut words);
+
+        // State starts at bit four. Preserve the activation flags below it and
+        // the parity field above the four-bit spill in word 100.
+        self.packed[0] = (self.packed[0] & 0xf) | (words[0] << 4);
+        for i in 1..100 {
+            self.packed[i] = (words[i - 1] >> 60) | (words[i] << 4);
+        }
+        self.packed[100] = (self.packed[100] & !0xf) | (words[99] >> 60);
+    }
+
+    #[inline(always)]
+    fn set_c_parities(&mut self, a: &[u64; 5], b: &[u64; 5]) {
+        debug_assert_eq!(self.packed.len(), 121);
+        let mut words = [0u64; 20];
+        pack_sliced_lanes(a, b, &mut words);
+
+        // Parities start at word 100, bit four. Preserve the state spill below
+        // them and the step/address field above their spill in word 120.
+        self.packed[100] = (self.packed[100] & 0xf) | (words[0] << 4);
+        for i in 1..20 {
+            self.packed[100 + i] = (words[i - 1] >> 60) | (words[i] << 4);
+        }
+        self.packed[120] = (self.packed[120] & !0xf) | (words[19] >> 60);
+    }
+}
+
 struct ThetaColumns {
     sums: [[u8; 64]; 5],
-    parities: [[u8; 64]; 5],
+    parities: [u64; 5],
 }
 
 impl ThetaColumns {
-    fn from_state(state: &KeccakState) -> Self {
+    #[inline(always)]
+    fn from_state(state: &LaneState) -> Self {
         let mut sums = [[0u8; 64]; 5];
-        let mut parities = [[0u8; 64]; 5];
+        let mut parities = [0u64; 5];
         for x in 0..5 {
+            let lanes = [state[x], state[x + 5], state[x + 10], state[x + 15], state[x + 20]];
+            parities[x] = lanes.into_iter().reduce(|a, b| a ^ b).unwrap();
             for z in 0..64 {
-                let sum = state[x][0][z]
-                    + state[x][1][z]
-                    + state[x][2][z]
-                    + state[x][3][z]
-                    + state[x][4][z];
-                sums[x][z] = sum;
-                parities[x][z] = sum % 2;
+                sums[x][z] = lanes.iter().map(|lane| ((lane >> z) & 1) as u8).sum();
             }
         }
         Self { sums, parities }
     }
+}
 
-    /// θ-output at the ρπ-source of χ-position (x, y, z): a clean state bit plus
-    /// two clean parities, value in [0,3]. Mirrors b = π(ρ(θ(state))).
-    #[inline(always)]
-    fn theta_out_at_source(&self, state: &KeccakState, x: usize, y: usize, z: usize) -> u8 {
-        let sx = (x + 3 * y) % 5;
-        let sy = x;
-        let sz = (z + 64 - RHO_OFFSETS[sx][sy]) % 64;
-        state[sx][sy][sz]
-            + self.parities[(sx + 4) % 5][sz]
-            + self.parities[(sx + 1) % 5][(sz + 63) % 64]
+/// Compute the θ output as two bit planes (sum in [0,3]), then apply ρπ.
+/// The low plane is also the clean mod-2 state consumed by χ.
+#[inline(always)]
+fn theta_rho_pi(state: &LaneState, parities: &[u64; 5]) -> (LaneState, LaneState) {
+    let mut lo = [0u64; 25];
+    let mut hi = [0u64; 25];
+    for y in 0..5 {
+        for x in 0..5 {
+            // χ-position (x,y) reads ρπ from source (x+3y,x).
+            let sx = (x + 3 * y) % 5;
+            let sy = x;
+            let a = state[sx + 5 * sy];
+            let b = parities[(sx + 4) % 5];
+            let c = parities[(sx + 1) % 5].rotate_left(1);
+            let rotation = RHO_OFFSETS[sx][sy] as u32;
+            lo[x + 5 * y] = (a ^ b ^ c).rotate_left(rotation);
+            hi[x + 5 * y] = ((a & b) | (a & c) | (b & c)).rotate_left(rotation);
+        }
     }
+    (lo, hi)
+}
+
+/// Standard lane-wise χ and ι over the clean low θ plane.
+#[inline(always)]
+fn chi_iota(b: &LaneState, round: usize) -> LaneState {
+    let mut next = [0u64; 25];
+    for y in 0..5 {
+        for x in 0..5 {
+            next[x + 5 * y] = b[x + 5 * y] ^ ((!b[(x + 1) % 5 + 5 * y]) & b[(x + 2) % 5 + 5 * y]);
+        }
+    }
+    next[0] ^= RC[round];
+    next
 }
 
 impl<F: PrimeField64> KeccakfSM<F> {
@@ -118,7 +231,7 @@ impl<F: PrimeField64> KeccakfSM<F> {
     /// flags stay off).
     #[inline(always)]
     #[allow(clippy::needless_range_loop)]
-    fn process_slot<R: KeccakfTraceRowOps<F>>(
+    fn process_slot<R: KeccakfTraceWriter<F>>(
         &self,
         trace: &mut [R],
         input_a: &KeccakfInput,
@@ -140,32 +253,24 @@ impl<F: PrimeField64> KeccakfSM<F> {
             trace[i].set_in_use_b(input_b.is_some());
         }
 
-        // Convert input states to 5x5x64 representation
-        let zero_state = [0u64; 25];
-        let mut state_a = keccakf_state_from_linear(&input_a.state);
-        let mut state_b = keccakf_state_from_linear(input_b.map_or(&zero_state, |b| &b.state));
+        // Keep the clean Keccak states in their native 25-lane representation.
+        // The AIR still receives the identical bit-expanded cells below.
+        let mut state_a = input_a.state;
+        let mut state_b = input_b.map_or([0u64; 25], |b| b.state);
 
         // Boundary input groups: plain bits
-        Self::set_bits_group(trace, GROUP_IN_A, &state_a);
-        Self::set_bits_group(trace, GROUP_IN_B, &state_b);
+        Self::set_lane_group(trace, GROUP_IN_A, &state_a);
+        Self::set_lane_group(trace, GROUP_IN_B, &state_b);
 
         // Round groups
-        let mut cells = [0u8; WIDTH];
         let mut ta = [0u8; 5];
         let mut tb = [0u8; 5];
         // let mut chi_accs = [0u32; LANE_BITS];
         for r in 0..=ROUNDS {
             // Sliced state-group of round r
             let group = GROUP_ROUND_0 + r * ROWS_PER_STATE;
-            for x in 0..5 {
-                for y in 0..5 {
-                    for z in 0..64 {
-                        cells[keccakf_bit_pos(x, y, z)] =
-                            state_a[x][y][z] + SLOT * state_b[x][y][z];
-                    }
-                }
-            }
-            Self::set_group(trace, group, &cells);
+            debug_assert_eq!(ROWS_PER_STATE, 1);
+            trace[group].set_state_lanes(&state_a, &state_b);
 
             if r == ROUNDS {
                 break;
@@ -174,20 +279,12 @@ impl<F: PrimeField64> KeccakfSM<F> {
             // θ columns of both instances
             let cols_a = ThetaColumns::from_state(&state_a);
             let cols_b = ThetaColumns::from_state(&state_b);
+            let (theta_lo_a, theta_hi_a) = theta_rho_pi(&state_a, &cols_a.parities);
+            let (theta_lo_b, theta_hi_b) = theta_rho_pi(&state_b, &cols_b.parities);
 
             // Committed sliced parities: position p = x·64+z lives at group-row
             // p / C_PER_ROW, column p % C_PER_ROW
-            for row in 0..ROWS_PER_STATE {
-                let mut c_cells = [0u8; C_PER_ROW];
-                for (j, c_cell) in c_cells.iter_mut().enumerate() {
-                    let pos = row * C_PER_ROW + j;
-                    if pos < 320 {
-                        let (x, z) = (pos / 64, pos % 64);
-                        *c_cell = cols_a.parities[x][z] + SLOT * cols_b.parities[x][z];
-                    }
-                }
-                trace[group + row].set_all_c(&c_cells);
-            }
+            trace[group].set_c_parities(&cols_a.parities, &cols_b.parities);
 
             // xor5 lookups: MUST mirror the AIR's batching — at each round row,
             // three c-column slots per lookup, where slot j of group-row `row`
@@ -212,8 +309,11 @@ impl<F: PrimeField64> KeccakfSM<F> {
             for y in 0..5 {
                 for z in 0..64 {
                     for x in 0..5 {
-                        ta[x] = cols_a.theta_out_at_source(&state_a, x, y, z);
-                        tb[x] = cols_b.theta_out_at_source(&state_b, x, y, z);
+                        let index = x + 5 * y;
+                        ta[x] = (((theta_lo_a[index] >> z) & 1)
+                            | (((theta_hi_a[index] >> z) & 1) << 1)) as u8;
+                        tb[x] = (((theta_lo_b[index] >> z) & 1)
+                            | (((theta_hi_b[index] >> z) & 1) << 1)) as u8;
                     }
                     let rc = y == 0 && ((RC[r] >> z) & 1) == 1;
                     let chi_row = KeccakfChiTableSM::calculate_table_row(&ta, &tb, rc);
@@ -232,49 +332,24 @@ impl<F: PrimeField64> KeccakfSM<F> {
             }
 
             // Advance both instances one round
-            keccak_f_round(&mut state_a, r);
-            keccak_f_round(&mut state_b, r);
-            Self::reduce_mod2(&mut state_a);
-            Self::reduce_mod2(&mut state_b);
+            state_a = chi_iota(&theta_lo_a, r);
+            state_b = chi_iota(&theta_lo_b, r);
         }
 
         // Boundary output groups: plain bits of the final states
-        Self::set_bits_group(trace, GROUP_OUT_A, &state_a);
-        Self::set_bits_group(trace, GROUP_OUT_B, &state_b);
-    }
-
-    /// Writes 1600 lane-major cells into the ROWS_PER_STATE rows of a state-group:
-    /// group-row k holds the lanes [k·LANES_PER_ROW, (k+1)·LANES_PER_ROW).
-    #[inline(always)]
-    fn set_group<R: KeccakfTraceRowOps<F>>(trace: &mut [R], first_row: usize, cells: &[u8; WIDTH]) {
-        for k in 0..ROWS_PER_STATE {
-            let row_cells: &[u8; BITS_PER_ROW] =
-                cells[k * BITS_PER_ROW..(k + 1) * BITS_PER_ROW].try_into().unwrap();
-            trace[first_row + k].set_all_state(row_cells);
-        }
+        Self::set_lane_group(trace, GROUP_OUT_A, &state_a);
+        Self::set_lane_group(trace, GROUP_OUT_B, &state_b);
     }
 
     /// Writes a clean (bit-valued) state into one boundary group.
     #[inline(always)]
-    fn set_bits_group<R: KeccakfTraceRowOps<F>>(
+    fn set_lane_group<R: KeccakfTraceWriter<F>>(
         trace: &mut [R],
         first_row: usize,
-        state: &KeccakState,
+        state: &LaneState,
     ) {
-        let mut cells = [0u8; WIDTH];
-        for x in 0..5 {
-            for y in 0..5 {
-                for z in 0..64 {
-                    cells[keccakf_bit_pos(x, y, z)] = state[x][y][z];
-                }
-            }
-        }
-        Self::set_group(trace, first_row, &cells);
-    }
-
-    #[inline(always)]
-    fn reduce_mod2(state: &mut KeccakState) {
-        state.iter_mut().flatten().flatten().for_each(|bit| *bit %= 2);
+        debug_assert_eq!(ROWS_PER_STATE, 1);
+        trace[first_row].set_state_lanes(state, &[0u64; LANES]);
     }
 
     /// Computes the witness for a series of inputs and produces an `AirInstance`.
@@ -284,7 +359,7 @@ impl<F: PrimeField64> KeccakfSM<F> {
     ///
     /// # Returns
     /// An `AirInstance` containing the computed witness data.
-    pub fn compute_witness<R: KeccakfTraceRowOps<F>>(
+    pub fn compute_witness<R: KeccakfTraceWriter<F>>(
         &self,
         _sctx: &SetupCtx<F>,
         inputs: &[Vec<KeccakfInput>],
@@ -365,5 +440,109 @@ impl<F: PrimeField64> KeccakfSM<F> {
         timer_stop_and_log_trace!(KECCAKF_TRACE);
 
         Ok(AirInstance::new_from_trace(FromTrace::new(&mut trace)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proofman_fields::Goldilocks;
+    use zisk_precomp_helpers::{keccak_f_round, keccakf_state_from_linear, KeccakState};
+
+    fn lanes_from_bits(state: &KeccakState) -> LaneState {
+        let mut lanes = [0u64; 25];
+        for y in 0..5 {
+            for x in 0..5 {
+                for z in 0..64 {
+                    lanes[x + 5 * y] |= (state[x][y][z] as u64) << z;
+                }
+            }
+        }
+        lanes
+    }
+
+    #[test]
+    fn lane_rounds_and_theta_digits_match_bit_reference() {
+        let mut seed = 0x9e3779b97f4a7c15u64;
+        for _ in 0..8 {
+            let mut lanes = [0u64; 25];
+            for lane in &mut lanes {
+                seed ^= seed << 7;
+                seed ^= seed >> 9;
+                seed ^= seed << 8;
+                *lane = seed;
+            }
+            let mut reference = keccakf_state_from_linear(&lanes);
+            for round in 0..ROUNDS {
+                let columns = ThetaColumns::from_state(&lanes);
+                let (lo, hi) = theta_rho_pi(&lanes, &columns.parities);
+                for y in 0..5 {
+                    for x in 0..5 {
+                        let sx = (x + 3 * y) % 5;
+                        let sy = x;
+                        for z in 0..64 {
+                            let sz = (z + 64 - RHO_OFFSETS[sx][sy]) % 64;
+                            let expected = reference[sx][sy][sz]
+                                + ((columns.parities[(sx + 4) % 5] >> sz) & 1) as u8
+                                + ((columns.parities[(sx + 1) % 5] >> ((sz + 63) % 64)) & 1) as u8;
+                            let index = x + 5 * y;
+                            let actual = (((lo[index] >> z) & 1) | (((hi[index] >> z) & 1) << 1)) as u8;
+                            assert_eq!(actual, expected);
+                        }
+                    }
+                }
+
+                lanes = chi_iota(&lo, round);
+                keccak_f_round(&mut reference, round);
+                reference.iter_mut().flatten().flatten().for_each(|bit| *bit %= 2);
+                assert_eq!(lanes, lanes_from_bits(&reference));
+            }
+        }
+    }
+
+    #[test]
+    fn packed_bulk_writer_matches_generated_setters() {
+        let mut seed = 0xd1b5_4a32_d192_ed03u64;
+        for _ in 0..8 {
+            let mut a = [0u64; LANES];
+            let mut b = [0u64; LANES];
+            for lane in a.iter_mut().chain(b.iter_mut()) {
+                seed ^= seed << 7;
+                seed ^= seed >> 9;
+                seed ^= seed << 8;
+                *lane = seed;
+            }
+            let parity_a = ThetaColumns::from_state(&a).parities;
+            let parity_b = ThetaColumns::from_state(&b).parities;
+
+            let mut expected = KeccakfTraceRowPacked::<Goldilocks>::default();
+            let mut actual = KeccakfTraceRowPacked::<Goldilocks>::default();
+            for row in [&mut expected, &mut actual] {
+                row.set_in_use_a(true);
+                row.set_in_use_b(true);
+                row.set_step_addr(0x00ab_cdef_1234);
+            }
+
+            let mut state_cells = [0u8; WIDTH];
+            for lane in 0..LANES {
+                for z in 0..LANE_BITS {
+                    state_cells[lane * LANE_BITS + z] =
+                        ((a[lane] >> z) & 1) as u8 + SLOT * ((b[lane] >> z) & 1) as u8;
+                }
+            }
+            let mut c_cells = [0u8; 320];
+            for x in 0..5 {
+                for z in 0..LANE_BITS {
+                    c_cells[x * LANE_BITS + z] =
+                        ((parity_a[x] >> z) & 1) as u8 + SLOT * ((parity_b[x] >> z) & 1) as u8;
+                }
+            }
+            expected.set_all_state(&state_cells);
+            expected.set_all_c(&c_cells);
+            actual.set_state_lanes(&a, &b);
+            actual.set_c_parities(&parity_a, &parity_b);
+
+            assert_eq!(actual.packed, expected.packed);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Keep Keccak state as `[u64; 25]` throughout witness generation instead of
expanding it into a `5 x 5 x 64` byte representation. Theta, rho, pi, chi, and
iota use lane-level bit operations.

For the reached packed GPU trace, sixteen lane bits are spread into sixteen
four-bit trace cells at once and the exact 121-word row is written directly.
The generic unpacked writer remains as a fallback.

## Performance

The isolated official screen was essentially neutral on authoritative Proof
Time and is not claimed as a standalone performance win:

| Metric | PR 1 champion | PR 1 + Keccak change | Change | Role |
|---|---:|---:|---:|---|
| **Proof Time** | **3.300 s** | **3.293 s** | **-0.21%** | **Authoritative** |
| Generating inner proofs | 2.163 s | 2.180 s | +0.79% | Diagnostic |
| Expressions | 1.8410 s | 1.7475 s | -5.08% | Diagnostic |
| STARK GPU proof sum | 4.4596 s | 4.2689 s | -4.28% | Diagnostic, overlapping sum |

With both Proofman PRs and this change applied, final paired promotion measured:

| Metric | Previous champion | Full champion | Change | Role |
|---|---:|---:|---:|---|
| **Proof Time** | **3.340 s** | **3.039 s** | **-9.01%** | **Authoritative** |
| Generating inner proofs | 2.187 s | 1.972 s | -9.83% | Diagnostic |
| Expressions | 1.7753 s | 1.5474 s | -12.84% | Diagnostic |
| STARK GPU proof sum | 4.4760 s | 3.7647 s | -15.89% | Diagnostic, overlapping sum |

The final result measures the two Proofman PRs and this PR together; it does
not isolate this PR's contribution.

## Validation

- `lane_rounds_and_theta_digits_match_bit_reference`: passed.
- `packed_bulk_writer_matches_generated_setters`: passed.
- Final official promotion passed all 42 generated AIR coverage checks.
- Exact one-file diff SHA-256:
  `407185517af62ce4def85774a534149f1965e3c6997c7ea27c81b6bd57097584`.
- Benchmark-only `Cargo.toml`, `Cargo.lock`, and `verifier/Cargo.toml` changes
  are excluded from this commit.

The benchmark used pinned base `c444d3d81`. The current upstream base has
advanced; a test merge is conflict-free, but performance has not been
remeasured on the newer base.
